### PR TITLE
Persist MELCloud Home session to survive reboots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1934,9 +1934,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -1966,7 +1966,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5702,7 +5704,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -171,6 +171,7 @@ export {
   type ErrorLogQuery,
   type HomeAPI,
   type HomeAPIConfig,
+  type HomeAPISettings,
   type Logger,
   type OnSyncFunction,
   type SettingManager,

--- a/src/services/home-api.ts
+++ b/src/services/home-api.ts
@@ -88,19 +88,23 @@ const storeCookies = async (
   jar: CookieJar,
   { headers }: AxiosResponse,
   url: string,
-): Promise<void> => {
+): Promise<boolean> => {
   const { 'set-cookie': setCookies } = headers as { 'set-cookie'?: string[] }
-  if (Array.isArray(setCookies)) {
-    await Promise.all(
-      setCookies.map(async (raw: string) => {
-        try {
-          await jar.setCookie(raw, url)
-        } catch {
-          // Ignore invalid Set-Cookie values
-        }
-      }),
-    )
+  if (!Array.isArray(setCookies)) {
+    return false
   }
+  let hasStored = false
+  await Promise.all(
+    setCookies.map(async (raw: string) => {
+      try {
+        await jar.setCookie(raw, url)
+        hasStored = true
+      } catch {
+        // Ignore invalid Set-Cookie values
+      }
+    }),
+  )
+  return hasStored
 }
 
 /**
@@ -136,13 +140,16 @@ export class MELCloudHomeAPI implements Disposable, HomeAPI {
 
   #context: HomeContext | null = null
 
-  readonly #jar = new CookieJar()
+  readonly #jar: CookieJar
 
   readonly #registry = new HomeDeviceRegistry()
 
   readonly #syncManager: SyncManager
 
   #user: HomeUser | null = null
+
+  @setting
+  private accessor cookies = ''
 
   @setting
   private accessor expiry = ''
@@ -166,12 +173,8 @@ export class MELCloudHomeAPI implements Disposable, HomeAPI {
     this.logger = logger
     this.onSync = onSync
     this.settingManager = settingManager
-    if (username !== undefined) {
-      this.username = username
-    }
-    if (password !== undefined) {
-      this.password = password
-    }
+    this.#jar = this.#loadJar()
+    this.#applyCredentials(username, password)
     this.#api = axios.create({ baseURL, headers: { 'x-csrf': '1' } })
     this.#syncManager = new SyncManager(
       async () => this.list(),
@@ -182,12 +185,19 @@ export class MELCloudHomeAPI implements Disposable, HomeAPI {
 
   /**
    * Create and initialize a MELCloud Home API instance.
-   * Authenticates and fetches the current user if credentials are provided.
+   *
+   * If the SettingManager holds a persisted session (cookies + unexpired
+   * expiry), the instance reuses it via `getUser()` and skips the OIDC
+   * re-login entirely. Otherwise, or if the persisted session is rejected
+   * by the server, falls back to a full `authenticate()` flow.
    * @param config - Optional configuration.
    * @returns The initialized API instance.
    */
   public static async create(config?: HomeAPIConfig): Promise<MELCloudHomeAPI> {
     const api = new MELCloudHomeAPI(config)
+    if (api.#hasPersistedSession() && (await api.getUser()) !== null) {
+      return api
+    }
     await api.authenticate()
     return api
   }
@@ -198,6 +208,8 @@ export class MELCloudHomeAPI implements Disposable, HomeAPI {
     const { password, username } = data ?? { password: '', username: '' }
     this.#user = null
     this.expiry = ''
+    this.#jar.removeAllCookiesSync()
+    this.cookies = ''
     await this.#performOidcLogin({ password, username })
     ;({ password: this.password, username: this.username } = {
       password,
@@ -327,6 +339,15 @@ export class MELCloudHomeAPI implements Disposable, HomeAPI {
     }
   }
 
+  #applyCredentials(username?: string, password?: string): void {
+    if (username !== undefined) {
+      this.username = username
+    }
+    if (password !== undefined) {
+      this.password = password
+    }
+  }
+
   async #performOidcLogin(credentials: LoginCredentials): Promise<void> {
     const { data: html } = await this.#followRedirects<string>(LOGIN_PATH)
     const action = extractFormAction(html)
@@ -366,6 +387,21 @@ export class MELCloudHomeAPI implements Disposable, HomeAPI {
     })
   }
 
+  #hasPersistedSession(): boolean {
+    return this.expiry !== '' && new Date(this.expiry) > new Date()
+  }
+
+  #loadJar(): CookieJar {
+    if (!this.cookies) {
+      return new CookieJar()
+    }
+    try {
+      return CookieJar.deserializeSync(this.cookies)
+    } catch {
+      return new CookieJar()
+    }
+  }
+
   #logError(error: unknown): void {
     if (axios.isAxiosError(error)) {
       this.logger.error(String(createAPICallErrorData(error)))
@@ -373,8 +409,16 @@ export class MELCloudHomeAPI implements Disposable, HomeAPI {
   }
 
   async #onResponse(response: AxiosResponse, url: string): Promise<void> {
-    await storeCookies(this.#jar, response, url)
+    if (await storeCookies(this.#jar, response, url)) {
+      this.#persistJar()
+    }
     this.logger.log(String(new APICallResponseData(response)))
+  }
+
+  #persistJar(): void {
+    const serialized = this.#jar.serializeSync()
+    /* v8 ignore next -- default MemoryCookieStore always returns a value */
+    this.cookies = serialized ? JSON.stringify(serialized) : ''
   }
 
   /*

--- a/src/services/home-api.ts
+++ b/src/services/home-api.ts
@@ -195,8 +195,17 @@ export class MELCloudHomeAPI implements Disposable, HomeAPI {
    */
   public static async create(config?: HomeAPIConfig): Promise<MELCloudHomeAPI> {
     const api = new MELCloudHomeAPI(config)
-    if (api.#hasPersistedSession() && (await api.getUser()) !== null) {
-      return api
+    if (api.#hasPersistedSession()) {
+      if ((await api.getUser()) !== null) {
+        return api
+      }
+      /*
+       * Persisted session was rejected (401, network error, stale cookies):
+       * wipe it before falling back to a full OIDC login so a subsequent
+       * authenticate() short-circuit (missing credentials) doesn't leave
+       * the dead session in the SettingManager and loop forever on reboots.
+       */
+      api.#clearPersistedSession()
     }
     await api.authenticate()
     return api
@@ -206,10 +215,7 @@ export class MELCloudHomeAPI implements Disposable, HomeAPI {
   public async authenticate(data?: LoginCredentials): Promise<boolean> {
     /* v8 ignore next -- @authenticate guarantees data is always provided */
     const { password, username } = data ?? { password: '', username: '' }
-    this.#user = null
-    this.expiry = ''
-    this.#jar.removeAllCookiesSync()
-    this.cookies = ''
+    this.#clearPersistedSession()
     await this.#performOidcLogin({ password, username })
     ;({ password: this.password, username: this.username } = {
       password,
@@ -348,6 +354,13 @@ export class MELCloudHomeAPI implements Disposable, HomeAPI {
     }
   }
 
+  #clearPersistedSession(): void {
+    this.#user = null
+    this.expiry = ''
+    this.cookies = ''
+    this.#jar.removeAllCookiesSync()
+  }
+
   async #performOidcLogin(credentials: LoginCredentials): Promise<void> {
     const { data: html } = await this.#followRedirects<string>(LOGIN_PATH)
     const action = extractFormAction(html)
@@ -388,7 +401,11 @@ export class MELCloudHomeAPI implements Disposable, HomeAPI {
   }
 
   #hasPersistedSession(): boolean {
-    return this.expiry !== '' && new Date(this.expiry) > new Date()
+    return (
+      this.cookies !== '' &&
+      this.expiry !== '' &&
+      new Date(this.expiry) > new Date()
+    )
   }
 
   #loadJar(): CookieJar {
@@ -398,6 +415,14 @@ export class MELCloudHomeAPI implements Disposable, HomeAPI {
     try {
       return CookieJar.deserializeSync(this.cookies)
     } catch {
+      /*
+       * Self-heal: drop the corrupted value so we don't retry parsing it on
+       * every subsequent boot. The jar is currently being constructed, so
+       * clearing via the @setting accessors (not #clearPersistedSession())
+       * is required — we must not touch this.#jar from here.
+       */
+      this.cookies = ''
+      this.expiry = ''
       return new CookieJar()
     }
   }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -9,6 +9,7 @@ export type {
   ErrorLogQuery,
   HomeAPI,
   HomeAPIConfig,
+  HomeAPISettings,
   Logger,
   OnSyncFunction,
   SettingManager,

--- a/src/services/interfaces.ts
+++ b/src/services/interfaces.ts
@@ -89,6 +89,21 @@ export interface APISettings {
   readonly username?: string | null
 }
 
+/** Persistent settings managed by the Home API for session authentication. */
+export interface HomeAPISettings {
+  /** Serialized tough-cookie CookieJar (JSON). */
+  readonly cookies?: string | null
+
+  /** Session expiry timestamp in ISO 8601 format. */
+  readonly expiry?: string | null
+
+  /** MELCloud Home account password. */
+  readonly password?: string | null
+
+  /** MELCloud Home account username (email). */
+  readonly username?: string | null
+}
+
 /** A single error entry from the device error log. */
 export interface ErrorDetails {
   /** ISO 8601 date of the error occurrence. */

--- a/tests/unit/home-api.test.ts
+++ b/tests/unit/home-api.test.ts
@@ -958,6 +958,56 @@ describe('melcloud home API', () => {
       expect(api.isAuthenticated()).toBe(true)
     })
 
+    it('should wipe persisted state when rejected session has no credentials', async () => {
+      /*
+       * Without credentials, @authenticate short-circuits to false. The
+       * dead cookies/expiry must be cleared before the fallback so a
+       * subsequent boot doesn't loop forever retrying the same bad session.
+       */
+      const cookies = await buildSerializedJar()
+      const futureExpiry = new Date(Date.now() + HOUR_MS).toISOString()
+      const { setSpy, settingManager } = createStore({
+        cookies,
+        expiry: futureExpiry,
+      })
+      mockRequest.mockRejectedValueOnce(new Error('401 Unauthorized'))
+
+      const api = await melCloudHomeApi.create({
+        baseURL: BASE_URL,
+        settingManager,
+      })
+
+      expect(api.isAuthenticated()).toBe(false)
+      expect(setSpy).toHaveBeenCalledWith('cookies', '')
+      expect(setSpy).toHaveBeenCalledWith('expiry', '')
+    })
+
+    it('should skip getUser when expiry is set but cookies are empty', async () => {
+      /*
+       * Edge case (e.g. after a settings migration where `cookies` didn't
+       * exist previously): an unexpired `expiry` alone must not trigger a
+       * getUser() attempt with an empty cookie jar.
+       */
+      const futureExpiry = new Date(Date.now() + HOUR_MS).toISOString()
+      const { settingManager } = createStore({
+        expiry: futureExpiry,
+        password: 'pass',
+        username: 'user@test.com',
+      })
+      setupSuccessfulLogin()
+
+      const api = await melCloudHomeApi.create({
+        baseURL: BASE_URL,
+        settingManager,
+      })
+
+      expect(api.isAuthenticated()).toBe(true)
+      // First call must be the OIDC entry (/bff/login), not /bff/user.
+      expect(mockRequest.mock.calls[0]?.[0]).toStrictEqual(
+        expect.objectContaining({ url: '/bff/login' }),
+      )
+    })
+
     it('should fall back to OIDC when expiry is in the past', async () => {
       const cookies = await buildSerializedJar()
       const pastExpiry = new Date(Date.now() - HOUR_MS).toISOString()
@@ -979,7 +1029,7 @@ describe('melcloud home API', () => {
 
     it('should recover from corrupted cookies and fall back to OIDC', async () => {
       const futureExpiry = new Date(Date.now() + HOUR_MS).toISOString()
-      const { settingManager } = createStore({
+      const { setSpy, settingManager } = createStore({
         cookies: 'not-valid-json',
         expiry: futureExpiry,
         password: 'pass',
@@ -993,6 +1043,12 @@ describe('melcloud home API', () => {
       })
 
       expect(api.isAuthenticated()).toBe(true)
+      /*
+       * Self-heal: corrupted cookies + paired expiry must be wiped so the
+       * bad value is not retried on subsequent boots.
+       */
+      expect(setSpy).toHaveBeenCalledWith('cookies', '')
+      expect(setSpy).toHaveBeenCalledWith('expiry', '')
     })
 
     it('should persist cookies via settingManager after login', async () => {

--- a/tests/unit/home-api.test.ts
+++ b/tests/unit/home-api.test.ts
@@ -1,7 +1,12 @@
+import { CookieJar } from 'tough-cookie'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { MELCloudHomeAPI } from '../../src/services/home-api.ts'
-import type { HomeAPIConfig, Logger } from '../../src/services/index.ts'
+import type {
+  HomeAPIConfig,
+  Logger,
+  SettingManager,
+} from '../../src/services/index.ts'
 import type {
   HomeBuilding,
   HomeClaim,
@@ -190,6 +195,33 @@ const setupSuccessfulLogin = (): void => {
     )
     .mockResolvedValueOnce(mockResponse('', {}, 200))
     .mockResolvedValueOnce(mockResponse(userClaims, {}, 200))
+}
+
+const HOUR_MS = 60 * 60 * 1000
+
+const buildSerializedJar = async (): Promise<string> => {
+  const jar = new CookieJar()
+  await jar.setCookie('session=persisted; Path=/; Secure', BASE_URL)
+  return JSON.stringify(jar.serializeSync())
+}
+
+const createStore = (
+  initial: Record<string, string> = {},
+): {
+  setSpy: ReturnType<typeof vi.fn<(key: string, value: string) => void>>
+  settingManager: SettingManager
+} => {
+  const store = new Map(Object.entries(initial))
+  const setSpy = vi.fn((key: string, value: string) => {
+    store.set(key, value)
+  })
+  return {
+    setSpy,
+    settingManager: {
+      set: setSpy,
+      get: (key: string) => store.get(key) ?? null,
+    },
+  }
 }
 
 describe('melcloud home API', () => {
@@ -878,6 +910,175 @@ describe('melcloud home API', () => {
       const api = await createApi()
 
       expect(api.isAuthenticated()).toBe(true)
+    })
+  })
+
+  describe('session persistence', () => {
+    it('should reuse persisted session and skip OIDC re-login', async () => {
+      const cookies = await buildSerializedJar()
+      const futureExpiry = new Date(Date.now() + HOUR_MS).toISOString()
+      const { settingManager } = createStore({
+        cookies,
+        expiry: futureExpiry,
+        password: 'pass',
+        username: 'user@test.com',
+      })
+      mockRequest.mockResolvedValueOnce(mockResponse(userClaims, {}, 200))
+
+      const api = await melCloudHomeApi.create({
+        baseURL: BASE_URL,
+        settingManager,
+      })
+
+      expect(api.isAuthenticated()).toBe(true)
+      expect(mockRequest).toHaveBeenCalledTimes(1)
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ url: '/bff/user' }),
+      )
+    })
+
+    it('should fall back to OIDC when persisted session is rejected', async () => {
+      const cookies = await buildSerializedJar()
+      const futureExpiry = new Date(Date.now() + HOUR_MS).toISOString()
+      const { settingManager } = createStore({
+        cookies,
+        expiry: futureExpiry,
+        password: 'pass',
+        username: 'user@test.com',
+      })
+      // First getUser() call fails → triggers fallback to full authenticate()
+      mockRequest.mockRejectedValueOnce(new Error('401 Unauthorized'))
+      setupSuccessfulLogin()
+
+      const api = await melCloudHomeApi.create({
+        baseURL: BASE_URL,
+        settingManager,
+      })
+
+      expect(api.isAuthenticated()).toBe(true)
+    })
+
+    it('should fall back to OIDC when expiry is in the past', async () => {
+      const cookies = await buildSerializedJar()
+      const pastExpiry = new Date(Date.now() - HOUR_MS).toISOString()
+      const { settingManager } = createStore({
+        cookies,
+        expiry: pastExpiry,
+        password: 'pass',
+        username: 'user@test.com',
+      })
+      setupSuccessfulLogin()
+
+      const api = await melCloudHomeApi.create({
+        baseURL: BASE_URL,
+        settingManager,
+      })
+
+      expect(api.isAuthenticated()).toBe(true)
+    })
+
+    it('should recover from corrupted cookies and fall back to OIDC', async () => {
+      const futureExpiry = new Date(Date.now() + HOUR_MS).toISOString()
+      const { settingManager } = createStore({
+        cookies: 'not-valid-json',
+        expiry: futureExpiry,
+        password: 'pass',
+        username: 'user@test.com',
+      })
+      setupSuccessfulLogin()
+
+      const api = await melCloudHomeApi.create({
+        baseURL: BASE_URL,
+        settingManager,
+      })
+
+      expect(api.isAuthenticated()).toBe(true)
+    })
+
+    it('should persist cookies via settingManager after login', async () => {
+      /*
+       * Inject a Set-Cookie header on the Cognito login page response so that
+       * #onResponse triggers #persistJar(). The rest of the OIDC chain is
+       * identical to setupSuccessfulLogin().
+       */
+      const callbackUrl =
+        'https://auth.melcloudhome.com/signin-oidc-meu?code=abc&state=xyz'
+      mockRequest
+        .mockResolvedValueOnce(
+          mockResponse('', { location: `${BASE_URL}/auth-redirect` }, 302),
+        )
+        .mockResolvedValueOnce(
+          mockResponse(
+            '',
+            { location: `${COGNITO}/oauth2/authorize?client_id=test` },
+            302,
+          ),
+        )
+        .mockResolvedValueOnce(
+          mockResponse(
+            '',
+            { location: `${COGNITO}/login?client_id=test` },
+            302,
+          ),
+        )
+        .mockResolvedValueOnce(
+          mockResponse(
+            cognitoLoginPage(),
+            { 'set-cookie': ['session=abc; Path=/; Secure'] },
+            200,
+          ),
+        )
+        .mockResolvedValueOnce(mockResponse('', { location: callbackUrl }, 302))
+        .mockResolvedValueOnce(
+          mockResponse(
+            '',
+            {
+              location: 'https://auth.melcloudhome.com/ExternalLogin/Callback',
+            },
+            302,
+          ),
+        )
+        .mockResolvedValueOnce(
+          mockResponse(
+            '',
+            { location: `${BASE_URL}/signin-oidc?code=final` },
+            302,
+          ),
+        )
+        .mockResolvedValueOnce(mockResponse('', {}, 200))
+        .mockResolvedValueOnce(mockResponse(userClaims, {}, 200))
+      const { setSpy, settingManager } = createStore()
+
+      await melCloudHomeApi.create({
+        baseURL: BASE_URL,
+        password: 'pass',
+        settingManager,
+        username: 'user@test.com',
+      })
+
+      const cookiesCalls = setSpy.mock.calls.filter(
+        ([key]) => key === 'cookies',
+      )
+      const lastCookies = cookiesCalls.at(-1)?.[1] ?? ''
+
+      expect(lastCookies).not.toBe('')
+      expect(() => CookieJar.deserializeSync(lastCookies)).not.toThrow()
+    })
+
+    it('should clear persisted cookies at the start of authenticate()', async () => {
+      const { setSpy, settingManager } = createStore({
+        cookies: await buildSerializedJar(),
+      })
+      setupSuccessfulLogin()
+
+      await melCloudHomeApi.create({
+        baseURL: BASE_URL,
+        password: 'pass',
+        settingManager,
+        username: 'user@test.com',
+      })
+
+      expect(setSpy).toHaveBeenCalledWith('cookies', '')
     })
   })
 


### PR DESCRIPTION
The Home API used to discard its CookieJar on every instantiation and force a full OIDC re-login in `.create()`. When users rebooted Homey during a MELCloud Home outage (503 from AWS ELB) or Cognito rate-limit, the app stayed stuck because it couldn't complete a fresh login.

Persist the tough-cookie jar through the existing SettingManager under a new `cookies` @setting accessor, and skip `authenticate()` in `.create()` when a valid persisted session is found — falling back to the full OIDC flow if the cookies are rejected, the expiry is in the past, or the stored value is corrupted. Symmetrical to how the classic API reuses `contextKey` + `expiry` at boot.

Also expose a new `HomeAPISettings` type describing the fields that consumers must support on their SettingManager for the Home API.

https://claude.ai/code/session_01J6wtP7iiQ89yq6eQXsD2hN