### PR TITLE
Fix npm audit vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1934,9 +1934,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -1966,7 +1966,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5702,7 +5704,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {


### PR DESCRIPTION
Bump three dependencies via `npm audit fix` (all within semver range, no package.json change):

- axios 1.14.0 → 1.15.0 (CRITICAL)
  - GHSA-3p68-rc4w-qgx5: NO_PROXY hostname normalization bypass (SSRF)
  - GHSA-fvcv-3m26-pcqx: unrestricted cloud metadata exfiltration
- brace-expansion 5.0.4 → 5.0.5 (moderate, GHSA-f886-m6hf-6m8v)
- yaml 2.8.2 → 2.8.3 (moderate, GHSA-48c2-rrv3-qjmp)

`npm audit` now reports zero vulnerabilities. Typecheck, lint, format and the full test suite (369/369) still pass.

https://claude.ai/code/session_01J6wtP7iiQ89yq6eQXsD2hN