### PR TITLE
Rename ID branding functions to use `to` prefix and convert retry loop to while

### DIFF
--- a/src/api/classic.ts
+++ b/src/api/classic.ts
@@ -54,12 +54,12 @@ import {
 } from '../observability/index.ts'
 import {
   DEFAULT_TRANSIENT_RETRY_OPTIONS,
-  toDeviceId,
   isSessionExpired,
   isTransientServerError,
   RateLimitError,
   RateLimitGate,
   RetryGuard,
+  toDeviceId,
   withRetryBackoff,
 } from '../resilience/index.ts'
 import type {

--- a/src/api/classic.ts
+++ b/src/api/classic.ts
@@ -54,7 +54,7 @@ import {
 } from '../observability/index.ts'
 import {
   DEFAULT_TRANSIENT_RETRY_OPTIONS,
-  deviceId,
+  toDeviceId,
   isSessionExpired,
   isTransientServerError,
   RateLimitError,
@@ -670,7 +670,7 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
   ): Promise<ErrorLogData[]> {
     const { data } = await this.getErrorEntries({
       postData: {
-        DeviceIDs: deviceIds.map((id) => deviceId(id)),
+        DeviceIDs: deviceIds.map((id) => toDeviceId(id)),
         FromDate: toISODate(fromDate),
         ToDate: toISODate(toDate),
       },

--- a/src/facades/area.ts
+++ b/src/facades/area.ts
@@ -1,11 +1,11 @@
 import type { Area, DeviceAny } from '../models/index.ts'
-import { areaId } from '../types/index.ts'
+import { toAreaId } from '../types/index.ts'
 import { BaseZoneFacade } from './base-zone.ts'
 
 /** Facade for an area, grouping devices within a floor or building. */
 export class AreaFacade extends BaseZoneFacade<Area> {
   public override get devices(): DeviceAny[] {
-    return this.registry.getDevicesByAreaId(areaId(this.id))
+    return this.registry.getDevicesByAreaId(toAreaId(this.id))
   }
 
   protected readonly frostProtectionLocation = 'AreaIds'

--- a/src/facades/area.ts
+++ b/src/facades/area.ts
@@ -4,7 +4,7 @@ import { BaseZoneFacade } from './base-zone.ts'
 
 /** Facade for an area, grouping devices within a floor or building. */
 export class AreaFacade extends BaseZoneFacade<Area> {
-  public declare readonly id: AreaID
+  declare public readonly id: AreaID
 
   public override get devices(): DeviceAny[] {
     return this.registry.getDevicesByAreaId(this.id)

--- a/src/facades/area.ts
+++ b/src/facades/area.ts
@@ -1,11 +1,13 @@
 import type { Area, DeviceAny } from '../models/index.ts'
-import { toAreaId } from '../types/index.ts'
+import type { AreaID } from '../types/index.ts'
 import { BaseZoneFacade } from './base-zone.ts'
 
 /** Facade for an area, grouping devices within a floor or building. */
 export class AreaFacade extends BaseZoneFacade<Area> {
+  public declare readonly id: AreaID
+
   public override get devices(): DeviceAny[] {
-    return this.registry.getDevicesByAreaId(toAreaId(this.id))
+    return this.registry.getDevicesByAreaId(this.id)
   }
 
   protected readonly frostProtectionLocation = 'AreaIds'

--- a/src/facades/base-device.ts
+++ b/src/facades/base-device.ts
@@ -10,8 +10,8 @@ import {
   type ReportPostData,
   type SetDeviceData,
   type TilesData,
+  type DeviceID,
   type UpdateDeviceData,
-  toDeviceId,
 } from '../types/index.ts'
 import {
   fromListToSetAta,
@@ -71,6 +71,8 @@ export abstract class BaseDeviceFacade<T extends DeviceType>
   extends BaseFacade<DeviceAny>
   implements DeviceFacade<T>
 {
+  public declare readonly id: DeviceID
+
   public abstract readonly flags: Record<keyof UpdateDeviceData<T>, number>
 
   protected abstract readonly temperaturesLegend: (string | undefined)[]
@@ -167,7 +169,7 @@ export abstract class BaseDeviceFacade<T extends DeviceType>
     const { data: finalData } = await api.setValues({
       postData: {
         ...this.prepareUpdateData(newData),
-        DeviceID: toDeviceId(id),
+        DeviceID: id,
         EffectiveFlags: flags,
       },
       type,
@@ -253,7 +255,7 @@ export abstract class BaseDeviceFacade<T extends DeviceType>
   ): ReportPostData {
     const { from: newFrom, to: newTo } = getReportPostDataDates({ from, to })
     return {
-      DeviceID: toDeviceId(this.id),
+      DeviceID: this.id,
       Duration:
         shouldUseExactRange ?
           getDuration({ from: newFrom, to: newTo })

--- a/src/facades/base-device.ts
+++ b/src/facades/base-device.ts
@@ -71,7 +71,7 @@ export abstract class BaseDeviceFacade<T extends DeviceType>
   extends BaseFacade<DeviceAny>
   implements DeviceFacade<T>
 {
-  public declare readonly id: DeviceID
+  declare public readonly id: DeviceID
 
   public abstract readonly flags: Record<keyof UpdateDeviceData<T>, number>
 

--- a/src/facades/base-device.ts
+++ b/src/facades/base-device.ts
@@ -11,7 +11,7 @@ import {
   type SetDeviceData,
   type TilesData,
   type UpdateDeviceData,
-  deviceId,
+  toDeviceId,
 } from '../types/index.ts'
 import {
   fromListToSetAta,
@@ -167,7 +167,7 @@ export abstract class BaseDeviceFacade<T extends DeviceType>
     const { data: finalData } = await api.setValues({
       postData: {
         ...this.prepareUpdateData(newData),
-        DeviceID: deviceId(id),
+        DeviceID: toDeviceId(id),
         EffectiveFlags: flags,
       },
       type,
@@ -253,7 +253,7 @@ export abstract class BaseDeviceFacade<T extends DeviceType>
   ): ReportPostData {
     const { from: newFrom, to: newTo } = getReportPostDataDates({ from, to })
     return {
-      DeviceID: deviceId(this.id),
+      DeviceID: toDeviceId(this.id),
       Duration:
         shouldUseExactRange ?
           getDuration({ from: newFrom, to: newTo })

--- a/src/facades/base-device.ts
+++ b/src/facades/base-device.ts
@@ -1,18 +1,18 @@
 import { DateTime } from 'luxon'
 
+import type {
+  DeviceID,
+  EnergyData,
+  GetDeviceData,
+  ListDeviceData,
+  ReportPostData,
+  SetDeviceData,
+  TilesData,
+  UpdateDeviceData,
+} from '../types/index.ts'
 import { DeviceType, FLAG_UNCHANGED } from '../constants.ts'
 import { fetchDevices, syncDevices, updateDevice } from '../decorators/index.ts'
 import { type DeviceAny, Device } from '../models/index.ts'
-import {
-  type EnergyData,
-  type GetDeviceData,
-  type ListDeviceData,
-  type ReportPostData,
-  type SetDeviceData,
-  type TilesData,
-  type DeviceID,
-  type UpdateDeviceData,
-} from '../types/index.ts'
 import {
   fromListToSetAta,
   getChartLineOptions,

--- a/src/facades/base.ts
+++ b/src/facades/base.ts
@@ -24,7 +24,7 @@ import {
   type SettingsParams,
   type SuccessData,
   type TilesData,
-  deviceId,
+  toDeviceId,
 } from '../types/index.ts'
 import { getChartLineOptions, now } from '../utils.ts'
 import type {
@@ -143,7 +143,7 @@ export abstract class BaseFacade<T extends Model> implements Facade {
   public async setPower(isOn = true): Promise<boolean> {
     const { data: isPowered } = await this.api.setPower({
       postData: {
-        DeviceIds: this.#deviceIds.map((id) => deviceId(id)),
+        DeviceIds: this.#deviceIds.map((id) => toDeviceId(id)),
         Power: isOn,
       },
     })
@@ -186,7 +186,7 @@ export abstract class BaseFacade<T extends Model> implements Facade {
   public async getTiles<TDeviceType extends DeviceType>(
     device: false | Device<TDeviceType> = false,
   ): Promise<TilesData<TDeviceType | null>> {
-    const postData = { DeviceIDs: this.#deviceIds.map((id) => deviceId(id)) }
+    const postData = { DeviceIDs: this.#deviceIds.map((id) => toDeviceId(id)) }
     if (device === false || !this.#deviceIds.includes(device.id)) {
       const { data } = await this.api.getTiles({ postData })
       return data

--- a/src/facades/building.ts
+++ b/src/facades/building.ts
@@ -11,7 +11,7 @@ import { BaseZoneFacade } from './base-zone.ts'
 
 /** Facade for a building, providing access to all its devices and zone settings. */
 export class BuildingFacade extends BaseZoneFacade<Building> {
-  public declare readonly id: BuildingID
+  declare public readonly id: BuildingID
 
   public get data(): ZoneSettings {
     return this.instance.data

--- a/src/facades/building.ts
+++ b/src/facades/building.ts
@@ -5,8 +5,8 @@ import type {
   DeviceAny,
   Model,
 } from '../models/index.ts'
+import type { BuildingID, ZoneSettings } from '../types/index.ts'
 import { fetchDevices } from '../decorators/index.ts'
-import { type ZoneSettings, type BuildingID } from '../types/index.ts'
 import { BaseZoneFacade } from './base-zone.ts'
 
 /** Facade for a building, providing access to all its devices and zone settings. */

--- a/src/facades/building.ts
+++ b/src/facades/building.ts
@@ -6,17 +6,19 @@ import type {
   Model,
 } from '../models/index.ts'
 import { fetchDevices } from '../decorators/index.ts'
-import { type ZoneSettings, toBuildingId } from '../types/index.ts'
+import { type ZoneSettings, type BuildingID } from '../types/index.ts'
 import { BaseZoneFacade } from './base-zone.ts'
 
 /** Facade for a building, providing access to all its devices and zone settings. */
 export class BuildingFacade extends BaseZoneFacade<Building> {
+  public declare readonly id: BuildingID
+
   public get data(): ZoneSettings {
     return this.instance.data
   }
 
   public override get devices(): DeviceAny[] {
-    return this.registry.getDevicesByBuildingId(toBuildingId(this.id))
+    return this.registry.getDevicesByBuildingId(this.id)
   }
 
   protected readonly frostProtectionLocation = 'BuildingIds'

--- a/src/facades/building.ts
+++ b/src/facades/building.ts
@@ -6,7 +6,7 @@ import type {
   Model,
 } from '../models/index.ts'
 import { fetchDevices } from '../decorators/index.ts'
-import { type ZoneSettings, buildingId } from '../types/index.ts'
+import { type ZoneSettings, toBuildingId } from '../types/index.ts'
 import { BaseZoneFacade } from './base-zone.ts'
 
 /** Facade for a building, providing access to all its devices and zone settings. */
@@ -16,7 +16,7 @@ export class BuildingFacade extends BaseZoneFacade<Building> {
   }
 
   public override get devices(): DeviceAny[] {
-    return this.registry.getDevicesByBuildingId(buildingId(this.id))
+    return this.registry.getDevicesByBuildingId(toBuildingId(this.id))
   }
 
   protected readonly frostProtectionLocation = 'BuildingIds'

--- a/src/facades/floor.ts
+++ b/src/facades/floor.ts
@@ -1,11 +1,11 @@
 import type { DeviceAny, Floor } from '../models/index.ts'
-import { floorId } from '../types/index.ts'
+import { toFloorId } from '../types/index.ts'
 import { BaseZoneFacade } from './base-zone.ts'
 
 /** Facade for a floor, grouping devices on that floor within a building. */
 export class FloorFacade extends BaseZoneFacade<Floor> {
   public override get devices(): DeviceAny[] {
-    return this.registry.getDevicesByFloorId(floorId(this.id))
+    return this.registry.getDevicesByFloorId(toFloorId(this.id))
   }
 
   protected readonly frostProtectionLocation = 'FloorIds'

--- a/src/facades/floor.ts
+++ b/src/facades/floor.ts
@@ -1,11 +1,13 @@
 import type { DeviceAny, Floor } from '../models/index.ts'
-import { toFloorId } from '../types/index.ts'
+import type { FloorID } from '../types/index.ts'
 import { BaseZoneFacade } from './base-zone.ts'
 
 /** Facade for a floor, grouping devices on that floor within a building. */
 export class FloorFacade extends BaseZoneFacade<Floor> {
+  public declare readonly id: FloorID
+
   public override get devices(): DeviceAny[] {
-    return this.registry.getDevicesByFloorId(toFloorId(this.id))
+    return this.registry.getDevicesByFloorId(this.id)
   }
 
   protected readonly frostProtectionLocation = 'FloorIds'

--- a/src/facades/floor.ts
+++ b/src/facades/floor.ts
@@ -4,7 +4,7 @@ import { BaseZoneFacade } from './base-zone.ts'
 
 /** Facade for a floor, grouping devices on that floor within a building. */
 export class FloorFacade extends BaseZoneFacade<Floor> {
-  public declare readonly id: FloorID
+  declare public readonly id: FloorID
 
   public override get devices(): DeviceAny[] {
     return this.registry.getDevicesByFloorId(this.id)

--- a/src/models/classic-registry.ts
+++ b/src/models/classic-registry.ts
@@ -12,9 +12,9 @@ import {
   type FloorZone,
   type ListDeviceAny,
   type Zone,
-  areaId as toAreaId,
-  buildingId as toBuildingId,
-  floorId as toFloorId,
+  toAreaId,
+  toBuildingId,
+  toFloorId,
 } from '../types/index.ts'
 import type { DeviceAny } from './interfaces.ts'
 import { Area } from './area.ts'

--- a/src/resilience/index.ts
+++ b/src/resilience/index.ts
@@ -22,4 +22,4 @@ export {
   RateLimitError,
   TransientServerError,
 } from '../errors/index.ts'
-export { areaId, buildingId, deviceId, floorId } from '../types/ids.ts'
+export { toAreaId, toBuildingId, toDeviceId, toFloorId } from '../types/ids.ts'

--- a/src/resilience/retry-backoff.ts
+++ b/src/resilience/retry-backoff.ts
@@ -131,8 +131,7 @@ export const withRetryBackoff = async <T>(
   operation: () => Promise<T>,
   options: RetryBackoffOptions,
 ): Promise<T> => {
-  let attempt = 0
-  while (attempt <= options.maxRetries) {
+  for (let attempt = 0; attempt <= options.maxRetries; attempt += 1) {
     try {
       /*
        * Sequential awaits inside this loop are intentional (each retry
@@ -151,7 +150,6 @@ export const withRetryBackoff = async <T>(
       // eslint-disable-next-line no-await-in-loop -- sequential retry
       await sleep(delayMs)
     }
-    attempt += 1
   }
   /* v8 ignore next -- unreachable: loop always exits via return or throw */
   throw new Error('withRetryBackoff: unreachable')

--- a/src/resilience/retry-backoff.ts
+++ b/src/resilience/retry-backoff.ts
@@ -131,7 +131,8 @@ export const withRetryBackoff = async <T>(
   operation: () => Promise<T>,
   options: RetryBackoffOptions,
 ): Promise<T> => {
-  for (let attempt = 0; attempt <= options.maxRetries; attempt += 1) {
+  let attempt = 0
+  while (attempt <= options.maxRetries) {
     try {
       /*
        * Sequential awaits inside this loop are intentional (each retry
@@ -150,6 +151,7 @@ export const withRetryBackoff = async <T>(
       // eslint-disable-next-line no-await-in-loop -- sequential retry
       await sleep(delayMs)
     }
+    attempt += 1
   }
   /* v8 ignore next -- unreachable: loop always exits via return or throw */
   throw new Error('withRetryBackoff: unreachable')

--- a/src/types/ids.ts
+++ b/src/types/ids.ts
@@ -27,26 +27,26 @@ export type FloorID = Brand<'FloorID'>
  * @param id - The raw numeric area identifier.
  * @returns The branded {@link AreaID}.
  */
-export const areaId = (id: number): AreaID => id as AreaID
+export const toAreaId = (id: number): AreaID => id as AreaID
 
 /**
  * Brand a plain number as a {@link BuildingID}.
  * @param id - The raw numeric building identifier.
  * @returns The branded {@link BuildingID}.
  */
-export const buildingId = (id: number): BuildingID => id as BuildingID
+export const toBuildingId = (id: number): BuildingID => id as BuildingID
 
 /**
  * Brand a plain number as a {@link DeviceID}.
  * @param id - The raw numeric device identifier.
  * @returns The branded {@link DeviceID}.
  */
-export const deviceId = (id: number): DeviceID => id as DeviceID
+export const toDeviceId = (id: number): DeviceID => id as DeviceID
 
 /**
  * Brand a plain number as a {@link FloorID}.
  * @param id - The raw numeric floor identifier.
  * @returns The branded {@link FloorID}.
  */
-export const floorId = (id: number): FloorID => id as FloorID
+export const toFloorId = (id: number): FloorID => id as FloorID
 /* eslint-enable @typescript-eslint/no-unsafe-type-assertion */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -93,4 +93,4 @@ export type {
 } from './home.ts'
 export type { AreaID, BuildingID, DeviceID, FloorID } from './ids.ts'
 
-export { areaId, buildingId, deviceId, floorId } from './ids.ts'
+export { toAreaId, toBuildingId, toDeviceId, toFloorId } from './ids.ts'

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -9,10 +9,10 @@ import {
   type ListDeviceDataAtw,
   type ListDeviceDataErv,
   type ReportData,
-  areaId,
-  buildingId,
-  deviceId,
-  floorId,
+  toAreaId,
+  toBuildingId,
+  toDeviceId,
+  toFloorId,
 } from '../src/types/index.ts'
 import { mock } from './helpers.ts'
 
@@ -33,7 +33,7 @@ export const buildingData = (
   HMEnabled: false,
   HMEndDate: null,
   HMStartDate: null,
-  ID: buildingId(1),
+  ID: toBuildingId(1),
   Location: 10,
   Name: 'Building',
   TimeZone: 0,
@@ -41,7 +41,7 @@ export const buildingData = (
 })
 
 export const floorData = (overrides: Partial<FloorData> = {}): FloorData => ({
-  BuildingId: buildingId(1),
+  BuildingId: toBuildingId(1),
   ID: 10,
   Name: 'Floor',
   ...overrides,
@@ -50,7 +50,7 @@ export const floorData = (overrides: Partial<FloorData> = {}): FloorData => ({
 export const areaData = (
   overrides: Partial<AreaDataAny> = {},
 ): AreaDataAny => ({
-  BuildingId: buildingId(1),
+  BuildingId: toBuildingId(1),
   FloorId: 10,
   ID: 100,
   Name: 'Area',
@@ -174,12 +174,12 @@ export const ervDeviceData = (
  */
 
 /* eslint-disable @typescript-eslint/no-magic-numbers -- fixture IDs are inherently arbitrary test values */
-const DEFAULT_AREA_ID = areaId(100)
-const DEFAULT_BUILDING_ID = buildingId(1)
-const DEFAULT_FLOOR_ID = floorId(10)
-const DEFAULT_ATA_DEVICE_ID = deviceId(1000)
-const DEFAULT_ATW_DEVICE_ID = deviceId(1001)
-const DEFAULT_ERV_DEVICE_ID = deviceId(1002)
+const DEFAULT_AREA_ID = toAreaId(100)
+const DEFAULT_BUILDING_ID = toBuildingId(1)
+const DEFAULT_FLOOR_ID = toFloorId(10)
+const DEFAULT_ATA_DEVICE_ID = toDeviceId(1000)
+const DEFAULT_ATW_DEVICE_ID = toDeviceId(1001)
+const DEFAULT_ERV_DEVICE_ID = toDeviceId(1002)
 /* eslint-enable @typescript-eslint/no-magic-numbers */
 
 /*

--- a/tests/integration/api-lifecycle.test.ts
+++ b/tests/integration/api-lifecycle.test.ts
@@ -5,10 +5,10 @@ import { DeviceType } from '../../src/constants.ts'
 import { ClassicFacadeManager } from '../../src/facades/classic-manager.ts'
 import {
   type BuildingWithStructure,
-  areaId,
-  buildingId,
-  deviceId,
-  floorId,
+  toAreaId,
+  toBuildingId,
+  toDeviceId,
+  toFloorId,
 } from '../../src/types/index.ts'
 import { ataDeviceData, buildingData } from '../fixtures.ts'
 import { cast, defined, mock } from '../helpers.ts'
@@ -35,18 +35,18 @@ const buildingResponse: BuildingWithStructure[] = [
         {
           Areas: [
             {
-              BuildingId: buildingId(1),
+              BuildingId: toBuildingId(1),
               Devices: [
                 {
-                  AreaID: areaId(100),
-                  BuildingID: buildingId(1),
+                  AreaID: toAreaId(100),
+                  BuildingID: toBuildingId(1),
                   Device: ataDeviceData({
                     NumberOfFanSpeeds: 5,
                     SetTemperature: 23,
                   }),
-                  DeviceID: deviceId(1001),
+                  DeviceID: toDeviceId(1001),
                   DeviceName: 'AC unit',
-                  FloorID: floorId(10),
+                  FloorID: toFloorId(10),
                   Type: DeviceType.Ata,
                 },
               ],
@@ -55,7 +55,7 @@ const buildingResponse: BuildingWithStructure[] = [
               Name: 'Living room',
             },
           ],
-          BuildingId: buildingId(1),
+          BuildingId: toBuildingId(1),
           Devices: [],
           ID: 10,
           Name: 'Ground floor',
@@ -106,10 +106,10 @@ describe('api lifecycle', () => {
     const api = await melCloudApi.create({ autoSyncInterval: 0 })
 
     expect(api.registry.getDevices()).toHaveLength(1)
-    expect(api.registry.getDevicesByBuildingId(buildingId(1))).toHaveLength(1)
-    expect(api.registry.getFloorsByBuildingId(buildingId(1))).toHaveLength(1)
-    expect(api.registry.getAreasByFloorId(floorId(10))).toHaveLength(1)
-    expect(api.registry.getDevicesByAreaId(areaId(100))).toHaveLength(1)
+    expect(api.registry.getDevicesByBuildingId(toBuildingId(1))).toHaveLength(1)
+    expect(api.registry.getFloorsByBuildingId(toBuildingId(1))).toHaveLength(1)
+    expect(api.registry.getAreasByFloorId(toFloorId(10))).toHaveLength(1)
+    expect(api.registry.getDevicesByAreaId(toAreaId(100))).toHaveLength(1)
 
     const device = api.registry.devices.getById(1001)
 
@@ -232,7 +232,7 @@ describe('api lifecycle', () => {
     await api.fetch()
 
     expect(api.registry.getDevices()).toHaveLength(0)
-    expect(api.registry.getFloorsByBuildingId(buildingId(1))).toHaveLength(0)
+    expect(api.registry.getFloorsByBuildingId(toBuildingId(1))).toHaveLength(0)
   })
 
   it('onSync callback is invoked after fetch', async () => {

--- a/tests/integration/registry-facades.test.ts
+++ b/tests/integration/registry-facades.test.ts
@@ -175,58 +175,32 @@ describe('registry + facade manager integration', () => {
         }),
       )
 
-    expect(tree).toMatchInlineSnapshot(`
-      [
-        {
-          "areas": [
-            {
-              "devices": [
-                "Studio AC",
-              ],
-              "name": "Studio",
-            },
-          ],
-          "floors": [],
-          "name": "Guest house",
-        },
-        {
-          "areas": [],
-          "floors": [
-            {
-              "areas": [
-                {
-                  "devices": [
-                    "Bedroom ERV",
-                  ],
-                  "name": "Bedroom",
-                },
-              ],
-              "devices": [],
-              "name": "First floor",
-            },
-            {
-              "areas": [
-                {
-                  "devices": [
-                    "Kitchen heat pump",
-                  ],
-                  "name": "Kitchen",
-                },
-                {
-                  "devices": [
-                    "Living room AC",
-                  ],
-                  "name": "Living room",
-                },
-              ],
-              "devices": [],
-              "name": "Ground floor",
-            },
-          ],
-          "name": "Main house",
-        },
-      ]
-    `)
+    expect(tree).toStrictEqual([
+      {
+        areas: [{ devices: ['Studio AC'], name: 'Studio' }],
+        floors: [],
+        name: 'Guest house',
+      },
+      {
+        areas: [],
+        floors: [
+          {
+            areas: [{ devices: ['Bedroom ERV'], name: 'Bedroom' }],
+            devices: [],
+            name: 'First floor',
+          },
+          {
+            areas: [
+              { devices: ['Kitchen heat pump'], name: 'Kitchen' },
+              { devices: ['Living room AC'], name: 'Living room' },
+            ],
+            devices: [],
+            name: 'Ground floor',
+          },
+        ],
+        name: 'Main house',
+      },
+    ])
   })
 
   it('filters devices by type across the entire registry', () => {

--- a/tests/integration/registry-facades.test.ts
+++ b/tests/integration/registry-facades.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it } from 'vitest'
 import { DeviceType } from '../../src/constants.ts'
 import { ClassicFacadeManager } from '../../src/facades/classic-manager.ts'
 import { ClassicRegistry } from '../../src/models/index.ts'
-import { toAreaId, toBuildingId, toDeviceId, toFloorId } from '../../src/types/index.ts'
+import {
+  toAreaId,
+  toBuildingId,
+  toDeviceId,
+  toFloorId,
+} from '../../src/types/index.ts'
 import {
   areaData,
   ataDevice,

--- a/tests/integration/registry-facades.test.ts
+++ b/tests/integration/registry-facades.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { DeviceType } from '../../src/constants.ts'
 import { ClassicFacadeManager } from '../../src/facades/classic-manager.ts'
 import { ClassicRegistry } from '../../src/models/index.ts'
-import { areaId, buildingId, deviceId, floorId } from '../../src/types/index.ts'
+import { toAreaId, toBuildingId, toDeviceId, toFloorId } from '../../src/types/index.ts'
 import {
   areaData,
   ataDevice,
@@ -51,7 +51,7 @@ const buildings = [
   buildingData({
     FPDefined: false,
     HMDefined: false,
-    ID: buildingId(2),
+    ID: toBuildingId(2),
     Location: 0,
     Name: 'Guest house',
     TimeZone: 1,
@@ -68,7 +68,7 @@ const areas = [
   areaData({ ID: 101, Name: 'Kitchen' }),
   areaData({ FloorId: 11, ID: 102, Name: 'Bedroom' }),
   areaData({
-    BuildingId: buildingId(2),
+    BuildingId: toBuildingId(2),
     FloorId: null,
     ID: 200,
     Name: 'Studio',
@@ -78,28 +78,28 @@ const areas = [
 const devices = [
   ataDevice({
     Device: ataData,
-    DeviceID: deviceId(1001),
+    DeviceID: toDeviceId(1001),
     DeviceName: 'Living room AC',
   }),
   atwDevice({
-    AreaID: areaId(101),
+    AreaID: toAreaId(101),
     Device: atwData,
-    DeviceID: deviceId(1002),
+    DeviceID: toDeviceId(1002),
     DeviceName: 'Kitchen heat pump',
   }),
   ervDevice({
-    AreaID: areaId(102),
-    BuildingID: buildingId(1),
+    AreaID: toAreaId(102),
+    BuildingID: toBuildingId(1),
     Device: ervData,
-    DeviceID: deviceId(1003),
+    DeviceID: toDeviceId(1003),
     DeviceName: 'Bedroom ERV',
-    FloorID: floorId(11),
+    FloorID: toFloorId(11),
   }),
   ataDevice({
-    AreaID: areaId(200),
-    BuildingID: buildingId(2),
+    AreaID: toAreaId(200),
+    BuildingID: toBuildingId(2),
     Device: ataDeviceData({ ...ataData, Power: false }),
-    DeviceID: deviceId(2001),
+    DeviceID: toDeviceId(2001),
     DeviceName: 'Studio AC',
     FloorID: null,
   }),
@@ -125,17 +125,17 @@ describe('registry + facade manager integration', () => {
   it('syncs a full building hierarchy and resolves cross-references', () => {
     const { registry } = createContext()
 
-    expect(registry.getDevicesByBuildingId(buildingId(1))).toHaveLength(3)
-    expect(registry.getDevicesByBuildingId(buildingId(2))).toHaveLength(1)
-    expect(registry.getFloorsByBuildingId(buildingId(1))).toHaveLength(2)
-    expect(registry.getFloorsByBuildingId(buildingId(2))).toHaveLength(0)
-    expect(registry.getAreasByFloorId(floorId(10))).toHaveLength(2)
-    expect(registry.getAreasByFloorId(floorId(11))).toHaveLength(1)
-    expect(registry.getAreasByBuildingId(buildingId(2))).toHaveLength(1)
-    expect(registry.getDevicesByFloorId(floorId(10))).toHaveLength(2)
-    expect(registry.getDevicesByFloorId(floorId(11))).toHaveLength(1)
-    expect(registry.getDevicesByAreaId(areaId(100))).toHaveLength(1)
-    expect(registry.getDevicesByAreaId(areaId(200))).toHaveLength(1)
+    expect(registry.getDevicesByBuildingId(toBuildingId(1))).toHaveLength(3)
+    expect(registry.getDevicesByBuildingId(toBuildingId(2))).toHaveLength(1)
+    expect(registry.getFloorsByBuildingId(toBuildingId(1))).toHaveLength(2)
+    expect(registry.getFloorsByBuildingId(toBuildingId(2))).toHaveLength(0)
+    expect(registry.getAreasByFloorId(toFloorId(10))).toHaveLength(2)
+    expect(registry.getAreasByFloorId(toFloorId(11))).toHaveLength(1)
+    expect(registry.getAreasByBuildingId(toBuildingId(2))).toHaveLength(1)
+    expect(registry.getDevicesByFloorId(toFloorId(10))).toHaveLength(2)
+    expect(registry.getDevicesByFloorId(toFloorId(11))).toHaveLength(1)
+    expect(registry.getDevicesByAreaId(toAreaId(100))).toHaveLength(1)
+    expect(registry.getDevicesByAreaId(toAreaId(200))).toHaveLength(1)
   })
 
   /*
@@ -293,10 +293,10 @@ describe('registry + facade manager integration', () => {
     registry.syncDevices([
       ...devices,
       ataDevice({
-        AreaID: areaId(200),
-        BuildingID: buildingId(2),
+        AreaID: toAreaId(200),
+        BuildingID: toBuildingId(2),
         Device: ataData,
-        DeviceID: deviceId(2002),
+        DeviceID: toDeviceId(2002),
         DeviceName: 'Studio AC 2',
         FloorID: null,
       }),
@@ -331,7 +331,7 @@ describe('registry + facade manager integration', () => {
     registry.syncFloors([])
     registry.syncAreas([
       areaData({
-        BuildingId: buildingId(2),
+        BuildingId: toBuildingId(2),
         FloorId: null,
         ID: 200,
         Name: 'Studio',
@@ -343,7 +343,7 @@ describe('registry + facade manager integration', () => {
     const facade = manager.get(defined(registry.buildings.getById(2)))
 
     expect(facade.devices).toHaveLength(1)
-    expect(registry.getFloorsByBuildingId(buildingId(2))).toHaveLength(0)
-    expect(registry.getAreasByBuildingId(buildingId(2))).toHaveLength(1)
+    expect(registry.getFloorsByBuildingId(toBuildingId(2))).toHaveLength(0)
+    expect(registry.getAreasByBuildingId(toBuildingId(2))).toHaveLength(1)
   })
 })

--- a/tests/unit/classic-api.test.ts
+++ b/tests/unit/classic-api.test.ts
@@ -25,8 +25,8 @@ import {
   type BuildingWithStructure,
   type ListDeviceAny,
   type SetDevicePostData,
-  buildingId,
-  deviceId,
+  toBuildingId,
+  toDeviceId,
 } from '../../src/types/index.ts'
 import { cast, createSettingStore, mock } from '../helpers.ts'
 
@@ -146,7 +146,7 @@ const createBuilding = (
     HMEnabled: false,
     HMEndDate: null,
     HMStartDate: null,
-    ID: buildingId(1),
+    ID: toBuildingId(1),
     Location: 10,
     Name: 'Test',
     Structure: { Areas: [], Devices: [], Floors: [] },
@@ -514,7 +514,7 @@ describe('mELCloud Classic API', () => {
       mockAxiosInstance.post.mockResolvedValue({ data: {} })
       await api.setValues({
         postData: mock<SetDevicePostData<typeof DeviceType.Ata>>({
-          DeviceID: deviceId(1),
+          DeviceID: toDeviceId(1),
           EffectiveFlags: 1,
         }),
         type,
@@ -1194,7 +1194,7 @@ describe('mELCloud Classic API', () => {
         Structure: {
           Areas: [
             {
-              BuildingId: buildingId(1),
+              BuildingId: toBuildingId(1),
               Devices: [
                 createDevice({
                   AreaID: 100,
@@ -1214,7 +1214,7 @@ describe('mELCloud Classic API', () => {
             {
               Areas: [
                 {
-                  BuildingId: buildingId(1),
+                  BuildingId: toBuildingId(1),
                   Devices: [
                     createDevice({
                       AreaID: 200,
@@ -1228,7 +1228,7 @@ describe('mELCloud Classic API', () => {
                   Name: 'FA1',
                 },
               ],
-              BuildingId: buildingId(1),
+              BuildingId: toBuildingId(1),
               Devices: [
                 createDevice({
                   DeviceID: 4000,

--- a/tests/unit/classic-registry.test.ts
+++ b/tests/unit/classic-registry.test.ts
@@ -6,10 +6,10 @@ import {
   type ListDevice,
   type ListDeviceAny,
   type ListDeviceDataAta,
-  areaId,
-  buildingId,
-  deviceId,
-  floorId,
+  toAreaId,
+  toBuildingId,
+  toDeviceId,
+  toFloorId,
 } from '../../src/types/index.ts'
 import {
   areaData,
@@ -25,7 +25,7 @@ const allBuildings = [
   buildingData({ Name: 'Building 1' }),
   buildingData({
     FPDefined: false,
-    ID: buildingId(2),
+    ID: toBuildingId(2),
     Location: 20,
     Name: 'Building 2',
   }),
@@ -34,14 +34,14 @@ const allBuildings = [
 const allFloors = [
   floorData({ Name: 'Floor 1' }),
   floorData({ ID: 11, Name: 'Floor 2' }),
-  floorData({ BuildingId: buildingId(2), ID: 12, Name: 'Floor 3' }),
+  floorData({ BuildingId: toBuildingId(2), ID: 12, Name: 'Floor 3' }),
 ]
 
 const allAreas = [
   areaData({ Name: 'Area 1' }),
   areaData({ FloorId: null, ID: 101, Name: 'Area 2' }),
   areaData({
-    BuildingId: buildingId(2),
+    BuildingId: toBuildingId(2),
     FloorId: 12,
     ID: 102,
     Name: 'Area 3',
@@ -51,10 +51,10 @@ const allAreas = [
 const allDevices: ListDeviceAny[] = [
   ataDevice({ DeviceName: 'Device ATA' }),
   atwDevice({
-    AreaID: areaId(102),
-    BuildingID: buildingId(2),
+    AreaID: toAreaId(102),
+    BuildingID: toBuildingId(2),
     DeviceName: 'Device ATW',
-    FloorID: floorId(12),
+    FloorID: toFloorId(12),
   }),
   ervDevice({ AreaID: null, DeviceName: 'Device ERV' }),
 ]
@@ -106,9 +106,9 @@ describe('model registry', () => {
       const registry = new ClassicRegistry()
       const invalidDevice = mock<ListDevice<0>>({
         AreaID: null,
-        BuildingID: buildingId(1),
+        BuildingID: toBuildingId(1),
         Device: mock<ListDeviceDataAta>(),
-        DeviceID: deviceId(9999),
+        DeviceID: toDeviceId(9999),
         DeviceName: 'Invalid',
         FloorID: null,
         Type: cast(999),
@@ -128,9 +128,9 @@ describe('model registry', () => {
       const registry = new ClassicRegistry()
       const invalidDevice = mock<ListDevice<0>>({
         AreaID: null,
-        BuildingID: buildingId(1),
+        BuildingID: toBuildingId(1),
         Device: mock<ListDeviceDataAta>(),
-        DeviceID: deviceId(9999),
+        DeviceID: toDeviceId(9999),
         DeviceName: 'Invalid',
         FloorID: null,
         Type: cast({ nested: 'value' }),
@@ -167,10 +167,10 @@ describe('model registry', () => {
       registry.syncDevices([
         ataDevice({ DeviceName: 'Updated ATA' }),
         atwDevice({
-          AreaID: areaId(102),
-          BuildingID: buildingId(2),
+          AreaID: toAreaId(102),
+          BuildingID: toBuildingId(2),
           DeviceName: 'Updated ATW',
-          FloorID: floorId(12),
+          FloorID: toFloorId(12),
         }),
         ervDevice({ AreaID: null, DeviceName: 'Updated ERV' }),
       ])
@@ -238,7 +238,7 @@ describe('model registry', () => {
   describe('cross-references', () => {
     it('getFloorsByBuildingId returns floors belonging to a building', () => {
       const registry = createPopulatedRegistry(allFixtures)
-      const floors = registry.getFloorsByBuildingId(buildingId(1))
+      const floors = registry.getFloorsByBuildingId(toBuildingId(1))
 
       expect(floors).toHaveLength(2)
       expect(floors.map(({ name }) => name)).toStrictEqual([
@@ -249,7 +249,7 @@ describe('model registry', () => {
 
     it('getAreasByBuildingId returns areas belonging to a building', () => {
       const registry = createPopulatedRegistry(allFixtures)
-      const areas = registry.getAreasByBuildingId(buildingId(1))
+      const areas = registry.getAreasByBuildingId(toBuildingId(1))
 
       expect(areas).toHaveLength(2)
     })
@@ -257,37 +257,37 @@ describe('model registry', () => {
     it('getAreasByFloorId returns areas belonging to a floor', () => {
       const registry = createPopulatedRegistry(allFixtures)
 
-      expect(registry.getAreasByFloorId(floorId(10))).toHaveLength(1)
-      expect(registry.getAreasByFloorId(floorId(11))).toHaveLength(0)
+      expect(registry.getAreasByFloorId(toFloorId(10))).toHaveLength(1)
+      expect(registry.getAreasByFloorId(toFloorId(11))).toHaveLength(0)
     })
 
     it('getDevicesByBuildingId returns devices belonging to a building', () => {
       const registry = createPopulatedRegistry(allFixtures)
 
-      expect(registry.getDevicesByBuildingId(buildingId(1))).toHaveLength(2)
-      expect(registry.getDevicesByBuildingId(buildingId(2))).toHaveLength(1)
+      expect(registry.getDevicesByBuildingId(toBuildingId(1))).toHaveLength(2)
+      expect(registry.getDevicesByBuildingId(toBuildingId(2))).toHaveLength(1)
     })
 
     it('getDevicesByFloorId returns devices belonging to a floor', () => {
       const registry = createPopulatedRegistry(allFixtures)
 
-      expect(registry.getDevicesByFloorId(floorId(10))).toHaveLength(1)
-      expect(registry.getDevicesByFloorId(floorId(11))).toHaveLength(0)
+      expect(registry.getDevicesByFloorId(toFloorId(10))).toHaveLength(1)
+      expect(registry.getDevicesByFloorId(toFloorId(11))).toHaveLength(0)
     })
 
     it('getDevicesByAreaId returns devices belonging to an area', () => {
       const registry = createPopulatedRegistry(allFixtures)
 
-      expect(registry.getDevicesByAreaId(areaId(100))).toHaveLength(1)
-      expect(registry.getDevicesByAreaId(areaId(101))).toHaveLength(0)
+      expect(registry.getDevicesByAreaId(toAreaId(100))).toHaveLength(1)
+      expect(registry.getDevicesByAreaId(toAreaId(101))).toHaveLength(0)
     })
 
     it('returns empty arrays for unknown building id', () => {
       const registry = createPopulatedRegistry(allFixtures)
 
-      expect(registry.getFloorsByBuildingId(buildingId(999))).toHaveLength(0)
-      expect(registry.getAreasByBuildingId(buildingId(999))).toHaveLength(0)
-      expect(registry.getDevicesByBuildingId(buildingId(999))).toHaveLength(0)
+      expect(registry.getFloorsByBuildingId(toBuildingId(999))).toHaveLength(0)
+      expect(registry.getAreasByBuildingId(toBuildingId(999))).toHaveLength(0)
+      expect(registry.getDevicesByBuildingId(toBuildingId(999))).toHaveLength(0)
     })
   })
 })

--- a/tests/unit/facades.test.ts
+++ b/tests/unit/facades.test.ts
@@ -23,7 +23,7 @@ import { type Device, ClassicRegistry } from '../../src/models/index.ts'
 import {
   type SetDeviceDataAta,
   type SetDevicePostData,
-  buildingId,
+  toBuildingId,
 } from '../../src/types/index.ts'
 import {
   areaData,
@@ -626,7 +626,7 @@ describe('base facade instance error', () => {
     const registry = createRegistry()
     registry.syncAreas([
       {
-        BuildingId: buildingId(1),
+        BuildingId: toBuildingId(1),
         FloorId: null,
         ID: 200,
         Name: 'Empty Area',

--- a/tests/unit/get-zones.test.ts
+++ b/tests/unit/get-zones.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { ClassicRegistry } from '../../src/models/index.ts'
 import { DeviceType } from '../../src/constants.ts'
-import { areaId, buildingId, deviceId, floorId } from '../../src/types/index.ts'
+import { toAreaId, toBuildingId, toDeviceId, toFloorId } from '../../src/types/index.ts'
 import {
   areaData,
   ataDevice,
@@ -17,7 +17,7 @@ import { createPopulatedRegistry, defined } from '../helpers.ts'
 const buildings = [
   buildingData({
     HMDefined: false,
-    ID: buildingId(1),
+    ID: toBuildingId(1),
     Location: 0,
     Name: 'Bravo',
     TimeZone: 1,
@@ -25,7 +25,7 @@ const buildings = [
   buildingData({
     FPDefined: false,
     HMDefined: false,
-    ID: buildingId(2),
+    ID: toBuildingId(2),
     Location: 0,
     Name: 'Alpha',
     TimeZone: 1,
@@ -33,18 +33,18 @@ const buildings = [
 ]
 
 const floors = [
-  floorData({ BuildingId: buildingId(1), ID: 10, Name: 'Ground floor' }),
+  floorData({ BuildingId: toBuildingId(1), ID: 10, Name: 'Ground floor' }),
 ]
 
 const areas = [
   areaData({
-    BuildingId: buildingId(1),
+    BuildingId: toBuildingId(1),
     FloorId: 10,
     ID: 100,
     Name: 'Salon',
   }),
   areaData({
-    BuildingId: buildingId(2),
+    BuildingId: toBuildingId(2),
     FloorId: null,
     ID: 200,
     Name: 'Studio',
@@ -53,26 +53,26 @@ const areas = [
 
 const devices = [
   ataDevice({
-    AreaID: areaId(100),
-    BuildingID: buildingId(1),
+    AreaID: toAreaId(100),
+    BuildingID: toBuildingId(1),
     Device: ataDeviceData(),
-    DeviceID: deviceId(1001),
+    DeviceID: toDeviceId(1001),
     DeviceName: 'AC unit',
-    FloorID: floorId(10),
+    FloorID: toFloorId(10),
   }),
   atwDevice({
     AreaID: null,
-    BuildingID: buildingId(1),
+    BuildingID: toBuildingId(1),
     Device: atwDeviceData({ HasZone2: false }),
-    DeviceID: deviceId(1002),
+    DeviceID: toDeviceId(1002),
     DeviceName: 'Heat pump',
     FloorID: null,
   }),
   ataDevice({
-    AreaID: areaId(200),
-    BuildingID: buildingId(2),
+    AreaID: toAreaId(200),
+    BuildingID: toBuildingId(2),
     Device: ataDeviceData(),
-    DeviceID: deviceId(2001),
+    DeviceID: toDeviceId(2001),
     DeviceName: 'Studio AC',
     FloorID: null,
   }),

--- a/tests/unit/get-zones.test.ts
+++ b/tests/unit/get-zones.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from 'vitest'
 
 import type { ClassicRegistry } from '../../src/models/index.ts'
 import { DeviceType } from '../../src/constants.ts'
-import { toAreaId, toBuildingId, toDeviceId, toFloorId } from '../../src/types/index.ts'
+import {
+  toAreaId,
+  toBuildingId,
+  toDeviceId,
+  toFloorId,
+} from '../../src/types/index.ts'
 import {
   areaData,
   ataDevice,


### PR DESCRIPTION
The branding helpers (areaId, buildingId, deviceId, floorId) are conversion
functions that brand plain numbers as nominal ID types. Renaming them to
toAreaId, toBuildingId, toDeviceId, toFloorId makes their intent explicit
and eliminates the import-alias workaround in classic-registry.ts where
they were already aliased to `toXxxId` to avoid colliding with model
property names.

Also converts the `for (let attempt …)` loop in withRetryBackoff to a
`while` loop, which better matches the control flow (the increment only
matters on the retry path).

https://claude.ai/code/session_011zJLkB3E7WWLMfhtT3gsr1