### PR TITLE
Add fan speed, vane direction getters to HomeDeviceAtaFacade

### DIFF
--- a/src/facades/home-device-ata.ts
+++ b/src/facades/home-device-ata.ts
@@ -83,8 +83,20 @@ export class HomeDeviceAtaFacade {
     return Number(this.#setting('RoomTemperature'))
   }
 
+  public get setFanSpeed(): string {
+    return this.#setting('SetFanSpeed')
+  }
+
   public get setTemperature(): number {
     return Number(this.#setting('SetTemperature'))
+  }
+
+  public get vaneHorizontalDirection(): string {
+    return this.#setting('VaneHorizontalDirection')
+  }
+
+  public get vaneVerticalDirection(): string {
+    return this.#setting('VaneVerticalDirection')
   }
 
   public constructor(api: HomeAPI, device: HomeDevice) {

--- a/tests/unit/home-device-ata-facade.test.ts
+++ b/tests/unit/home-device-ata-facade.test.ts
@@ -79,12 +79,30 @@ describe('home device ata facade', () => {
       expect(facade.setTemperature).toBe(20)
     })
 
+    it('should read fan speed and vane directions from settings', () => {
+      const facade = new HomeDeviceAtaFacade(
+        createApi(),
+        createDevice({
+          SetFanSpeed: 'Auto',
+          VaneHorizontalDirection: 'Centre',
+          VaneVerticalDirection: 'Swing',
+        }),
+      )
+
+      expect(facade.setFanSpeed).toBe('Auto')
+      expect(facade.vaneHorizontalDirection).toBe('Centre')
+      expect(facade.vaneVerticalDirection).toBe('Swing')
+    })
+
     it('should return defaults for missing settings', () => {
       const facade = new HomeDeviceAtaFacade(createApi(), createDevice())
 
       expect(facade.operationMode).toBe('')
       expect(facade.power).toBe(false)
       expect(facade.roomTemperature).toBe(0)
+      expect(facade.setFanSpeed).toBe('')
+      expect(facade.vaneHorizontalDirection).toBe('')
+      expect(facade.vaneVerticalDirection).toBe('')
     })
 
     it('should read device name', () => {


### PR DESCRIPTION
Expose setFanSpeed, vaneHorizontalDirection, and vaneVerticalDirection as public getters on HomeDeviceAtaFacade, reading from the device settings array via the existing #setting() helper.

These are needed by consumers (e.g., Homey app) to sync fan speed and vane position capabilities from the Home API to the UI.