### PR TITLE
Change license from ISC to MIT and add LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Olivier Zalmanski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@olivierzal/melcloud-api",
       "version": "23.3.3",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "axios": "^1.14.0",
         "luxon": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "type": "git",
     "url": "git+https://github.com/OlivierZal/melcloud-api.git"
   },
-  "license": "ISC",
+  "license": "MIT",
   "author": "Olivier Zalmanski",
   "sideEffects": false,
   "type": "module",


### PR DESCRIPTION
ISC and MIT are functionally equivalent permissive licenses, but MIT
is more widely recognized. This also adds the missing LICENSE file
at the repository root.

https://claude.ai/code/session_01J6wtP7iiQ89yq6eQXsD2hN