### PR TITLE
Replace Home API with token-based mobile BFF

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "24.0.0",
+  "version": "24.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "24.0.0",
+      "version": "24.0.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "24.0.0",
+  "version": "24.0.1",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -1,0 +1,119 @@
+import axios, { type AxiosInstance } from 'axios'
+
+import type { LoginCredentials } from '../types/index.ts'
+import { setting } from '../decorators/index.ts'
+import { createAPICallErrorData } from '../observability/index.ts'
+import { RateLimitGate, RetryGuard } from '../resilience/index.ts'
+import { RequestLifecycleEmitter } from '../observability/index.ts'
+import type {
+  BaseAPIConfig,
+  Logger,
+  OnSyncFunction,
+  SettingManager,
+} from './interfaces.ts'
+import { SyncManager } from './sync-manager.ts'
+
+/**
+ * Shared infrastructure for MELCloud API clients.
+ *
+ * Extracts the common fields, lifecycle management (sync, rate-limit,
+ * retry guard, dispose), and credential handling that both ClassicAPI
+ * and HomeAPI duplicate.
+ */
+export abstract class BaseAPI implements Disposable {
+  public readonly logger: Logger
+
+  public readonly onSync?: OnSyncFunction
+
+  public readonly settingManager?: SettingManager
+
+  protected readonly abortSignal?: AbortSignal
+
+  protected readonly api: AxiosInstance
+
+  protected readonly events: RequestLifecycleEmitter
+
+  protected readonly rateLimitGate: RateLimitGate
+
+  protected readonly retryGuard: RetryGuard
+
+  readonly #syncManager: SyncManager
+
+  @setting
+  protected accessor expiry = ''
+
+  @setting
+  protected accessor password = ''
+
+  @setting
+  protected accessor username = ''
+
+  protected constructor(
+    config: BaseAPIConfig,
+    axiosConfig: {
+      baseURL: string
+      headers?: Record<string, string>
+      timeout: number
+    },
+    syncCallback: () => Promise<unknown>,
+    rateLimitHours: number,
+    retryDelay: number,
+    axiosInstance?: AxiosInstance,
+  ) {
+    const {
+      abortSignal,
+      autoSyncInterval,
+      events,
+      logger = console,
+      onSync,
+      settingManager,
+    } = config
+    this.abortSignal = abortSignal
+    this.logger = logger
+    this.onSync = onSync
+    this.settingManager = settingManager
+    this.events = new RequestLifecycleEmitter(events, logger)
+    this.rateLimitGate = new RateLimitGate({ hours: rateLimitHours })
+    this.retryGuard = new RetryGuard(retryDelay)
+    this.api = axiosInstance ?? axios.create(axiosConfig)
+    this.#syncManager = new SyncManager(syncCallback, logger, autoSyncInterval)
+  }
+
+  public get isRateLimited(): boolean {
+    return this.rateLimitGate.isPaused
+  }
+
+  public clearSync(): void {
+    this.#syncManager.clear()
+  }
+
+  public setSyncInterval(minutes: number | null): void {
+    this.#syncManager.setInterval(minutes)
+  }
+
+  public [Symbol.dispose](): void {
+    this.#syncManager[Symbol.dispose]()
+    this.retryGuard[Symbol.dispose]()
+  }
+
+  public abstract authenticate(data?: LoginCredentials): Promise<boolean>
+
+  protected applyCredentials(username?: string, password?: string): void {
+    if (username !== undefined) {
+      this.username = username
+    }
+    if (password !== undefined) {
+      this.password = password
+    }
+  }
+
+  protected logError(error: unknown): void {
+    if (axios.isAxiosError(error)) {
+      this.logger.error(String(createAPICallErrorData(error)))
+    }
+  }
+
+  protected get syncManager(): SyncManager {
+    return this.#syncManager
+  }
+}

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -2,9 +2,11 @@ import axios, { type AxiosInstance } from 'axios'
 
 import type { LoginCredentials } from '../types/index.ts'
 import { setting } from '../decorators/index.ts'
-import { createAPICallErrorData } from '../observability/index.ts'
+import {
+  createAPICallErrorData,
+  RequestLifecycleEmitter,
+} from '../observability/index.ts'
 import { RateLimitGate, RetryGuard } from '../resilience/index.ts'
-import { RequestLifecycleEmitter } from '../observability/index.ts'
 import type {
   BaseAPIConfig,
   Logger,
@@ -12,6 +14,19 @@ import type {
   SettingManager,
 } from './interfaces.ts'
 import { SyncManager } from './sync-manager.ts'
+
+/** Options for the {@link BaseAPI} constructor beyond the base config. */
+interface BaseAPIConstructorOptions {
+  axiosConfig: {
+    baseURL: string
+    timeout: number
+    headers?: Record<string, string>
+  }
+  rateLimitHours: number
+  retryDelay: number
+  axiosInstance?: AxiosInstance
+  syncCallback: () => Promise<unknown>
+}
 
 /**
  * Shared infrastructure for MELCloud API clients.
@@ -27,6 +42,10 @@ export abstract class BaseAPI implements Disposable {
 
   public readonly settingManager?: SettingManager
 
+  public get isRateLimited(): boolean {
+    return this.rateLimitGate.isPaused
+  }
+
   protected readonly abortSignal?: AbortSignal
 
   protected readonly api: AxiosInstance
@@ -37,8 +56,6 @@ export abstract class BaseAPI implements Disposable {
 
   protected readonly retryGuard: RetryGuard
 
-  readonly #syncManager: SyncManager
-
   @setting
   protected accessor expiry = ''
 
@@ -48,26 +65,29 @@ export abstract class BaseAPI implements Disposable {
   @setting
   protected accessor username = ''
 
+  protected get syncManager(): SyncManager {
+    return this.#syncManager
+  }
+
+  readonly #syncManager: SyncManager
+
   protected constructor(
-    config: BaseAPIConfig,
-    axiosConfig: {
-      baseURL: string
-      headers?: Record<string, string>
-      timeout: number
-    },
-    syncCallback: () => Promise<unknown>,
-    rateLimitHours: number,
-    retryDelay: number,
-    axiosInstance?: AxiosInstance,
-  ) {
-    const {
+    {
       abortSignal,
       autoSyncInterval,
       events,
       logger = console,
       onSync,
       settingManager,
-    } = config
+    }: BaseAPIConfig,
+    {
+      axiosConfig,
+      axiosInstance,
+      rateLimitHours,
+      retryDelay,
+      syncCallback,
+    }: BaseAPIConstructorOptions,
+  ) {
     this.abortSignal = abortSignal
     this.logger = logger
     this.onSync = onSync
@@ -79,16 +99,10 @@ export abstract class BaseAPI implements Disposable {
     this.#syncManager = new SyncManager(syncCallback, logger, autoSyncInterval)
   }
 
-  public get isRateLimited(): boolean {
-    return this.rateLimitGate.isPaused
-  }
+  public abstract authenticate(data?: LoginCredentials): Promise<boolean>
 
   public clearSync(): void {
     this.#syncManager.clear()
-  }
-
-  public setSyncInterval(minutes: number | null): void {
-    this.#syncManager.setInterval(minutes)
   }
 
   public [Symbol.dispose](): void {
@@ -96,7 +110,9 @@ export abstract class BaseAPI implements Disposable {
     this.retryGuard[Symbol.dispose]()
   }
 
-  public abstract authenticate(data?: LoginCredentials): Promise<boolean>
+  public setSyncInterval(minutes: number | null): void {
+    this.#syncManager.setInterval(minutes)
+  }
 
   protected applyCredentials(username?: string, password?: string): void {
     if (username !== undefined) {
@@ -111,9 +127,5 @@ export abstract class BaseAPI implements Disposable {
     if (axios.isAxiosError(error)) {
       this.logger.error(String(createAPICallErrorData(error)))
     }
-  }
-
-  protected get syncManager(): SyncManager {
-    return this.#syncManager
   }
 }

--- a/src/api/classic.ts
+++ b/src/api/classic.ts
@@ -50,15 +50,12 @@ import {
   APICallRequestData,
   APICallResponseData,
   createAPICallErrorData,
-  RequestLifecycleEmitter,
 } from '../observability/index.ts'
 import {
   DEFAULT_TRANSIENT_RETRY_OPTIONS,
   isSessionExpired,
   isTransientServerError,
   RateLimitError,
-  RateLimitGate,
-  RetryGuard,
   toDeviceId,
   withRetryBackoff,
 } from '../resilience/index.ts'
@@ -67,11 +64,8 @@ import type {
   ClassicAPIConfig,
   ErrorLog,
   ErrorLogQuery,
-  Logger,
-  OnSyncFunction,
-  SettingManager,
 } from './interfaces.ts'
-import { SyncManager } from './sync-manager.ts'
+import { BaseAPI } from './base.ts'
 
 const deviceTypeNames = {
   [DeviceType.Ata]: 'Ata',
@@ -200,44 +194,17 @@ const collectDevices = function* collectDevices(
  * Main MELCloud Classic API client. Handles authentication, device syncing, and all
  * ClassicAPI endpoint calls. Uses a private constructor — create instances via {@link ClassicAPI.create}.
  */
-export class ClassicAPI implements ClassicAPIAdapter, Disposable {
-  public readonly logger: Logger
-
-  public readonly onSync?: OnSyncFunction
-
-  public readonly settingManager?: SettingManager
-
+export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
   public get registry(): ClassicRegistry {
     return this.#registry
   }
 
-  readonly #abortSignal?: AbortSignal
-
-  readonly #api: AxiosInstance
-
-  readonly #events: RequestLifecycleEmitter
-
   #language = 'en'
-
-  readonly #rateLimitGate = new RateLimitGate({ hours: DEFAULT_RETRY_HOURS })
 
   readonly #registry = new ClassicRegistry()
 
-  readonly #retryGuard = new RetryGuard(RETRY_DELAY)
-
-  readonly #syncManager: SyncManager
-
   @setting
   private accessor contextKey = ''
-
-  @setting
-  private accessor expiry = ''
-
-  @setting
-  private accessor password = ''
-
-  @setting
-  private accessor username = ''
 
   private get language(): string {
     return this.#language
@@ -249,31 +216,41 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
 
   private constructor(config: ClassicAPIConfig = {}) {
     const {
-      abortSignal,
       autoSyncInterval = DEFAULT_SYNC_INTERVAL,
-      events,
       language,
-      logger = console,
-      onSync,
       password,
       requestTimeout = DEFAULT_TIMEOUT_MS,
-      settingManager,
       shouldVerifySSL = true,
       timezone,
       username,
     } = config
-    this.logger = logger
-    this.onSync = onSync
-    this.settingManager = settingManager
-    this.#abortSignal = abortSignal
-    this.#events = new RequestLifecycleEmitter(events, logger)
-    this.#applyOptionalConfig({ language, password, timezone, username })
-    this.#api = this.#createAPI(shouldVerifySSL, requestTimeout)
-    this.#syncManager = new SyncManager(
-      async () => this.fetch(),
-      logger,
-      autoSyncInterval,
+    const axiosInstance = ClassicAPI.#createAxiosInstance(
+      shouldVerifySSL,
+      requestTimeout,
     )
+    super(
+      { ...config, autoSyncInterval },
+      { baseURL: API_BASE_URL, timeout: requestTimeout },
+      async () => this.fetch(),
+      DEFAULT_RETRY_HOURS,
+      RETRY_DELAY,
+      axiosInstance,
+    )
+    this.#applyOptionalConfig({ language, password, timezone, username })
+    this.#setupAxiosInterceptors(this.api)
+  }
+
+  static #createAxiosInstance(
+    shouldRejectUnauthorized: boolean,
+    timeout: number,
+  ): AxiosInstance {
+    return axios.create({
+      baseURL: API_BASE_URL,
+      httpsAgent: new https.Agent({
+        rejectUnauthorized: shouldRejectUnauthorized,
+      }),
+      timeout,
+    })
   }
 
   /**
@@ -318,20 +295,15 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
    */
   @syncDevices()
   public async fetch(): Promise<BuildingWithStructure[]> {
-    this.#syncManager.clear()
+    this.clearSync()
     try {
       return await this.#fetch()
     } catch (error) {
       this.logger.error('Failed to fetch devices:', error)
       return []
     } finally {
-      this.#syncManager.planNext()
+      this.syncManager.planNext()
     }
-  }
-
-  /** Cancel any pending automatic sync timer. */
-  public clearSync(): void {
-    this.#syncManager.clear()
   }
 
   public async getEnergy<T extends DeviceType>({
@@ -339,7 +311,7 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
   }: {
     postData: EnergyPostData
   }): Promise<{ data: EnergyData<T> }> {
-    return this.#api.post('/EnergyCost/Report', postData)
+    return this.api.post('/EnergyCost/Report', postData)
   }
 
   public async getErrorEntries({
@@ -347,7 +319,7 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
   }: {
     postData: ErrorLogPostData
   }): Promise<{ data: ErrorLogData[] | FailureData }> {
-    return this.#api.post('/Report/GetUnitErrorLog2', postData)
+    return this.api.post('/Report/GetUnitErrorLog2', postData)
   }
 
   public async getFrostProtection({
@@ -355,28 +327,13 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
   }: {
     params: SettingsParams
   }): Promise<{ data: FrostProtectionData }> {
-    return this.#api.get('/FrostProtection/GetSettings', {
+    return this.api.get('/FrostProtection/GetSettings', {
       params,
     })
   }
 
   public isAuthenticated(): boolean {
     return this.contextKey !== ''
-  }
-
-  /**
-   * Whether the upstream rate-limit gate is currently closed.
-   *
-   * A `true` value means the SDK recently observed a 429 Too Many
-   * Requests response on `LIST_PATH` and is intentionally failing
-   * subsequent list operations fast to honor the upstream
-   * `Retry-After` window. Consumers can poll this to display a
-   * "throttled, please wait" indicator without catching
-   * {@link RateLimitError} through the full call stack.
-   * @returns `true` while the gate is holding a pause window.
-   */
-  public get isRateLimited(): boolean {
-    return this.#rateLimitGate.isPaused
   }
 
   /**
@@ -424,7 +381,7 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
   }: {
     postData: GetGroupPostData
   }): Promise<{ data: GetGroupData }> {
-    return this.#api.post('/Group/Get', postData)
+    return this.api.post('/Group/Get', postData)
   }
 
   public async getHolidayMode({
@@ -432,7 +389,7 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
   }: {
     params: SettingsParams
   }): Promise<{ data: HolidayModeData }> {
-    return this.#api.get('/HolidayMode/GetSettings', {
+    return this.api.get('/HolidayMode/GetSettings', {
       params,
     })
   }
@@ -442,7 +399,7 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
   }: {
     postData: { device: number; hour: HourNumbers }
   }): Promise<{ data: ReportData }> {
-    return this.#api.post('/Report/GetHourlyTemperature', postData)
+    return this.api.post('/Report/GetHourlyTemperature', postData)
   }
 
   public async getInternalTemperatures({
@@ -450,7 +407,7 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
   }: {
     postData: ReportPostData
   }): Promise<{ data: ReportData }> {
-    return this.#api.post('/Report/GetInternalTemperatures2', postData)
+    return this.api.post('/Report/GetInternalTemperatures2', postData)
   }
 
   public async getOperationModes({
@@ -458,7 +415,7 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
   }: {
     postData: ReportPostData
   }): Promise<{ data: OperationModeLogData }> {
-    return this.#api.post('/Report/GetOperationModeLog2', postData)
+    return this.api.post('/Report/GetOperationModeLog2', postData)
   }
 
   public async getSignal({
@@ -466,7 +423,7 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
   }: {
     postData: { devices: number | number[]; hour: HourNumbers }
   }): Promise<{ data: ReportData }> {
-    return this.#api.post('/Report/GetSignalStrength', postData)
+    return this.api.post('/Report/GetSignalStrength', postData)
   }
 
   public async getTemperatures({
@@ -474,7 +431,7 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
   }: {
     postData: TemperatureLogPostData
   }): Promise<{ data: ReportData }> {
-    return this.#api.post('/Report/GetTemperatureLog2', postData)
+    return this.api.post('/Report/GetTemperatureLog2', postData)
   }
 
   public async getTiles({
@@ -492,7 +449,7 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
   }: {
     postData: TilesPostData<T>
   }): Promise<{ data: TilesData<T> }> {
-    return this.#api.post('/Tile/Get2', postData)
+    return this.api.post('/Tile/Get2', postData)
   }
 
   public async getValues<T extends DeviceType>({
@@ -500,11 +457,11 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
   }: {
     params: GetDeviceDataParams
   }): Promise<{ data: GetDeviceData<T> }> {
-    return this.#api.get('/Device/Get', { params })
+    return this.api.get('/Device/Get', { params })
   }
 
   public async list(): Promise<{ data: BuildingWithStructure[] }> {
-    return this.#api.get(LIST_PATH)
+    return this.api.get(LIST_PATH)
   }
 
   public async login({
@@ -512,13 +469,7 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
   }: {
     postData: LoginPostData
   }): Promise<{ data: LoginData }> {
-    return this.#api.post(LOGIN_PATH, postData)
-  }
-
-  /** Dispose both sync and retry timers. */
-  public [Symbol.dispose](): void {
-    this.#syncManager[Symbol.dispose]()
-    this.#retryGuard[Symbol.dispose]()
+    return this.api.post(LOGIN_PATH, postData)
   }
 
   public async setFrostProtection({
@@ -526,7 +477,7 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
   }: {
     postData: FrostProtectionPostData
   }): Promise<{ data: FailureData | SuccessData }> {
-    return this.#api.post('/FrostProtection/Update', postData)
+    return this.api.post('/FrostProtection/Update', postData)
   }
 
   public async setGroup({
@@ -534,7 +485,7 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
   }: {
     postData: SetGroupPostData
   }): Promise<{ data: FailureData | SuccessData }> {
-    return this.#api.post('/Group/SetAta', postData)
+    return this.api.post('/Group/SetAta', postData)
   }
 
   public async setHolidayMode({
@@ -542,7 +493,7 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
   }: {
     postData: HolidayModePostData
   }): Promise<{ data: FailureData | SuccessData }> {
-    return this.#api.post('/HolidayMode/Update', postData)
+    return this.api.post('/HolidayMode/Update', postData)
   }
 
   /**
@@ -551,7 +502,7 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
    */
   public async setLanguage(language: string): Promise<void> {
     if (language !== this.language) {
-      const { data: hasLanguageChanged } = await this.#api.post<boolean>(
+      const { data: hasLanguageChanged } = await this.api.post<boolean>(
         '/User/UpdateLanguage',
         { language: this.#getLanguageCode(language) },
       )
@@ -566,15 +517,7 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
   }: {
     postData: SetPowerPostData
   }): Promise<{ data: boolean }> {
-    return this.#api.post('/Device/Power', postData)
-  }
-
-  /**
-   * Update the automatic sync interval and reschedule.
-   * @param minutes - Interval in minutes. Set to `0` or `null` to disable auto-sync.
-   */
-  public setSyncInterval(minutes: number | null): void {
-    this.#syncManager.setInterval(minutes)
+    return this.api.post('/Device/Power', postData)
   }
 
   public async setValues<T extends DeviceType>({
@@ -584,7 +527,7 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
     postData: SetDevicePostData<T>
     type: T
   }): Promise<{ data: SetDeviceData<T> }> {
-    return this.#api.post(`/Device/Set${deviceTypeNames[type]}`, postData)
+    return this.api.post(`/Device/Set${deviceTypeNames[type]}`, postData)
   }
 
   // Allow one retry per RETRY_DELAY window to avoid infinite retry loops
@@ -605,32 +548,12 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
     if (language !== undefined) {
       this.language = language
     }
-    if (username !== undefined) {
-      this.username = username
-    }
-    if (password !== undefined) {
-      this.password = password
-    }
+    this.applyCredentials(username, password)
   }
 
   #clearPersistedSession(): void {
     this.contextKey = ''
     this.expiry = ''
-  }
-
-  #createAPI(
-    shouldRejectUnauthorized: boolean,
-    timeout: number,
-  ): AxiosInstance {
-    const api = axios.create({
-      baseURL: API_BASE_URL,
-      httpsAgent: new https.Agent({
-        rejectUnauthorized: shouldRejectUnauthorized,
-      }),
-      timeout,
-    })
-    this.#setupAxiosInterceptors(api)
-    return api
   }
 
   #emitErrorEvent(
@@ -654,7 +577,7 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
     if (meta === undefined) {
       return
     }
-    this.#events.emitError({
+    this.events.emitError({
       correlationId: meta.correlationId,
       durationMs: Date.now() - meta.startedAt,
       error,
@@ -716,19 +639,19 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
 
     const { config, response: { headers, status } = {} } = error
     if (status === HttpStatusCode.TooManyRequests) {
-      this.#rateLimitGate.recordAndLog(
+      this.rateLimitGate.recordAndLog(
         this.logger,
         headers?.['retry-after'],
         'list operations',
       )
     } else if (
       status === HttpStatusCode.Unauthorized &&
-      this.#retryGuard.tryConsume() &&
+      this.retryGuard.tryConsume() &&
       config &&
       config.url !== LOGIN_PATH &&
       (await this.authenticate())
     ) {
-      return this.#api.request(config)
+      return this.api.request(config)
     }
     this.#emitErrorEvent(error, config)
     throw new Error(errorData.errorMessage, { cause: error })
@@ -737,11 +660,11 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
   async #onRequest(
     config: InternalAxiosRequestConfig,
   ): Promise<InternalAxiosRequestConfig> {
-    const newConfig = { ...config, signal: this.#abortSignal ?? config.signal }
-    if (newConfig.url === LIST_PATH && this.#rateLimitGate.isPaused) {
+    const newConfig = { ...config, signal: this.abortSignal ?? config.signal }
+    if (newConfig.url === LIST_PATH && this.rateLimitGate.isPaused) {
       throw new RateLimitError(
-        `API requests to ${LIST_PATH} are on hold for ${this.#rateLimitGate.formatRemaining()}`,
-        { retryAfter: this.#rateLimitGate.remaining },
+        `API requests to ${LIST_PATH} are on hold for ${this.rateLimitGate.formatRemaining()}`,
+        { retryAfter: this.rateLimitGate.remaining },
       )
     }
     if (newConfig.url !== LOGIN_PATH) {
@@ -765,7 +688,7 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
     const { [LIFECYCLE_KEY]: meta } =
       response.config as LifecycleTagged<InternalAxiosRequestConfig>
     if (meta !== undefined) {
-      this.#events.emitComplete({
+      this.events.emitComplete({
         correlationId: meta.correlationId,
         durationMs: Date.now() - meta.startedAt,
         method: meta.method,
@@ -820,7 +743,7 @@ export class ClassicAPI implements ClassicAPIAdapter, Disposable {
     }
     const tagged = config as LifecycleTagged<InternalAxiosRequestConfig>
     tagged[LIFECYCLE_KEY] = meta
-    this.#events.emitStart({
+    this.events.emitStart({
       correlationId: meta.correlationId,
       method: meta.method,
       url: meta.url,

--- a/src/api/classic.ts
+++ b/src/api/classic.ts
@@ -228,14 +228,13 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
       shouldVerifySSL,
       requestTimeout,
     )
-    super(
-      { ...config, autoSyncInterval },
-      { baseURL: API_BASE_URL, timeout: requestTimeout },
-      async () => this.fetch(),
-      DEFAULT_RETRY_HOURS,
-      RETRY_DELAY,
+    super({ ...config, autoSyncInterval }, {
+      axiosConfig: { baseURL: API_BASE_URL, timeout: requestTimeout },
       axiosInstance,
-    )
+      rateLimitHours: DEFAULT_RETRY_HOURS,
+      retryDelay: RETRY_DELAY,
+      syncCallback: async () => this.fetch(),
+    })
     this.#applyOptionalConfig({ language, password, timezone, username })
     this.#setupAxiosInterceptors(this.api)
   }

--- a/src/api/classic.ts
+++ b/src/api/classic.ts
@@ -228,13 +228,16 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
       shouldVerifySSL,
       requestTimeout,
     )
-    super({ ...config, autoSyncInterval }, {
-      axiosConfig: { baseURL: API_BASE_URL, timeout: requestTimeout },
-      axiosInstance,
-      rateLimitHours: DEFAULT_RETRY_HOURS,
-      retryDelay: RETRY_DELAY,
-      syncCallback: async () => this.fetch(),
-    })
+    super(
+      { ...config, autoSyncInterval },
+      {
+        axiosConfig: { baseURL: API_BASE_URL, timeout: requestTimeout },
+        axiosInstance,
+        rateLimitHours: DEFAULT_RETRY_HOURS,
+        retryDelay: RETRY_DELAY,
+        syncCallback: async () => this.fetch(),
+      },
+    )
     this.#applyOptionalConfig({ language, password, timezone, username })
     this.#setupAxiosInterceptors(this.api)
   }

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -1,8 +1,6 @@
 import { randomUUID } from 'node:crypto'
 
-import { CookieJar } from 'tough-cookie'
 import axios, {
-  type AxiosInstance,
   type AxiosResponse,
   HttpStatusCode,
 } from 'axios'
@@ -10,7 +8,6 @@ import axios, {
 import type {
   HomeAtaValues,
   HomeBuilding,
-  HomeClaim,
   HomeContext,
   HomeEnergyData,
   HomeErrorLogEntry,
@@ -24,135 +21,64 @@ import { HomeRegistry } from '../models/home-registry.ts'
 import {
   APICallRequestData,
   APICallResponseData,
-  createAPICallErrorData,
-  RequestLifecycleEmitter,
 } from '../observability/index.ts'
 import {
   DEFAULT_TRANSIENT_RETRY_OPTIONS,
   isSessionExpired,
   isTransientServerError,
   RateLimitError,
-  RateLimitGate,
-  RetryGuard,
   withRetryBackoff,
 } from '../resilience/index.ts'
 import type {
   HomeAPIConfig,
   HomeAPI as HomeAPIContract,
-  Logger,
-  OnSyncFunction,
-  SettingManager,
 } from './interfaces.ts'
-import { SyncManager } from './sync-manager.ts'
+import { BaseAPI } from './base.ts'
+import {
+  type TokenResponse,
+  performTokenAuth,
+  refreshAccessToken,
+} from './token-auth.ts'
 
-const COGNITO_AUTHORITY =
-  'https://live-melcloudhome.auth.eu-west-1.amazoncognito.com'
+/* ------------------------------------------------------------------ */
+/*  Constants                                                         */
+/* ------------------------------------------------------------------ */
 
-const API_BASE_URL = 'https://melcloudhome.com'
-const ATA_UNIT_PATH = '/api/ataunit'
-const CONTEXT_PATH = '/api/user/context'
+const API_BASE_URL = 'https://mobile.bff.melcloudhome.com'
+const ATA_UNIT_PATH = '/monitor/ataunit'
+const CONTEXT_PATH = '/context'
 const DEFAULT_RATE_LIMIT_FALLBACK_HOURS = 2
 const DEFAULT_TIMEOUT_MS = 30_000
-const ENERGY_PATH = '/api/telemetry/energy'
-const LOGIN_PATH = '/bff/login'
+const ENERGY_PATH = '/monitor/telemetry/energy'
 const MILLISECONDS_IN_SECOND = 1000
-const REPORT_PATH = '/api/v1/report/trendsummary'
+const REPORT_PATH = '/report/trendsummary'
 const RETRY_DELAY = 1000
-const SIGNAL_PATH = '/api/telemetry/actual'
-const MAX_REDIRECTS = 20
-const USER_PATH = '/bff/user'
+const SIGNAL_PATH = '/monitor/telemetry/actual'
 
-const HTTP_REDIRECT_MIN = 300
-const HTTP_REDIRECT_MAX = 400
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                           */
+/* ------------------------------------------------------------------ */
 
-const isRedirect = (status: number): boolean =>
-  status >= HTTP_REDIRECT_MIN && status < HTTP_REDIRECT_MAX
-
-const extractFormAction = (html: string): string | null => {
-  const match = /<form[^>]+action="(?<action>[^"]+)"/iu.exec(html)
-  const encoded = match?.groups?.['action']
-  if (encoded === undefined) {
-    return null
-  }
-  const action = encoded.split('&amp;').join('&')
-  return action.startsWith('/') ? `${COGNITO_AUTHORITY}${action}` : action
-}
-
-const extractHiddenFields = (html: string): Record<string, string> =>
-  Object.fromEntries(
-    [...html.matchAll(/<input[^>]+type="hidden"[^>]*>/giu)].flatMap(([tag]) => {
-      const name = /name="(?<name>[^"]+)"/u.exec(tag)?.groups?.['name']
-      const value =
-        /value="(?<value>[^"]*)"/u.exec(tag)?.groups?.['value'] ?? ''
-      return name === undefined ? [] : [[name, value] as const]
-    }),
-  )
-
-const getClaimValue = (claims: HomeClaim[], type: string): string =>
-  claims.find((claim) => claim.type === type)?.value ?? ''
-
-const parseClaims = (claims: HomeClaim[]): HomeUser => ({
-  email: getClaimValue(claims, 'email'),
-  firstName: getClaimValue(claims, 'given_name'),
-  lastName: getClaimValue(claims, 'family_name'),
-  sub: getClaimValue(claims, 'sub'),
+const parseUser = (data: HomeContext): HomeUser => ({
+  email: data.email,
+  firstName: data.firstname,
+  lastName: data.lastname,
+  sub: data.id,
 })
 
-const resolveUrl = (location: string, base: string): string =>
-  location.startsWith('http') ? location : new URL(location, base).href
-
-/*
- * Auth-related endpoints that must bypass both proactive reauth
- * (#ensureSession) and reactive 401 retry (#shouldRetryAuth):
- *  - LOGIN_PATH and USER_PATH are the entry points of the OIDC flow
- *    themselves and what refreshes `expiry` — triggering reauth on
- *    them would recurse infinitely.
- *  - Absolute URLs belong to the cross-domain redirect chain and
- *    are only reachable from within `#performOidcLogin`.
- */
-const isAuthExempt = (url: string): boolean =>
-  url.startsWith('http') || url === LOGIN_PATH || url === USER_PATH
-
-const storeCookies = async (
-  jar: CookieJar,
-  { headers }: AxiosResponse,
-  url: string,
-): Promise<boolean> => {
-  const { 'set-cookie': setCookies } = headers as { 'set-cookie'?: string[] }
-  if (!Array.isArray(setCookies)) {
-    return false
-  }
-  let hasStored = false
-  await Promise.all(
-    setCookies.map(async (raw: string) => {
-      try {
-        await jar.setCookie(raw, url)
-        hasStored = true
-      } catch {
-        // Ignore invalid Set-Cookie values
-      }
-    }),
-  )
-  return hasStored
-}
-
 /**
- * MELCloud Home API client. Authenticates via headless OIDC login through
- * a double-federated flow: BFF → IdentityServer → AWS Cognito.
+ * MELCloud Home API client using the mobile BFF at
+ * `mobile.bff.melcloudhome.com` with Bearer-token authentication.
  *
- * Cookies are managed manually (not via axios-cookiejar-support) because the
- * cross-domain redirect chain requires Set-Cookie headers to be captured at
- * each intermediate 302 response.
+ * Authenticates via a headless OIDC flow:
+ *   PAR → IdentityServer → AWS Cognito → token exchange.
+ *
+ * Access and refresh tokens are persisted through the SettingManager
+ * (analogous to the Classic API's `contextKey`).
  *
  * Uses a private constructor — create instances via {@link HomeAPI.create}.
  */
-export class HomeAPI implements Disposable, HomeAPIContract {
-  public readonly logger: Logger
-
-  public readonly onSync?: OnSyncFunction
-
-  public readonly settingManager?: SettingManager
-
+export class HomeAPI extends BaseAPI implements HomeAPIContract {
   public get context(): HomeContext | null {
     return this.#context
   }
@@ -165,83 +91,45 @@ export class HomeAPI implements Disposable, HomeAPIContract {
     return this.#user
   }
 
-  readonly #abortSignal?: AbortSignal
-
-  readonly #api: AxiosInstance
-
-  readonly #baseURL: string
-
   #context: HomeContext | null = null
 
-  readonly #events: RequestLifecycleEmitter
-
-  readonly #jar: CookieJar
-
-  readonly #rateLimitGate = new RateLimitGate({
-    hours: DEFAULT_RATE_LIMIT_FALLBACK_HOURS,
-  })
-
   readonly #registry = new HomeRegistry()
-
-  readonly #retryGuard = new RetryGuard(RETRY_DELAY)
-
-  readonly #syncManager: SyncManager
 
   #user: HomeUser | null = null
 
   @setting
-  private accessor cookies = ''
+  private accessor accessToken = ''
 
   @setting
-  private accessor expiry = ''
-
-  @setting
-  private accessor password = ''
-
-  @setting
-  private accessor username = ''
+  private accessor refreshToken = ''
 
   // eslint-disable-next-line max-statements -- wiring a constructor, 1-to-1 config → instance field
   private constructor(config: HomeAPIConfig = {}) {
     const {
-      abortSignal,
-      autoSyncInterval = 1,
       baseURL = API_BASE_URL,
-      events,
-      logger = console,
-      onSync,
       password,
       requestTimeout = DEFAULT_TIMEOUT_MS,
-      settingManager,
       username,
+      autoSyncInterval = 1,
     } = config
-    this.#abortSignal = abortSignal
-    this.logger = logger
-    this.onSync = onSync
-    this.settingManager = settingManager
-    this.#events = new RequestLifecycleEmitter(events, logger)
-    this.#jar = this.#loadJar()
-    this.#applyCredentials(username, password)
-    this.#baseURL = baseURL
-    this.#api = axios.create({
-      baseURL,
-      headers: { 'x-csrf': '1' },
-      timeout: requestTimeout,
-    })
-    this.#syncManager = new SyncManager(
+    super(
+      { ...config, autoSyncInterval },
+      { baseURL, timeout: requestTimeout },
       async () => this.list(),
-      logger,
-      autoSyncInterval,
+      DEFAULT_RATE_LIMIT_FALLBACK_HOURS,
+      RETRY_DELAY,
     )
+    this.applyCredentials(username, password)
   }
 
   /**
    * Create and initialize a MELCloud Home API instance.
    *
-   * If the SettingManager holds a persisted session (cookies + unexpired
-   * expiry), the instance reuses it via `getUser()` and skips the OIDC
-   * re-login entirely. Otherwise, or if the persisted session is rejected
-   * by the server, falls back to a full `authenticate()` flow.
+   * If the SettingManager holds a persisted session (tokens + unexpired
+   * expiry), the instance reuses it via `getUser()` and skips re-login.
+   * If the access token is expired but a refresh token is available,
+   * a token refresh is attempted. Otherwise, falls back to a full
+   * `authenticate()` flow.
    * @param config - Optional configuration.
    * @returns The initialized HomeAPI instance.
    */
@@ -251,12 +139,6 @@ export class HomeAPI implements Disposable, HomeAPIContract {
       if ((await api.getUser()) !== null) {
         return api
       }
-      /*
-       * Persisted session was rejected (401, network error, stale cookies):
-       * wipe it before falling back to a full OIDC login so a subsequent
-       * authenticate() short-circuit (missing credentials) doesn't leave
-       * the dead session in the SettingManager and loop forever on reboots.
-       */
       api.#clearPersistedSession()
     }
     await api.authenticate()
@@ -268,12 +150,17 @@ export class HomeAPI implements Disposable, HomeAPIContract {
     /* v8 ignore next -- @authenticate guarantees data is always provided */
     const { password, username } = data ?? { password: '', username: '' }
     this.#clearPersistedSession()
-    await this.#performOidcLogin({ password, username })
+    const tokens = await performTokenAuth(
+      { password, username },
+      this.abortSignal,
+    )
+    this.#storeTokens(tokens)
+    await this.#fetchContext()
     ;({ password: this.password, username: this.username } = {
       password,
       username,
     })
-    return (await this.getUser()) !== null
+    return this.#user !== null
   }
 
   public async getEnergy(
@@ -315,23 +202,14 @@ export class HomeAPI implements Disposable, HomeAPIContract {
   }
 
   /**
-   * Fetch the current user's claims from the BFF.
+   * Validate the current session by fetching the user context.
    * Returns `null` if the request fails (401, network error, etc.)
    * and clears the stored user state.
    * @returns The user or `null`.
    */
   public async getUser(): Promise<HomeUser | null> {
     try {
-      const { data } = await this.#request<HomeClaim[]>('get', USER_PATH, {
-        params: { slide: false },
-      })
-      this.#user = parseClaims(data)
-      const expiresIn = Number(getClaimValue(data, 'bff:session_expires_in'))
-      if (expiresIn > 0) {
-        this.expiry = new Date(
-          Date.now() + expiresIn * MILLISECONDS_IN_SECOND,
-        ).toISOString()
-      }
+      await this.#fetchContext()
       return this.#user
     } catch {
       this.#user = null
@@ -344,30 +222,15 @@ export class HomeAPI implements Disposable, HomeAPIContract {
   }
 
   /**
-   * Whether the upstream rate-limit gate is currently closed.
-   *
-   * A `true` value means the SDK recently observed a 429 Too Many
-   * Requests response and is intentionally failing subsequent requests
-   * fast to honor the upstream `Retry-After` window. Consumers can
-   * poll this to display a "throttled, please wait" indicator without
-   * catching {@link RateLimitError} through the full call stack.
-   * @returns `true` while the gate is holding a pause window.
-   */
-  public get isRateLimited(): boolean {
-    return this.#rateLimitGate.isPaused
-  }
-
-  /**
    * Fetch all buildings (owned + guest), sync the device registry,
    * and schedule the next auto-sync.
    * @returns All buildings or an empty array on failure.
    */
   @syncDevices()
   public async list(): Promise<HomeBuilding[]> {
-    this.#syncManager.clear()
+    this.clearSync()
     try {
-      const { data } = await this.#request<HomeContext>('get', CONTEXT_PATH)
-      this.#context = data
+      const data = await this.#fetchContext()
       const buildings = [...data.buildings, ...data.guestBuildings]
       this.#registry.sync(
         buildings.flatMap(({ airToAirUnits, airToWaterUnits }) => [
@@ -385,21 +248,8 @@ export class HomeAPI implements Disposable, HomeAPIContract {
     } catch {
       return []
     } finally {
-      this.#syncManager.planNext()
+      this.syncManager.planNext()
     }
-  }
-
-  public clearSync(): void {
-    this.#syncManager.clear()
-  }
-
-  public [Symbol.dispose](): void {
-    this.#syncManager[Symbol.dispose]()
-    this.#retryGuard[Symbol.dispose]()
-  }
-
-  public setSyncInterval(minutes: number | null): void {
-    this.#syncManager.setInterval(minutes)
   }
 
   public async setValues(id: string, values: HomeAtaValues): Promise<boolean> {
@@ -412,114 +262,76 @@ export class HomeAPI implements Disposable, HomeAPIContract {
     }
   }
 
-  #applyCredentials(username?: string, password?: string): void {
-    if (username !== undefined) {
-      this.username = username
-    }
-    if (password !== undefined) {
-      this.password = password
-    }
-  }
+  /* ---------------------------------------------------------------- */
+  /*  Private — credentials & session                                 */
+  /* ---------------------------------------------------------------- */
 
   #clearPersistedSession(): void {
     this.#user = null
+    this.accessToken = ''
+    this.refreshToken = ''
     this.expiry = ''
-    this.cookies = ''
-    this.#jar.removeAllCookiesSync()
-  }
-
-  async #performOidcLogin(credentials: LoginCredentials): Promise<void> {
-    const { data: html } = await this.#followRedirects<string>(LOGIN_PATH)
-    const action = extractFormAction(html)
-    if (action === null) {
-      throw new Error('Could not find login form action')
-    }
-    const callbackUrl = await this.#submitCredentials(action, html, credentials)
-    await this.#followRedirects(callbackUrl)
-  }
-
-  /*
-   * Follow redirects manually, capturing Set-Cookie at each step.
-   * This is required because cross-domain redirect chains drop cookies
-   * when using automatic redirect following.
-   */
-  async #followRedirects<T = unknown>(
-    url: string,
-    remaining = MAX_REDIRECTS,
-  ): Promise<AxiosResponse<T>> {
-    if (remaining <= 0) {
-      throw new Error(`Too many redirects (max ${String(MAX_REDIRECTS)})`)
-    }
-    const response = await this.#get<T>(url)
-    if (!isRedirect(response.status)) {
-      return response
-    }
-    const location = String(response.headers['location'] ?? '')
-    return location === '' ? response : (
-        this.#followRedirects<T>(resolveUrl(location, url), remaining - 1)
-      )
-  }
-
-  async #get<T = unknown>(url: string): Promise<AxiosResponse<T>> {
-    return this.#request<T>('get', url, {
-      maxRedirects: 0,
-      /* v8 ignore next -- callback executed inside axios, not traceable */
-      validateStatus: () => true,
-    })
   }
 
   #hasPersistedSession(): boolean {
     return (
-      this.cookies !== '' &&
-      this.expiry !== '' &&
-      !isSessionExpired(this.expiry)
+      (this.accessToken !== '' &&
+        this.expiry !== '' &&
+        !isSessionExpired(this.expiry)) ||
+      this.refreshToken !== ''
     )
   }
 
-  #loadJar(): CookieJar {
-    if (!this.cookies) {
-      return new CookieJar()
-    }
-    try {
-      return CookieJar.deserializeSync(this.cookies)
-    } catch {
-      /*
-       * Self-heal: drop the corrupted value so we don't retry parsing it on
-       * every subsequent boot. The jar is currently being constructed, so
-       * clearing via the @setting accessors (not #clearPersistedSession())
-       * is required — we must not touch this.#jar from here.
-       */
-      this.cookies = ''
-      this.expiry = ''
-      return new CookieJar()
-    }
+  #syncContext(data: HomeContext): void {
+    this.#context = data
+    this.#user = parseUser(data)
   }
 
-  #logError(error: unknown): void {
-    if (axios.isAxiosError(error)) {
-      this.logger.error(String(createAPICallErrorData(error)))
+  /**
+   * Fetch the user context from the BFF and update local state.
+   * Shared by `getUser()` and `list()`.
+   */
+  async #fetchContext(): Promise<HomeContext> {
+    const { data } = await this.#request<HomeContext>('get', CONTEXT_PATH)
+    this.#syncContext(data)
+    return data
+  }
+
+  /* ---------------------------------------------------------------- */
+  /*  Private — token management                                      */
+  /* ---------------------------------------------------------------- */
+
+  #storeTokens(data: TokenResponse): void {
+    this.accessToken = data.access_token
+    if (data.refresh_token) {
+      this.refreshToken = data.refresh_token
     }
+    this.expiry = new Date(
+      Date.now() + data.expires_in * MILLISECONDS_IN_SECOND,
+    ).toISOString()
   }
 
-  async #onResponse(response: AxiosResponse, url: string): Promise<void> {
-    if (await storeCookies(this.#jar, response, url)) {
-      this.#persistJar()
+  /** Use the refresh token to obtain a fresh access token. */
+  async #refreshAccessToken(): Promise<boolean> {
+    const tokens = await refreshAccessToken(
+      this.refreshToken,
+      this.abortSignal,
+    )
+    if (tokens === null) {
+      return false
     }
-    this.logger.log(String(new APICallResponseData(response)))
+    this.#storeTokens(tokens)
+    return true
   }
 
-  #persistJar(): void {
-    const serialized = this.#jar.serializeSync()
-    /* v8 ignore next -- default MemoryCookieStore always returns a value */
-    this.cookies = serialized ? JSON.stringify(serialized) : ''
-  }
+  /* ---------------------------------------------------------------- */
+  /*  Private — API request pipeline                                  */
+  /* ---------------------------------------------------------------- */
 
-  /*
-   * Send a single request through the shared axios instance, injecting any
-   * cookies applicable to the target URL and passing the response through
-   * `#onResponse()` for cookie capture and logging. Each request is logged
-   * symmetrically with `#onResponse` so a full request → response trace
-   * is available in the logger output, matching Classic's interceptor pattern.
+  /**
+   * Send a request through the API axios instance, injecting the
+   * Bearer token. Symmetric logging mirrors the Classic API's
+   * interceptor pattern.
    */
   async #dispatch<T = unknown>(
     method: string,
@@ -532,39 +344,36 @@ export class HomeAPI implements Disposable, HomeAPIContract {
       headers?: Record<string, string>
     },
   ): Promise<AxiosResponse<T>> {
-    const absoluteUrl = url.startsWith('http') ? url : `${this.#baseURL}${url}`
-    const cookieHeader = await this.#jar.getCookieString(absoluteUrl)
     const requestConfig = {
       ...config,
       headers: {
         ...configHeaders,
-        ...(cookieHeader === '' ? {} : { Cookie: cookieHeader }),
+        ...(this.accessToken === ''
+          ? {}
+          : { Authorization: `Bearer ${this.accessToken}` }),
       },
       method,
-      /*
-       * Wire the consumer-provided AbortSignal (if any) into every
-       * outgoing request. Axios honors `config.signal` natively and
-       * aborts in-flight requests with `ERR_CANCELED` when it fires.
-       */
-      ...(this.#abortSignal === undefined ? {} : { signal: this.#abortSignal }),
+      ...(this.abortSignal === undefined ? {} : { signal: this.abortSignal }),
       url,
     }
     this.logger.log(String(new APICallRequestData(requestConfig)))
-    const response = await this.#api.request<T>(requestConfig)
-    await this.#onResponse(response, absoluteUrl)
+    const response = await this.api.request<T>(requestConfig)
+    this.logger.log(String(new APICallResponseData(response)))
     return response
   }
 
-  /*
-   * Re-authenticate if the session is expired or the persisted expiry
-   * value is malformed. Skips auth-exempt URLs (OIDC chain, LOGIN_PATH,
-   * USER_PATH) to avoid infinite re-auth loops, analogous to the Classic
-   * API skipping LOGIN_PATH in its request interceptor.
+  /**
+   * Proactive session check: refresh the access token if expired,
+   * falling back to a full re-authentication when refresh fails.
    */
-  async #ensureSession(url: string): Promise<void> {
-    if (!isAuthExempt(url) && isSessionExpired(this.expiry)) {
-      await this.authenticate()
+  async #ensureSession(): Promise<void> {
+    if (!isSessionExpired(this.expiry)) {
+      return
     }
+    if (this.refreshToken !== '' && (await this.#refreshAccessToken())) {
+      return
+    }
+    await this.authenticate()
   }
 
   #makeRequestAttempt<T>(
@@ -576,9 +385,16 @@ export class HomeAPI implements Disposable, HomeAPIContract {
       try {
         return await this.#dispatch<T>(method, url, config)
       } catch (error) {
-        this.#logError(error)
+        this.logError(error)
         this.#recordRateLimitIfApplicable(error)
-        if (this.#shouldRetryAuth(error, url)) {
+        if (this.#shouldRetryAuth(error)) {
+          // Try token refresh first, then full re-auth
+          if (
+            this.refreshToken !== '' &&
+            (await this.#refreshAccessToken())
+          ) {
+            return this.#dispatch<T>(method, url, config)
+          }
           this.#clearPersistedSession()
           if (await this.authenticate()) {
             return this.#dispatch<T>(method, url, config)
@@ -596,7 +412,7 @@ export class HomeAPI implements Disposable, HomeAPIContract {
     if (error.response?.status !== HttpStatusCode.TooManyRequests) {
       return
     }
-    this.#rateLimitGate.recordAndLog(
+    this.rateLimitGate.recordAndLog(
       this.logger,
       (error.response.headers as Record<string, unknown>)['retry-after'],
     )
@@ -610,21 +426,14 @@ export class HomeAPI implements Disposable, HomeAPIContract {
       headers?: Record<string, string>
     } = {},
   ): Promise<AxiosResponse<T>> {
-    await this.#ensureSession(url)
-    this.#throwIfRateLimited(url)
+    await this.#ensureSession()
+    this.#throwIfRateLimited()
     const context = {
       correlationId: randomUUID(),
       method: method.toUpperCase(),
       url,
     }
     const attempt = this.#makeRequestAttempt<T>(method, url, config)
-    /*
-     * 5xx retry with exponential backoff, applied only to idempotent
-     * GET requests. POST is intentionally excluded: replaying a failed
-     * credential submit or state mutation is not safe. OIDC GET steps
-     * (cross-domain, LOGIN_PATH, USER_PATH) ARE retried — the original
-     * user-reported outage was a 503 on /bff/login.
-     */
     const runner =
       method.toUpperCase() === 'GET' ?
         async (): Promise<AxiosResponse<T>> =>
@@ -635,7 +444,7 @@ export class HomeAPI implements Disposable, HomeAPIContract {
               this.logger.log(
                 `Transient server error on ${url}: retry ${String(retryAttempt)} in ${String(delayMs)} ms`,
               )
-              this.#events.emitRetry({
+              this.events.emitRetry({
                 ...context,
                 attempt: retryAttempt,
                 delayMs,
@@ -652,17 +461,17 @@ export class HomeAPI implements Disposable, HomeAPIContract {
     runner: () => Promise<AxiosResponse<T>>,
   ): Promise<AxiosResponse<T>> {
     const startedAt = Date.now()
-    this.#events.emitStart(context)
+    this.events.emitStart(context)
     try {
       const response = await runner()
-      this.#events.emitComplete({
+      this.events.emitComplete({
         ...context,
         durationMs: Date.now() - startedAt,
         status: response.status,
       })
       return response
     } catch (error) {
-      this.#events.emitError({
+      this.events.emitError({
         ...context,
         durationMs: Date.now() - startedAt,
         error,
@@ -683,45 +492,23 @@ export class HomeAPI implements Disposable, HomeAPIContract {
     }
   }
 
-  #shouldRetryAuth(error: unknown, url: string): boolean {
+  #shouldRetryAuth(error: unknown): boolean {
     if (!axios.isAxiosError(error)) {
       return false
     }
     if (error.response?.status !== HttpStatusCode.Unauthorized) {
       return false
     }
-    if (isAuthExempt(url)) {
-      return false
-    }
-    return this.#retryGuard.tryConsume()
+    return this.retryGuard.tryConsume()
   }
 
-  async #submitCredentials(
-    action: string,
-    html: string,
-    { password, username }: LoginCredentials,
-  ): Promise<string> {
-    const response = await this.#request('post', action, {
-      data: new URLSearchParams({
-        ...extractHiddenFields(html),
-        password,
-        username,
-      }).toString(),
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      maxRedirects: 0,
-      validateStatus: isRedirect,
-    })
-    const location = String(response.headers['location'] ?? '')
-    return location === '' ? '' : resolveUrl(location, action)
-  }
-
-  #throwIfRateLimited(url: string): void {
-    if (isAuthExempt(url) || !this.#rateLimitGate.isPaused) {
+  #throwIfRateLimited(): void {
+    if (!this.rateLimitGate.isPaused) {
       return
     }
     throw new RateLimitError(
-      `API requests are on hold for ${this.#rateLimitGate.formatRemaining()} (upstream rate-limited)`,
-      { retryAfter: this.#rateLimitGate.remaining },
+      `API requests are on hold for ${this.rateLimitGate.formatRemaining()} (upstream rate-limited)`,
+      { retryAfter: this.rateLimitGate.remaining },
     )
   }
 }

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -1,9 +1,6 @@
 import { randomUUID } from 'node:crypto'
 
-import axios, {
-  type AxiosResponse,
-  HttpStatusCode,
-} from 'axios'
+import axios, { type AxiosResponse, HttpStatusCode } from 'axios'
 
 import type {
   HomeAtaValues,
@@ -29,10 +26,7 @@ import {
   RateLimitError,
   withRetryBackoff,
 } from '../resilience/index.ts'
-import type {
-  HomeAPIConfig,
-  HomeAPI as HomeAPIContract,
-} from './interfaces.ts'
+import type { HomeAPIConfig, HomeAPI as HomeAPIContract } from './interfaces.ts'
 import { BaseAPI } from './base.ts'
 import {
   type TokenResponse,
@@ -111,12 +105,15 @@ export class HomeAPI extends BaseAPI implements HomeAPIContract {
       requestTimeout = DEFAULT_TIMEOUT_MS,
       username,
     } = config
-    super({ ...config, autoSyncInterval }, {
-      axiosConfig: { baseURL, timeout: requestTimeout },
-      rateLimitHours: DEFAULT_RATE_LIMIT_FALLBACK_HOURS,
-      retryDelay: RETRY_DELAY,
-      syncCallback: async () => this.list(),
-    })
+    super(
+      { ...config, autoSyncInterval },
+      {
+        axiosConfig: { baseURL, timeout: requestTimeout },
+        rateLimitHours: DEFAULT_RATE_LIMIT_FALLBACK_HOURS,
+        retryDelay: RETRY_DELAY,
+        syncCallback: async () => this.list(),
+      },
+    )
     this.applyCredentials(username, password)
   }
 
@@ -316,10 +313,7 @@ export class HomeAPI extends BaseAPI implements HomeAPIContract {
    * @returns Whether the refresh succeeded.
    */
   async #refreshAccessToken(): Promise<boolean> {
-    const tokens = await refreshAccessToken(
-      this.refreshToken,
-      this.abortSignal,
-    )
+    const tokens = await refreshAccessToken(this.refreshToken, this.abortSignal)
     if (tokens === null) {
       return false
     }
@@ -356,9 +350,9 @@ export class HomeAPI extends BaseAPI implements HomeAPIContract {
       ...config,
       headers: {
         ...configHeaders,
-        ...(this.accessToken === ''
-          ? {}
-          : { Authorization: `Bearer ${this.accessToken}` }),
+        ...(this.accessToken === '' ?
+          {}
+        : { Authorization: `Bearer ${this.accessToken}` }),
       },
       method,
       ...(this.abortSignal === undefined ? {} : { signal: this.abortSignal }),

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -103,22 +103,20 @@ export class HomeAPI extends BaseAPI implements HomeAPIContract {
   @setting
   private accessor refreshToken = ''
 
-  // eslint-disable-next-line max-statements -- wiring a constructor, 1-to-1 config → instance field
   private constructor(config: HomeAPIConfig = {}) {
     const {
+      autoSyncInterval = 1,
       baseURL = API_BASE_URL,
       password,
       requestTimeout = DEFAULT_TIMEOUT_MS,
       username,
-      autoSyncInterval = 1,
     } = config
-    super(
-      { ...config, autoSyncInterval },
-      { baseURL, timeout: requestTimeout },
-      async () => this.list(),
-      DEFAULT_RATE_LIMIT_FALLBACK_HOURS,
-      RETRY_DELAY,
-    )
+    super({ ...config, autoSyncInterval }, {
+      axiosConfig: { baseURL, timeout: requestTimeout },
+      rateLimitHours: DEFAULT_RATE_LIMIT_FALLBACK_HOURS,
+      retryDelay: RETRY_DELAY,
+      syncCallback: async () => this.list(),
+    })
     this.applyCredentials(username, password)
   }
 
@@ -290,6 +288,7 @@ export class HomeAPI extends BaseAPI implements HomeAPIContract {
   /**
    * Fetch the user context from the BFF and update local state.
    * Shared by `getUser()` and `list()`.
+   * @returns The fetched home context.
    */
   async #fetchContext(): Promise<HomeContext> {
     const { data } = await this.#request<HomeContext>('get', CONTEXT_PATH)
@@ -302,16 +301,20 @@ export class HomeAPI extends BaseAPI implements HomeAPIContract {
   /* ---------------------------------------------------------------- */
 
   #storeTokens(data: TokenResponse): void {
-    this.accessToken = data.access_token
-    if (data.refresh_token) {
-      this.refreshToken = data.refresh_token
+    const { access_token, expires_in, refresh_token } = data
+    this.accessToken = access_token
+    if (refresh_token !== undefined && refresh_token !== '') {
+      this.refreshToken = refresh_token
     }
     this.expiry = new Date(
-      Date.now() + data.expires_in * MILLISECONDS_IN_SECOND,
+      Date.now() + expires_in * MILLISECONDS_IN_SECOND,
     ).toISOString()
   }
 
-  /** Use the refresh token to obtain a fresh access token. */
+  /**
+   * Use the refresh token to obtain a fresh access token.
+   * @returns Whether the refresh succeeded.
+   */
   async #refreshAccessToken(): Promise<boolean> {
     const tokens = await refreshAccessToken(
       this.refreshToken,
@@ -332,6 +335,11 @@ export class HomeAPI extends BaseAPI implements HomeAPIContract {
    * Send a request through the API axios instance, injecting the
    * Bearer token. Symmetric logging mirrors the Classic API's
    * interceptor pattern.
+   * @param method - HTTP method (GET, POST, etc.).
+   * @param url - Request URL path.
+   * @param root0 - Request configuration.
+   * @param root0.headers - Optional extra headers.
+   * @returns The Axios response.
    */
   async #dispatch<T = unknown>(
     method: string,
@@ -388,16 +396,9 @@ export class HomeAPI extends BaseAPI implements HomeAPIContract {
         this.logError(error)
         this.#recordRateLimitIfApplicable(error)
         if (this.#shouldRetryAuth(error)) {
-          // Try token refresh first, then full re-auth
-          if (
-            this.refreshToken !== '' &&
-            (await this.#refreshAccessToken())
-          ) {
-            return this.#dispatch<T>(method, url, config)
-          }
-          this.#clearPersistedSession()
-          if (await this.authenticate()) {
-            return this.#dispatch<T>(method, url, config)
+          const retried = await this.#retryWithReauth<T>(method, url, config)
+          if (retried !== null) {
+            return retried
           }
         }
         throw error
@@ -454,6 +455,21 @@ export class HomeAPI extends BaseAPI implements HomeAPIContract {
           })
       : attempt
     return this.#runWithEvents(context, runner)
+  }
+
+  async #retryWithReauth<T>(
+    method: string,
+    url: string,
+    config: { [key: string]: unknown; headers?: Record<string, string> },
+  ): Promise<AxiosResponse<T> | null> {
+    if (this.refreshToken !== '' && (await this.#refreshAccessToken())) {
+      return this.#dispatch<T>(method, url, config)
+    }
+    this.#clearPersistedSession()
+    if (await this.authenticate()) {
+      return this.#dispatch<T>(method, url, config)
+    }
+    return null
   }
 
   async #runWithEvents<T>(

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -19,5 +19,6 @@ export type {
   SettingManager,
 } from './interfaces.ts'
 
+export { BaseAPI } from './base.ts'
 export { ClassicAPI } from './classic.ts'
 export { HomeAPI } from './home.ts'

--- a/src/api/interfaces.ts
+++ b/src/api/interfaces.ts
@@ -184,14 +184,17 @@ export interface ClassicAPISettings {
 
 /** Persistent settings managed by the Home API for session authentication. */
 export interface HomeAPISettings {
-  /** Serialized tough-cookie CookieJar (JSON). */
-  readonly cookies?: string | null
+  /** IdentityServer access token (Bearer). */
+  readonly accessToken?: string | null
 
   /** Session expiry timestamp in ISO 8601 format. */
   readonly expiry?: string | null
 
   /** MELCloud Home account password. */
   readonly password?: string | null
+
+  /** IdentityServer refresh token. */
+  readonly refreshToken?: string | null
 
   /** MELCloud Home account username (email). */
   readonly username?: string | null

--- a/src/api/token-auth.ts
+++ b/src/api/token-auth.ts
@@ -1,0 +1,302 @@
+import { createHash, randomBytes } from 'node:crypto'
+
+import { CookieJar } from 'tough-cookie'
+import axios, { type AxiosResponse } from 'axios'
+
+/* ------------------------------------------------------------------ */
+/*  Constants                                                         */
+/* ------------------------------------------------------------------ */
+
+export const CLIENT_ID = 'homemobile'
+export const REDIRECT_URI = 'melcloudhome://'
+export const SCOPES = 'openid profile email offline_access IdentityServerApi'
+export const AUTH_BASIC = 'Basic aG9tZW1vYmlsZTo='
+export const AUTH_BASE_URL = 'https://auth.melcloudhome.com'
+export const COGNITO_AUTHORITY =
+  'https://live-melcloudhome.auth.eu-west-1.amazoncognito.com'
+export const PAR_PATH = '/connect/par'
+export const TOKEN_PATH = '/connect/token'
+
+const MAX_REDIRECTS = 20
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                             */
+/* ------------------------------------------------------------------ */
+
+export interface TokenResponse {
+  access_token: string
+  expires_in: number
+  id_token?: string
+  refresh_token?: string
+  scope: string
+  token_type: string
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                           */
+/* ------------------------------------------------------------------ */
+
+export const extractFormAction = (html: string): string | null => {
+  const match = /<form[^>]+action="(?<action>[^"]+)"/iu.exec(html)
+  const encoded = match?.groups?.['action']
+  if (encoded === undefined) {
+    return null
+  }
+  const action = encoded.split('&amp;').join('&')
+  return action.startsWith('/') ? `${COGNITO_AUTHORITY}${action}` : action
+}
+
+export const extractHiddenFields = (html: string): Record<string, string> =>
+  Object.fromEntries(
+    [...html.matchAll(/<input[^>]+type="hidden"[^>]*>/giu)].flatMap(([tag]) => {
+      const name = /name="(?<name>[^"]+)"/u.exec(tag)?.groups?.['name']
+      const value =
+        /value="(?<value>[^"]*)"/u.exec(tag)?.groups?.['value'] ?? ''
+      return name === undefined ? [] : [[name, value] as const]
+    }),
+  )
+
+export const generatePKCE = (): { challenge: string; verifier: string } => {
+  const verifier = randomBytes(32).toString('base64url')
+  const challenge = createHash('sha256').update(verifier).digest('base64url')
+  return { challenge, verifier }
+}
+
+export const resolveUrl = (location: string, base: string): string =>
+  location.startsWith('http') ? location : new URL(location, base).href
+
+export const storeCookies = async (
+  jar: CookieJar,
+  { headers }: AxiosResponse,
+  url: string,
+): Promise<void> => {
+  const { 'set-cookie': setCookies } = headers as { 'set-cookie'?: string[] }
+  if (!Array.isArray(setCookies)) {
+    return
+  }
+  await Promise.all(
+    setCookies.map(async (raw: string) => {
+      try {
+        await jar.setCookie(raw, url)
+      } catch {
+        // Ignore invalid Set-Cookie values
+      }
+    }),
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/*  Auth flow functions                                               */
+/* ------------------------------------------------------------------ */
+
+/** Push Authorization Request -> returns the opaque `request_uri`. */
+export const par = async (
+  challenge: string,
+  abortSignal?: AbortSignal,
+): Promise<string> => {
+  const { data } = await axios.post<{ request_uri: string }>(
+    `${AUTH_BASE_URL}${PAR_PATH}`,
+    new URLSearchParams({
+      client_id: CLIENT_ID,
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+      redirect_uri: REDIRECT_URI,
+      response_type: 'code',
+      scope: SCOPES,
+      state: randomBytes(16).toString('base64url'),
+    }).toString(),
+    {
+      headers: {
+        Authorization: AUTH_BASIC,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      ...(abortSignal === undefined ? {} : { signal: abortSignal }),
+    },
+  )
+  return data.request_uri
+}
+
+/**
+ * Low-level request for the OIDC auth flow. Uses a transient
+ * CookieJar (not the API instance) since the multi-domain redirect
+ * chain (IS <-> Cognito) requires cross-domain cookie management.
+ */
+export const authRequest = async <T = unknown>(
+  method: string,
+  url: string,
+  config: {
+    [key: string]: unknown
+    headers?: Record<string, string>
+  },
+  jar: CookieJar,
+  abortSignal?: AbortSignal,
+): Promise<AxiosResponse<T>> => {
+  const cookieHeader = await jar.getCookieString(url)
+  const { headers: configHeaders, ...rest } = config
+  const response = await axios.request<T>({
+    ...rest,
+    headers: {
+      ...configHeaders,
+      ...(cookieHeader === '' ? {} : { Cookie: cookieHeader }),
+    },
+    maxRedirects: 0,
+    method,
+    url,
+    validateStatus: () => true,
+    ...(abortSignal === undefined ? {} : { signal: abortSignal }),
+  })
+  await storeCookies(jar, response, url)
+  return response
+}
+
+/**
+ * Follow HTTP 302 redirects and IS JavaScript redirects until a
+ * non-redirect page is reached or the URL matches the app's custom
+ * scheme (`melcloudhome://`).
+ */
+export const authFollowRedirects = async (
+  url: string,
+  jar: CookieJar,
+  abortSignal?: AbortSignal,
+  remaining = MAX_REDIRECTS,
+): Promise<{ data: string; url: string }> => {
+  if (remaining <= 0) {
+    throw new Error(`Too many redirects (max ${String(MAX_REDIRECTS)})`)
+  }
+  if (url.startsWith(REDIRECT_URI)) {
+    return { data: '', url }
+  }
+  const response = await authRequest<string>('get', url, {}, jar, abortSignal)
+  if (response.status >= 300 && response.status < 400) {
+    const location = String(response.headers['location'] ?? '')
+    return authFollowRedirects(
+      resolveUrl(location, url),
+      jar,
+      abortSignal,
+      remaining - 1,
+    )
+  }
+  // IS Redirect page: 200 with JavaScript redirect
+  const jsMatch = /window\.location\s*=\s*['"]([^'"]+)/u.exec(
+    String(response.data),
+  )
+  if (jsMatch) {
+    const redirectUrl = (jsMatch[1] as string).split('&amp;').join('&')
+    return authFollowRedirects(
+      resolveUrl(redirectUrl, url),
+      jar,
+      abortSignal,
+      remaining - 1,
+    )
+  }
+  return { data: String(response.data), url }
+}
+
+/** POST to the IdentityServer token endpoint. */
+export const tokenRequest = async (
+  params: Record<string, string>,
+  abortSignal?: AbortSignal,
+): Promise<TokenResponse> => {
+  const { data } = await axios.post<TokenResponse>(
+    `${AUTH_BASE_URL}${TOKEN_PATH}`,
+    new URLSearchParams(params).toString(),
+    {
+      headers: {
+        Authorization: AUTH_BASIC,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      ...(abortSignal === undefined ? {} : { signal: abortSignal }),
+    },
+  )
+  return data
+}
+
+/**
+ * Full headless OIDC login: PAR -> Cognito -> token exchange.
+ * Returns the token response on success.
+ */
+export const performTokenAuth = async (
+  credentials: { password: string; username: string },
+  abortSignal?: AbortSignal,
+): Promise<TokenResponse> => {
+  const { challenge, verifier } = generatePKCE()
+  const jar = new CookieJar()
+
+  // 1. Pushed Authorization Request
+  const requestUri = await par(challenge, abortSignal)
+
+  // 2. Follow authorize -> IS login -> Cognito login page
+  const { data: html } = await authFollowRedirects(
+    `${AUTH_BASE_URL}/connect/authorize?client_id=${CLIENT_ID}&request_uri=${encodeURIComponent(requestUri)}`,
+    jar,
+    abortSignal,
+  )
+  const action = extractFormAction(html)
+  if (action === null) {
+    throw new Error('Could not find login form action')
+  }
+
+  // 3. Submit credentials to Cognito
+  const submitResponse = await authRequest(
+    'post',
+    action,
+    {
+      data: new URLSearchParams({
+        ...extractHiddenFields(html),
+        cognitoAsfData: '',
+        password: credentials.password,
+        username: credentials.username,
+      }).toString(),
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    },
+    jar,
+    abortSignal,
+  )
+
+  const callbackLocation = String(submitResponse.headers['location'] ?? '')
+  if (callbackLocation === '') {
+    throw new Error('No redirect after credential submission')
+  }
+
+  // 4. Follow IS callback chain -> melcloudhome:// with code
+  const { url: callbackUrl } = await authFollowRedirects(
+    resolveUrl(callbackLocation, action),
+    jar,
+    abortSignal,
+  )
+  const code = new URL(callbackUrl).searchParams.get('code')
+  if (code === null) {
+    throw new Error('No authorization code in callback')
+  }
+
+  // 5. Exchange code for tokens
+  return tokenRequest(
+    {
+      client_id: CLIENT_ID,
+      code,
+      code_verifier: verifier,
+      grant_type: 'authorization_code',
+      redirect_uri: REDIRECT_URI,
+    },
+    abortSignal,
+  )
+}
+
+/** Use the refresh token to obtain a fresh access token. Returns null on failure. */
+export const refreshAccessToken = async (
+  refreshToken: string,
+  abortSignal?: AbortSignal,
+): Promise<TokenResponse | null> => {
+  try {
+    return await tokenRequest(
+      {
+        client_id: CLIENT_ID,
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+      },
+      abortSignal,
+    )
+  } catch {
+    return null
+  }
+}

--- a/src/api/token-auth.ts
+++ b/src/api/token-auth.ts
@@ -18,6 +18,10 @@ export const PAR_PATH = '/connect/par'
 export const TOKEN_PATH = '/connect/token'
 
 const MAX_REDIRECTS = 20
+const PKCE_RANDOM_BYTES = 32
+const STATE_RANDOM_BYTES = 16
+const REDIRECT_STATUS_MIN = 300
+const REDIRECT_STATUS_MAX = 400
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                             */
@@ -26,16 +30,41 @@ const MAX_REDIRECTS = 20
 export interface TokenResponse {
   access_token: string
   expires_in: number
-  id_token?: string
-  refresh_token?: string
   scope: string
   token_type: string
+  id_token?: string
+  refresh_token?: string
+}
+
+/** Options for {@link authRequest}. */
+interface AuthRequestOptions {
+  config: {
+    [key: string]: unknown
+    headers?: Record<string, string>
+  }
+  jar: CookieJar
+  method: string
+  url: string
+  abortSignal?: AbortSignal
+}
+
+/** Options for {@link authFollowRedirects}. */
+interface FollowRedirectsOptions {
+  jar: CookieJar
+  url: string
+  abortSignal?: AbortSignal
+  remaining?: number
 }
 
 /* ------------------------------------------------------------------ */
 /*  Helpers                                                           */
 /* ------------------------------------------------------------------ */
 
+/**
+ * Extract the `action` attribute from the first `<form>` element in an HTML string.
+ * @param html - Raw HTML string from the login page.
+ * @returns The resolved form action URL, or `null` if not found.
+ */
 export const extractFormAction = (html: string): string | null => {
   const match = /<form[^>]+action="(?<action>[^"]+)"/iu.exec(html)
   const encoded = match?.groups?.['action']
@@ -46,6 +75,11 @@ export const extractFormAction = (html: string): string | null => {
   return action.startsWith('/') ? `${COGNITO_AUTHORITY}${action}` : action
 }
 
+/**
+ * Extract all hidden form fields from an HTML string.
+ * @param html - Raw HTML string containing hidden `<input>` fields.
+ * @returns A record of name-value pairs for each hidden field.
+ */
 export const extractHiddenFields = (html: string): Record<string, string> =>
   Object.fromEntries(
     [...html.matchAll(/<input[^>]+type="hidden"[^>]*>/giu)].flatMap(([tag]) => {
@@ -56,15 +90,32 @@ export const extractHiddenFields = (html: string): Record<string, string> =>
     }),
   )
 
+/**
+ * Generate a PKCE challenge and verifier pair.
+ * @returns An object containing the `challenge` and `verifier` strings.
+ */
 export const generatePKCE = (): { challenge: string; verifier: string } => {
-  const verifier = randomBytes(32).toString('base64url')
+  const verifier = randomBytes(PKCE_RANDOM_BYTES).toString('base64url')
   const challenge = createHash('sha256').update(verifier).digest('base64url')
   return { challenge, verifier }
 }
 
+/**
+ * Resolve a potentially relative URL against a base URL.
+ * @param location - The URL or relative path to resolve.
+ * @param base - The base URL for resolution.
+ * @returns The fully qualified URL.
+ */
 export const resolveUrl = (location: string, base: string): string =>
   location.startsWith('http') ? location : new URL(location, base).href
 
+/**
+ * Store any `Set-Cookie` headers from an Axios response into a CookieJar.
+ * @param jar - The cookie jar to populate.
+ * @param response - The Axios response containing potential Set-Cookie headers.
+ * @param response.headers - The response headers.
+ * @param url - The URL context for cookie storage.
+ */
 export const storeCookies = async (
   jar: CookieJar,
   { headers }: AxiosResponse,
@@ -89,7 +140,12 @@ export const storeCookies = async (
 /*  Auth flow functions                                               */
 /* ------------------------------------------------------------------ */
 
-/** Push Authorization Request -> returns the opaque `request_uri`. */
+/**
+ * Push Authorization Request -- returns the opaque `request_uri`.
+ * @param challenge - The PKCE code challenge.
+ * @param abortSignal - Optional signal to abort the request.
+ * @returns The opaque PAR request URI.
+ */
 export const par = async (
   challenge: string,
   abortSignal?: AbortSignal,
@@ -103,7 +159,7 @@ export const par = async (
       redirect_uri: REDIRECT_URI,
       response_type: 'code',
       scope: SCOPES,
-      state: randomBytes(16).toString('base64url'),
+      state: randomBytes(STATE_RANDOM_BYTES).toString('base64url'),
     }).toString(),
     {
       headers: {
@@ -119,18 +175,22 @@ export const par = async (
 /**
  * Low-level request for the OIDC auth flow. Uses a transient
  * CookieJar (not the API instance) since the multi-domain redirect
- * chain (IS <-> Cognito) requires cross-domain cookie management.
+ * chain (IS &lt;-&gt; Cognito) requires cross-domain cookie management.
+ * @param options - The auth request options.
+ * @param options.method - HTTP method.
+ * @param options.url - Target URL.
+ * @param options.config - Axios request config with optional headers.
+ * @param options.jar - CookieJar for cross-domain cookie management.
+ * @param options.abortSignal - Optional abort signal.
+ * @returns The Axios response.
  */
-export const authRequest = async <T = unknown>(
-  method: string,
-  url: string,
-  config: {
-    [key: string]: unknown
-    headers?: Record<string, string>
-  },
-  jar: CookieJar,
-  abortSignal?: AbortSignal,
-): Promise<AxiosResponse<T>> => {
+export const authRequest = async <T = unknown>({
+  abortSignal,
+  config,
+  jar,
+  method,
+  url,
+}: AuthRequestOptions): Promise<AxiosResponse<T>> => {
   const cookieHeader = await jar.getCookieString(url)
   const { headers: configHeaders, ...rest } = config
   const response = await axios.request<T>({
@@ -142,6 +202,7 @@ export const authRequest = async <T = unknown>(
     maxRedirects: 0,
     method,
     url,
+    /* v8 ignore next -- callback passed to axios; never invoked in unit tests where axios.request is mocked */
     validateStatus: () => true,
     ...(abortSignal === undefined ? {} : { signal: abortSignal }),
   })
@@ -150,49 +211,87 @@ export const authRequest = async <T = unknown>(
 }
 
 /**
+ * Extract a JavaScript-based redirect URL from an HTML response body.
+ * @param html - The HTML string to search for a JS redirect.
+ * @returns The redirect URL if found, or `null`.
+ */
+const extractJsRedirect = (html: string): string | null => {
+  const jsMatch = /window\.location\s*=\s*['"](?<url>[^'"]+)/u.exec(html)
+  if (jsMatch?.groups?.['url'] === undefined) {
+    return null
+  }
+  return jsMatch.groups['url'].split('&amp;').join('&')
+}
+
+/**
+ * Extract the redirect target from an HTTP or JS redirect response.
+ * @param response - The Axios response.
+ * @param currentUrl - The URL that produced this response.
+ * @returns The resolved redirect URL, or `null` if no redirect was detected.
+ */
+const extractRedirectTarget = (
+  response: AxiosResponse<string>,
+  currentUrl: string,
+): string | null => {
+  if (
+    response.status >= REDIRECT_STATUS_MIN &&
+    response.status < REDIRECT_STATUS_MAX
+  ) {
+    const location = String(response.headers['location'] ?? '')
+    return resolveUrl(location, currentUrl)
+  }
+  const jsRedirect = extractJsRedirect(response.data)
+  return jsRedirect === null ? null : resolveUrl(jsRedirect, currentUrl)
+}
+
+/**
  * Follow HTTP 302 redirects and IS JavaScript redirects until a
  * non-redirect page is reached or the URL matches the app's custom
  * scheme (`melcloudhome://`).
+ * @param options - The redirect-following options.
+ * @param options.url - Current URL to follow.
+ * @param options.jar - CookieJar for cross-domain cookie management.
+ * @param options.abortSignal - Optional abort signal.
+ * @param options.remaining - Number of remaining redirects allowed.
+ * @returns The final response data and URL.
  */
-export const authFollowRedirects = async (
-  url: string,
-  jar: CookieJar,
-  abortSignal?: AbortSignal,
+export const authFollowRedirects = async ({
+  abortSignal,
+  jar,
   remaining = MAX_REDIRECTS,
-): Promise<{ data: string; url: string }> => {
+  url,
+}: FollowRedirectsOptions): Promise<{ data: string; url: string }> => {
   if (remaining <= 0) {
     throw new Error(`Too many redirects (max ${String(MAX_REDIRECTS)})`)
   }
   if (url.startsWith(REDIRECT_URI)) {
     return { data: '', url }
   }
-  const response = await authRequest<string>('get', url, {}, jar, abortSignal)
-  if (response.status >= 300 && response.status < 400) {
-    const location = String(response.headers['location'] ?? '')
-    return authFollowRedirects(
-      resolveUrl(location, url),
+  const response = await authRequest<string>({
+    config: {},
+    jar,
+    method: 'get',
+    url,
+    ...(abortSignal === undefined ? {} : { abortSignal }),
+  })
+  const redirectTarget = extractRedirectTarget(response, url)
+  if (redirectTarget !== null) {
+    return authFollowRedirects({
       jar,
-      abortSignal,
-      remaining - 1,
-    )
+      remaining: remaining - 1,
+      url: redirectTarget,
+      ...(abortSignal === undefined ? {} : { abortSignal }),
+    })
   }
-  // IS Redirect page: 200 with JavaScript redirect
-  const jsMatch = /window\.location\s*=\s*['"]([^'"]+)/u.exec(
-    String(response.data),
-  )
-  if (jsMatch) {
-    const redirectUrl = (jsMatch[1] as string).split('&amp;').join('&')
-    return authFollowRedirects(
-      resolveUrl(redirectUrl, url),
-      jar,
-      abortSignal,
-      remaining - 1,
-    )
-  }
-  return { data: String(response.data), url }
+  return { data: response.data, url }
 }
 
-/** POST to the IdentityServer token endpoint. */
+/**
+ * POST to the IdentityServer token endpoint.
+ * @param params - URL-encoded form parameters for the token request.
+ * @param abortSignal - Optional signal to abort the request.
+ * @returns The token response.
+ */
 export const tokenRequest = async (
   params: Record<string, string>,
   abortSignal?: AbortSignal,
@@ -211,36 +310,40 @@ export const tokenRequest = async (
   return data
 }
 
+/** Options for {@link submitCredentials}. */
+interface SubmitCredentialsOptions {
+  authorizeUrl: string
+  credentials: { password: string; username: string }
+  jar: CookieJar
+  abortSignal?: AbortSignal
+}
+
 /**
- * Full headless OIDC login: PAR -> Cognito -> token exchange.
- * Returns the token response on success.
+ * Navigate to the Cognito login page and submit credentials.
+ * @param options - The credential submission options.
+ * @param options.authorizeUrl - The OIDC authorize URL to start from.
+ * @param options.credentials - The user's login credentials.
+ * @param options.jar - CookieJar for the auth flow.
+ * @param options.abortSignal - Optional abort signal.
+ * @returns The callback location URL after credential submission.
  */
-export const performTokenAuth = async (
-  credentials: { password: string; username: string },
-  abortSignal?: AbortSignal,
-): Promise<TokenResponse> => {
-  const { challenge, verifier } = generatePKCE()
-  const jar = new CookieJar()
-
-  // 1. Pushed Authorization Request
-  const requestUri = await par(challenge, abortSignal)
-
-  // 2. Follow authorize -> IS login -> Cognito login page
-  const { data: html } = await authFollowRedirects(
-    `${AUTH_BASE_URL}/connect/authorize?client_id=${CLIENT_ID}&request_uri=${encodeURIComponent(requestUri)}`,
+const submitCredentials = async ({
+  abortSignal,
+  authorizeUrl,
+  credentials,
+  jar,
+}: SubmitCredentialsOptions): Promise<string> => {
+  const { data: html } = await authFollowRedirects({
     jar,
-    abortSignal,
-  )
+    url: authorizeUrl,
+    ...(abortSignal === undefined ? {} : { abortSignal }),
+  })
   const action = extractFormAction(html)
   if (action === null) {
     throw new Error('Could not find login form action')
   }
-
-  // 3. Submit credentials to Cognito
-  const submitResponse = await authRequest(
-    'post',
-    action,
-    {
+  const submitResponse = await authRequest({
+    config: {
       data: new URLSearchParams({
         ...extractHiddenFields(html),
         cognitoAsfData: '',
@@ -250,26 +353,68 @@ export const performTokenAuth = async (
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     },
     jar,
-    abortSignal,
-  )
-
+    method: 'post',
+    url: action,
+    ...(abortSignal === undefined ? {} : { abortSignal }),
+  })
   const callbackLocation = String(submitResponse.headers['location'] ?? '')
   if (callbackLocation === '') {
     throw new Error('No redirect after credential submission')
   }
+  return resolveUrl(callbackLocation, action)
+}
 
-  // 4. Follow IS callback chain -> melcloudhome:// with code
-  const { url: callbackUrl } = await authFollowRedirects(
-    resolveUrl(callbackLocation, action),
+/**
+ * Follow the callback chain and extract the authorization code.
+ * @param callbackUrl - The callback URL to follow.
+ * @param jar - CookieJar for the auth flow.
+ * @param abortSignal - Optional abort signal.
+ * @returns The authorization code.
+ */
+const extractAuthorizationCode = async (
+  callbackUrl: string,
+  jar: CookieJar,
+  abortSignal?: AbortSignal,
+): Promise<string> => {
+  const { url: finalUrl } = await authFollowRedirects({
     jar,
-    abortSignal,
-  )
-  const code = new URL(callbackUrl).searchParams.get('code')
+    url: callbackUrl,
+    ...(abortSignal === undefined ? {} : { abortSignal }),
+  })
+  const code = new URL(finalUrl).searchParams.get('code')
   if (code === null) {
     throw new Error('No authorization code in callback')
   }
+  return code
+}
 
-  // 5. Exchange code for tokens
+/**
+ * Full headless OIDC login: PAR -> Cognito -> token exchange.
+ * Returns the token response on success.
+ * @param credentials - The user's login credentials.
+ * @param credentials.password - The user's password.
+ * @param credentials.username - The user's username.
+ * @param abortSignal - Optional signal to abort the auth flow.
+ * @returns The token response containing access and refresh tokens.
+ */
+export const performTokenAuth = async (
+  credentials: { password: string; username: string },
+  abortSignal?: AbortSignal,
+): Promise<TokenResponse> => {
+  const { challenge, verifier } = generatePKCE()
+  const jar = new CookieJar()
+
+  const requestUri = await par(challenge, abortSignal)
+  const authorizeUrl = `${AUTH_BASE_URL}/connect/authorize?client_id=${CLIENT_ID}&request_uri=${encodeURIComponent(requestUri)}`
+
+  const callbackUrl = await submitCredentials({
+    authorizeUrl,
+    credentials,
+    jar,
+    ...(abortSignal === undefined ? {} : { abortSignal }),
+  })
+  const code = await extractAuthorizationCode(callbackUrl, jar, abortSignal)
+
   return tokenRequest(
     {
       client_id: CLIENT_ID,
@@ -282,7 +427,12 @@ export const performTokenAuth = async (
   )
 }
 
-/** Use the refresh token to obtain a fresh access token. Returns null on failure. */
+/**
+ * Use the refresh token to obtain a fresh access token. Returns null on failure.
+ * @param refreshToken - The refresh token to exchange.
+ * @param abortSignal - Optional signal to abort the request.
+ * @returns The token response, or `null` if the refresh failed.
+ */
 export const refreshAccessToken = async (
   refreshToken: string,
   abortSignal?: AbortSignal,

--- a/src/types/home.ts
+++ b/src/types/home.ts
@@ -32,8 +32,13 @@ export interface HomeClaim {
 
 export interface HomeContext {
   readonly buildings: HomeBuilding[]
+  readonly country: string
+  readonly email: string
+  readonly firstname: string
   readonly guestBuildings: HomeBuilding[]
+  readonly id: string
   readonly language: string
+  readonly lastname: string
 }
 
 export interface HomeDeviceCapabilities {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -5,7 +5,11 @@ import type {
 } from 'axios'
 import { vi } from 'vitest'
 
-import type { ClassicAPIAdapter, Logger, SettingManager } from '../src/api/index.ts'
+import type {
+  ClassicAPIAdapter,
+  Logger,
+  SettingManager,
+} from '../src/api/index.ts'
 import type { DeviceType } from '../src/constants.ts'
 import type {
   AreaDataAny,

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -29,6 +29,8 @@ export const defined = <T>(value: T | null | undefined): T => {
   return value
 }
 
+const HTTP_OK = 200
+
 export function mock<T extends object>(value?: Partial<T>): T
 export function mock(value: unknown = {}): unknown {
   return value
@@ -141,7 +143,7 @@ export const createLogger = (): Logger => ({
 export const mockResponse = (
   data: unknown,
   headers: Record<string, string | string[]> = {},
-  status = 200,
+  status = HTTP_OK,
 ): {
   config: object
   data: unknown

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,6 +1,11 @@
+import type {
+  AxiosError,
+  AxiosResponse,
+  InternalAxiosRequestConfig,
+} from 'axios'
 import { vi } from 'vitest'
 
-import type { ClassicAPIAdapter, SettingManager } from '../src/api/index.ts'
+import type { ClassicAPIAdapter, Logger, SettingManager } from '../src/api/index.ts'
 import type { DeviceType } from '../src/constants.ts'
 import type {
   AreaDataAny,
@@ -127,3 +132,49 @@ export const createPopulatedRegistry = ({
   registry.syncDevices(devices)
   return registry
 }
+
+export const createLogger = (): Logger => ({
+  error: vi.fn<(...data: unknown[]) => void>(),
+  log: vi.fn<(...data: unknown[]) => void>(),
+})
+
+export const mockResponse = (
+  data: unknown,
+  headers: Record<string, string | string[]> = {},
+  status = 200,
+): {
+  config: object
+  data: unknown
+  headers: Record<string, string | string[]>
+  status: number
+} => ({
+  config: {},
+  data,
+  headers,
+  status,
+})
+
+export const createAxiosError = ({
+  message,
+  method = 'get',
+  responseHeaders = {},
+  status,
+  url,
+}: {
+  message: string
+  status: number
+  url: string
+  method?: string
+  responseHeaders?: Record<string, string>
+}): AxiosError =>
+  mock<AxiosError>({
+    config: mock<InternalAxiosRequestConfig>({ method, url }),
+    isAxiosError: true,
+    message,
+    response: mock<AxiosResponse>({
+      config: mock<InternalAxiosRequestConfig>({ data: null, method, url }),
+      data: {},
+      headers: responseHeaders,
+      status,
+    }),
+  })

--- a/tests/unit/classic-api.test.ts
+++ b/tests/unit/classic-api.test.ts
@@ -14,10 +14,7 @@ import {
   vi,
 } from 'vitest'
 
-import type {
-  ClassicAPI,
-  ClassicAPIConfig,
-} from '../../src/api/index.ts'
+import type { ClassicAPI, ClassicAPIConfig } from '../../src/api/index.ts'
 import type { DeviceType } from '../../src/constants.ts'
 import { RateLimitError } from '../../src/errors/index.ts'
 import {
@@ -27,7 +24,13 @@ import {
   toBuildingId,
   toDeviceId,
 } from '../../src/types/index.ts'
-import { cast, createAxiosError, createLogger, createSettingStore, mock } from '../helpers.ts'
+import {
+  cast,
+  createAxiosError,
+  createLogger,
+  createSettingStore,
+  mock,
+} from '../helpers.ts'
 
 const mockInterceptors = {
   request: { use: vi.fn() },

--- a/tests/unit/classic-api.test.ts
+++ b/tests/unit/classic-api.test.ts
@@ -17,7 +17,6 @@ import {
 import type {
   ClassicAPI,
   ClassicAPIConfig,
-  Logger,
 } from '../../src/api/index.ts'
 import type { DeviceType } from '../../src/constants.ts'
 import { RateLimitError } from '../../src/errors/index.ts'
@@ -28,7 +27,7 @@ import {
   toBuildingId,
   toDeviceId,
 } from '../../src/types/index.ts'
-import { cast, createSettingStore, mock } from '../helpers.ts'
+import { cast, createAxiosError, createLogger, createSettingStore, mock } from '../helpers.ts'
 
 const mockInterceptors = {
   request: { use: vi.fn() },
@@ -40,11 +39,6 @@ const mockAxiosInstance = {
   post: vi.fn(),
   request: vi.fn(),
 }
-
-const createLogger = (): Logger => ({
-  error: vi.fn<(...data: unknown[]) => void>(),
-  log: vi.fn<(...data: unknown[]) => void>(),
-})
 
 const loginResponse = (
   contextKey = 'ctx',
@@ -69,31 +63,6 @@ const createHeaders = (): {
   const setSpy = vi.spyOn(headers, 'set')
   return { headers, setSpy }
 }
-
-const createAxiosError = ({
-  message,
-  method = 'get',
-  responseHeaders = {},
-  status,
-  url,
-}: {
-  message: string
-  status: number
-  url: string
-  method?: string
-  responseHeaders?: Record<string, string>
-}): AxiosError =>
-  mock<AxiosError>({
-    config: mock<InternalAxiosRequestConfig>({ method, url }),
-    isAxiosError: true,
-    message,
-    response: mock<AxiosResponse>({
-      config: mock<InternalAxiosRequestConfig>({ data: null, method, url }),
-      data: {},
-      headers: responseHeaders,
-      status,
-    }),
-  })
 
 const transientServerError = (status: number): Error =>
   Object.assign(new Error(`Status ${String(status)}`), {

--- a/tests/unit/home-api.test.ts
+++ b/tests/unit/home-api.test.ts
@@ -760,6 +760,26 @@ describe('melcloud home API', () => {
       expect(buildings).toStrictEqual([mockBuilding])
     })
 
+    it('should fall back to full re-auth when refresh fails on 401', async () => {
+      setupSuccessfulLogin()
+      const api = await createApi()
+      /*
+       * 401 triggers reactive retry. Refresh token fails, so the handler
+       * clears the session and attempts full re-authentication, which
+       * succeeds. The retried dispatch then returns mockContext.
+       */
+      mockRequest.mockRejectedValueOnce(axiosUnauthorized())
+      // Refresh fails
+      mockAxiosPost.mockRejectedValueOnce(new Error('refresh failed'))
+      // Full re-auth succeeds
+      setupSuccessfulLogin()
+      // Retry dispatch after re-auth
+      mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
+      const buildings = await api.list()
+
+      expect(buildings).toStrictEqual([mockBuilding])
+    })
+
     it('should not retry when the retry budget is already consumed', async () => {
       setupSuccessfulLogin()
       const api = await createApi()
@@ -1084,6 +1104,35 @@ describe('melcloud home API', () => {
           message: expect.stringContaining('Too many redirects'),
         }),
       )
+    })
+
+    it('should treat a 302 with no location header as an empty redirect', async () => {
+      // PAR succeeds
+      mockAxiosPost.mockResolvedValueOnce(
+        mockResponse({ request_uri: 'urn:test' }),
+      )
+      // First redirect has a location, second 302 has no location header
+      mockAxiosRequest
+        .mockResolvedValueOnce(
+          mockResponse('', { location: `${AUTH_BASE}/step1` }, 302),
+        )
+        .mockResolvedValueOnce(mockResponse('', {}, 302))
+        /*
+         * The empty location resolves relative to current URL, producing an
+         * invalid redirect that eventually loops back to a page with no form.
+         */
+        .mockResolvedValueOnce(
+          mockResponse('<html>no form here</html>', {}, 200),
+        )
+      const logger = createLogger()
+      const api = await melCloudHomeApi.create({
+        baseURL: BASE_URL,
+        logger,
+        password: 'pass',
+        username: 'user@test.com',
+      })
+
+      expect(api.isAuthenticated()).toBe(false)
     })
 
     it('should resolve relative redirect URLs', async () => {
@@ -1607,6 +1656,35 @@ describe('melcloud home API', () => {
       const buildings = await api.list()
 
       expect(buildings).toStrictEqual([mockBuilding])
+    })
+  })
+
+  describe('token response without refresh_token', () => {
+    it('should not overwrite refresh token when response omits it', async () => {
+      vi.useFakeTimers()
+      try {
+        setupSuccessfulLogin()
+        const api = await createApi({ autoSyncInterval: null })
+
+        // Advance past token expiry
+        vi.advanceTimersByTime(3601 * MILLISECONDS_IN_SECOND)
+
+        // Refresh succeeds but response has no refresh_token
+        mockAxiosPost.mockResolvedValueOnce(
+          mockResponse({
+            access_token: 'refreshed-no-rt',
+            expires_in: 3600,
+            scope: mockTokenResponse.scope,
+            token_type: 'Bearer',
+          }),
+        )
+        mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
+        const buildings = await api.list()
+
+        expect(buildings).toStrictEqual([mockBuilding])
+      } finally {
+        vi.useRealTimers()
+      }
     })
   })
 

--- a/tests/unit/home-api.test.ts
+++ b/tests/unit/home-api.test.ts
@@ -16,7 +16,12 @@ import type {
   HomeErrorLogEntry,
   HomeReportData,
 } from '../../src/types/index.ts'
-import { cast, createLogger, createSettingStore, mockResponse } from '../helpers.ts'
+import {
+  cast,
+  createLogger,
+  createSettingStore,
+  mockResponse,
+} from '../helpers.ts'
 
 const BASE_URL = 'https://melcloudhome.com'
 const MILLISECONDS_IN_SECOND = 1000
@@ -151,7 +156,6 @@ vi.mock(import('axios'), async (importOriginal) => {
   }
 })
 
-
 /*
  * Simulate the OIDC token-based auth flow:
  *   1. axios.post to PAR endpoint → { request_uri }
@@ -205,7 +209,7 @@ const setupSuccessfulLogin = (): void => {
     )
     .mockResolvedValueOnce(
       mockResponse(
-        '<script>window.location=\'melcloudhome://?code=auth-code&amp;state=xyz\'</script>',
+        "<script>window.location='melcloudhome://?code=auth-code&amp;state=xyz'</script>",
         {},
         200,
       ),
@@ -1150,7 +1154,11 @@ describe('melcloud home API', () => {
           mockResponse('', { location: '/relative-path' }, 302),
         )
         .mockResolvedValueOnce(
-          mockResponse('', { location: `${COGNITO}/login?client_id=test` }, 302),
+          mockResponse(
+            '',
+            { location: `${COGNITO}/login?client_id=test` },
+            302,
+          ),
         )
         .mockResolvedValueOnce(
           mockResponse(
@@ -1383,11 +1391,7 @@ describe('melcloud home API', () => {
         .mockResolvedValueOnce(mockResponse(cognitoLoginPage(), {}, 200))
         // Credential POST -> callback without code param
         .mockResolvedValueOnce(
-          mockResponse(
-            '',
-            { location: 'melcloudhome://?state=abc' },
-            302,
-          ),
+          mockResponse('', { location: 'melcloudhome://?state=abc' }, 302),
         )
 
       const logger = createLogger()

--- a/tests/unit/home-api.test.ts
+++ b/tests/unit/home-api.test.ts
@@ -1322,6 +1322,37 @@ describe('melcloud home API', () => {
         expect.any(Error),
       )
     })
+
+    it('should handle callback URL without authorization code', async () => {
+      // PAR
+      mockAxiosPost.mockResolvedValueOnce(
+        mockResponse({ request_uri: 'urn:test' }),
+      )
+      mockAxiosRequest
+        .mockResolvedValueOnce(mockResponse(cognitoLoginPage(), {}, 200))
+        // Credential POST -> callback without code param
+        .mockResolvedValueOnce(
+          mockResponse(
+            '',
+            { location: 'melcloudhome://?state=abc' },
+            302,
+          ),
+        )
+
+      const logger = createLogger()
+      const api = await melCloudHomeApi.create({
+        baseURL: BASE_URL,
+        logger,
+        password: 'pass',
+        username: 'user@test.com',
+      })
+
+      expect(api.isAuthenticated()).toBe(false)
+      expect(logger.error).toHaveBeenCalledWith(
+        'Authentication failed:',
+        expect.any(Error),
+      )
+    })
   })
 
   describe('session persistence', () => {

--- a/tests/unit/home-api.test.ts
+++ b/tests/unit/home-api.test.ts
@@ -205,7 +205,7 @@ const setupSuccessfulLogin = (): void => {
     )
     .mockResolvedValueOnce(
       mockResponse(
-        `<script>window.location='melcloudhome://?code=auth-code&amp;state=xyz'</script>`,
+        '<script>window.location=\'melcloudhome://?code=auth-code&amp;state=xyz\'</script>',
         {},
         200,
       ),
@@ -670,15 +670,17 @@ describe('melcloud home API', () => {
         // Advance past the 3600s token expiry
         vi.advanceTimersByTime(3601 * MILLISECONDS_IN_SECOND)
 
-        // #ensureSession detects expired token, tries refresh first.
-        // Refresh token call succeeds via axios.post to token endpoint.
+        /*
+         * #ensureSession detects expired token, tries refresh first.
+         * Refresh token call succeeds via axios.post to token endpoint.
+         */
         mockAxiosPost.mockResolvedValueOnce(
           mockResponse({
             ...mockTokenResponse,
             access_token: 'refreshed-token',
           }),
         )
-        // list() -> #fetchContext() -> GET /context
+        /* List → #fetchContext → GET /context */
         mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
         const buildings = await api.list()
 
@@ -1508,8 +1510,10 @@ describe('melcloud home API', () => {
         refreshToken: 'old-refresh',
         username: 'user@test.com',
       })
-      // Refresh token attempt — simulated via #hasPersistedSession returning true
-      // since refreshToken is set, getUser is tried
+      /*
+       * Refresh token attempt — #hasPersistedSession returns true
+       * since refreshToken is set, getUser is tried.
+       */
       mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
 
       const api = await melCloudHomeApi.create({
@@ -1561,7 +1565,7 @@ describe('melcloud home API', () => {
         refreshToken: 'old-refresh',
         username: 'user@test.com',
       })
-      // getUser() succeeds with existing token — no OIDC needed for create()
+      /* GetUser succeeds with existing token — no OIDC needed for create */
       mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
       const api = await melCloudHomeApi.create({
         baseURL: BASE_URL,
@@ -1579,7 +1583,8 @@ describe('melcloud home API', () => {
       const tokenCalls = setSpy.mock.calls.filter(
         ([key]) => key === 'accessToken',
       )
-      // First call sets '' (clear), subsequent call sets the new token
+
+      /* First call sets '' (clear), subsequent call sets the new token */
       expect(tokenCalls[0]?.[1]).toBe('')
       expect(tokenCalls.at(-1)?.[1]).toBe('test-access-token')
     })
@@ -1606,11 +1611,13 @@ describe('melcloud home API', () => {
         const buildings = await api.list()
 
         expect(buildings).toStrictEqual([mockBuilding])
-        // Should have used refresh, not full OIDC (no axios.request calls for redirects)
-        const postCalls = mockAxiosPost.mock.calls
-        const lastPostUrl = postCalls.at(-1)?.[0] as string
 
-        expect(lastPostUrl).toContain('/connect/token')
+        /* Should have used refresh, not full OIDC (no axios.request calls for redirects) */
+        expect(mockAxiosPost).toHaveBeenLastCalledWith(
+          expect.stringContaining('/connect/token'),
+          expect.any(String),
+          expect.any(Object),
+        )
       } finally {
         vi.useRealTimers()
       }
@@ -1688,7 +1695,7 @@ describe('melcloud home API', () => {
     })
   })
 
-  describe('PAR and token exchange failures', () => {
+  describe('par and token exchange failures', () => {
     it('should handle PAR failure gracefully', async () => {
       const logger = createLogger()
       mockAxiosPost.mockRejectedValueOnce(new Error('PAR endpoint down'))

--- a/tests/unit/home-api.test.ts
+++ b/tests/unit/home-api.test.ts
@@ -1,10 +1,8 @@
-import { CookieJar } from 'tough-cookie'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { HomeAPI } from '../../src/api/home.ts'
 import type {
   HomeAPIConfig,
-  Logger,
   RequestCompleteEvent,
   RequestErrorEvent,
   RequestLifecycleEvents,
@@ -13,17 +11,17 @@ import type {
 } from '../../src/api/index.ts'
 import type {
   HomeBuilding,
-  HomeClaim,
   HomeContext,
   HomeEnergyData,
   HomeErrorLogEntry,
   HomeReportData,
 } from '../../src/types/index.ts'
-import { cast, createSettingStore } from '../helpers.ts'
+import { cast, createLogger, createSettingStore, mockResponse } from '../helpers.ts'
 
 const BASE_URL = 'https://melcloudhome.com'
 const MILLISECONDS_IN_SECOND = 1000
 const COGNITO = 'https://live-melcloudhome.auth.eu-west-1.amazoncognito.com'
+const AUTH_BASE = 'https://auth.melcloudhome.com'
 
 const X_KEY = 'x'
 const Y_KEY = 'y'
@@ -36,14 +34,6 @@ const cognitoLoginPage = (
   `<input type="hidden" name="_csrf" value="${csrf}"/>` +
   '<input type="hidden" name="cognitoAsfData" value=""/>' +
   '</form>'
-
-const userClaims: HomeClaim[] = [
-  { type: 'sub', value: 'user-123', valueType: 'null' },
-  { type: 'given_name', value: 'John', valueType: 'null' },
-  { type: 'family_name', value: 'Doe', valueType: 'null' },
-  { type: 'email', value: 'john@example.com', valueType: 'null' },
-  { type: 'bff:session_expires_in', value: '28800', valueType: 'null' },
-]
 
 const mockBuilding: HomeBuilding = {
   airToAirUnits: [
@@ -67,8 +57,13 @@ const mockBuilding: HomeBuilding = {
 
 const mockContext: HomeContext = {
   buildings: [],
+  country: 'FR',
+  email: 'test@example.com',
+  firstname: 'Test',
   guestBuildings: [mockBuilding],
+  id: 'user-1',
   language: 'fr',
+  lastname: 'User',
 }
 
 const mockEnergyData: HomeEnergyData = {
@@ -121,11 +116,27 @@ const mockSignalData: HomeEnergyData = {
   ],
 }
 
+const mockTokenResponse = {
+  access_token: 'test-access-token',
+  expires_in: 3600,
+  id_token: 'test-id-token',
+  refresh_token: 'test-refresh-token',
+  scope: 'openid profile email offline_access IdentityServerApi',
+  token_type: 'Bearer',
+}
+
+/** Mock for `this.#api.request()` — the BFF API instance. */
 const mockRequest = vi.fn()
 const mockAxiosInstance = {
   defaults: { baseURL: undefined as string | undefined },
   request: mockRequest,
 }
+
+/** Mock for bare `axios.post()` — used by PAR and token exchange. */
+const mockAxiosPost = vi.fn()
+
+/** Mock for bare `axios.request()` — used by the OIDC redirect chain. */
+const mockAxiosRequest = vi.fn()
 
 vi.mock(import('axios'), async (importOriginal) => {
   const original = await importOriginal()
@@ -134,44 +145,35 @@ vi.mock(import('axios'), async (importOriginal) => {
     default: cast({
       create: vi.fn().mockReturnValue(mockAxiosInstance),
       isAxiosError: original.default.isAxiosError,
+      post: mockAxiosPost,
+      request: mockAxiosRequest,
     }),
   }
 })
 
-const mockResponse = (
-  data: unknown,
-  headers: Record<string, string | string[]> = {},
-  status = 200,
-): {
-  config: object
-  data: unknown
-  headers: Record<string, string | string[]>
-  status: number
-} => ({
-  config: {},
-  data,
-  headers,
-  status,
-})
-
-const createLogger = (): Logger => ({
-  error: vi.fn<(...data: unknown[]) => void>(),
-  log: vi.fn<(...data: unknown[]) => void>(),
-})
 
 /*
- * Simulate the OIDC redirect chain:
- *   1. GET /bff/login → 302 → Cognito authorize → 302 → Cognito login page (200)
- *   2. POST credentials → 302 → callback URL
- *   3. GET callback → 302 chain → final 200
- *   4. GET /bff/user → 200 with claims
+ * Simulate the OIDC token-based auth flow:
+ *   1. axios.post to PAR endpoint → { request_uri }
+ *   2. axios.request redirect chain → Cognito login page (200)
+ *   3. axios.request credential POST → 302 with Location callback
+ *   4. axios.request callback chain → melcloudhome://?code=auth-code
+ *   5. axios.post to token endpoint → { access_token, refresh_token, ... }
+ *   6. mockAxiosInstance.request for GET /context → mockContext
  */
 const setupSuccessfulLogin = (): void => {
   const callbackUrl =
     'https://auth.melcloudhome.com/signin-oidc-meu?code=abc&state=xyz'
-  mockRequest
+
+  // 1. PAR
+  mockAxiosPost.mockResolvedValueOnce(
+    mockResponse({ request_uri: 'urn:ietf:params:oauth:request_uri:test' }),
+  )
+
+  // 2. Redirect chain to Cognito login page
+  mockAxiosRequest
     .mockResolvedValueOnce(
-      mockResponse('', { location: `${BASE_URL}/auth-redirect` }, 302),
+      mockResponse('', { location: `${AUTH_BASE}/connect/redirect` }, 302),
     )
     .mockResolvedValueOnce(
       mockResponse(
@@ -184,7 +186,14 @@ const setupSuccessfulLogin = (): void => {
       mockResponse('', { location: `${COGNITO}/login?client_id=test` }, 302),
     )
     .mockResolvedValueOnce(mockResponse(cognitoLoginPage(), {}, 200))
-    .mockResolvedValueOnce(mockResponse('', { location: callbackUrl }, 302))
+
+  // 3. Credential POST → 302 to callback
+  mockAxiosRequest.mockResolvedValueOnce(
+    mockResponse('', { location: callbackUrl }, 302),
+  )
+
+  // 4. Callback chain → JS redirect page → melcloudhome://?code=...
+  mockAxiosRequest
     .mockResolvedValueOnce(
       mockResponse(
         '',
@@ -195,21 +204,23 @@ const setupSuccessfulLogin = (): void => {
       ),
     )
     .mockResolvedValueOnce(
-      mockResponse('', { location: `${BASE_URL}/signin-oidc?code=final` }, 302),
+      mockResponse(
+        `<script>window.location='melcloudhome://?code=auth-code&amp;state=xyz'</script>`,
+        {},
+        200,
+      ),
     )
-    .mockResolvedValueOnce(mockResponse('', {}, 200))
-    .mockResolvedValueOnce(mockResponse(userClaims, {}, 200))
+
+  // 5. Token exchange
+  mockAxiosPost.mockResolvedValueOnce(mockResponse(mockTokenResponse))
+
+  // 6. GET /context via the API instance
+  mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
 }
 
 const HOUR_MS = 60 * 60 * 1000
 
-const buildSerializedJar = async (): Promise<string> => {
-  const jar = new CookieJar()
-  await jar.setCookie('session=persisted; Path=/; Secure', BASE_URL)
-  return JSON.stringify(jar.serializeSync())
-}
-
-const axiosUnauthorized = (url = '/api/user/context'): Error =>
+const axiosUnauthorized = (url = '/context'): Error =>
   Object.assign(new Error('Unauthorized'), {
     config: { url },
     isAxiosError: true,
@@ -226,10 +237,10 @@ const axiosServerError = (
   headers: Record<string, string> = {},
 ): Error =>
   Object.assign(new Error(`Status ${String(status)}`), {
-    config: { url: '/api/user/context' },
+    config: { url: '/context' },
     isAxiosError: true,
     response: {
-      config: { url: '/api/user/context' },
+      config: { url: '/context' },
       data: undefined,
       headers,
       status,
@@ -241,6 +252,8 @@ describe('melcloud home API', () => {
 
   beforeEach(async () => {
     mockRequest.mockReset()
+    mockAxiosPost.mockReset()
+    mockAxiosRequest.mockReset()
     vi.clearAllMocks()
     mockAxiosInstance.defaults.baseURL = BASE_URL
     ;({ HomeAPI: melCloudHomeApi } = await import('../../src/api/home.ts'))
@@ -263,10 +276,10 @@ describe('melcloud home API', () => {
 
       expect(api.isAuthenticated()).toBe(true)
       expect(api.user).toStrictEqual({
-        email: 'john@example.com',
-        firstName: 'John',
-        lastName: 'Doe',
-        sub: 'user-123',
+        email: 'test@example.com',
+        firstName: 'Test',
+        lastName: 'User',
+        sub: 'user-1',
       })
     })
 
@@ -292,7 +305,7 @@ describe('melcloud home API', () => {
 
       expect(api.isAuthenticated()).toBe(true)
 
-      mockRequest.mockRejectedValueOnce(new Error('network'))
+      mockAxiosPost.mockRejectedValueOnce(new Error('network'))
 
       await expect(
         api.authenticate({ password: 'wrong', username: 'u@t.com' }),
@@ -303,7 +316,7 @@ describe('melcloud home API', () => {
 
     it('should log and return false on stored credential failure', async () => {
       const logger = createLogger()
-      mockRequest.mockRejectedValueOnce(new Error('network'))
+      mockAxiosPost.mockRejectedValueOnce(new Error('network'))
       const api = await melCloudHomeApi.create({
         baseURL: BASE_URL,
         logger,
@@ -321,7 +334,7 @@ describe('melcloud home API', () => {
     it('should throw on explicit credential failure', async () => {
       setupSuccessfulLogin()
       const api = await createApi()
-      mockRequest.mockRejectedValueOnce(new Error('bad credentials'))
+      mockAxiosPost.mockRejectedValueOnce(new Error('bad credentials'))
 
       await expect(
         api.authenticate({ password: 'wrong', username: 'user@test.com' }),
@@ -434,7 +447,7 @@ describe('melcloud home API', () => {
         expect.objectContaining({
           data: { operationMode: 'Heat', power: true },
           method: 'put',
-          url: '/api/ataunit/device-1',
+          url: '/monitor/ataunit/device-1',
         }),
       )
     })
@@ -459,7 +472,7 @@ describe('melcloud home API', () => {
       expect(result).toStrictEqual(mockErrorLog)
       expect(mockRequest).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          url: '/api/ataunit/device-1/errorlog',
+          url: '/monitor/ataunit/device-1/errorlog',
         }),
       )
     })
@@ -637,7 +650,7 @@ describe('melcloud home API', () => {
         await vi.advanceTimersByTimeAsync(60_001)
 
         expect(mockRequest).toHaveBeenLastCalledWith(
-          expect.objectContaining({ url: '/api/user/context' }),
+          expect.objectContaining({ url: '/context' }),
         )
       } finally {
         vi.useRealTimers()
@@ -654,10 +667,18 @@ describe('melcloud home API', () => {
 
         expect(api.isAuthenticated()).toBe(true)
 
-        // Advance past the 28800s session expiry
-        vi.advanceTimersByTime(28_801 * MILLISECONDS_IN_SECOND)
+        // Advance past the 3600s token expiry
+        vi.advanceTimersByTime(3601 * MILLISECONDS_IN_SECOND)
 
-        setupSuccessfulLogin()
+        // #ensureSession detects expired token, tries refresh first.
+        // Refresh token call succeeds via axios.post to token endpoint.
+        mockAxiosPost.mockResolvedValueOnce(
+          mockResponse({
+            ...mockTokenResponse,
+            access_token: 'refreshed-token',
+          }),
+        )
+        // list() -> #fetchContext() -> GET /context
         mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
         const buildings = await api.list()
 
@@ -682,21 +703,30 @@ describe('melcloud home API', () => {
     })
 
     it('should treat a malformed persisted expiry as expired and reauthenticate', async () => {
-      /*
-       * A malformed `expiry` value (e.g. settings migration) must be
-       * treated as expired so the session is re-established via OIDC.
-       * Before the isSessionExpired() helper, `new Date('not-a-date')`
-       * silently produced an Invalid Date that compared as `false` against
-       * `new Date()`, leaving Home stuck on the dead session.
-       */
-      const cookies = await buildSerializedJar()
       const { settingManager } = createSettingStore({
-        cookies,
+        accessToken: 'old-token',
         expiry: 'not-a-valid-iso-date',
         password: 'pass',
+        refreshToken: 'old-refresh',
         username: 'user@test.com',
       })
-      setupSuccessfulLogin()
+      /*
+       * #hasPersistedSession() returns true (refreshToken is set).
+       * getUser() -> #fetchContext() -> #request() -> #ensureSession()
+       *   -> isSessionExpired('not-a-valid-iso-date') -> true
+       *   -> try refresh (refreshToken is set) -> succeeds
+       *   -> #fetchContext completes with new token
+       */
+      // Refresh token succeeds
+      mockAxiosPost.mockResolvedValueOnce(
+        mockResponse({
+          ...mockTokenResponse,
+          access_token: 'refreshed-token',
+        }),
+      )
+      // GET /context succeeds
+      mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
+
       const api = await melCloudHomeApi.create({
         baseURL: BASE_URL,
         settingManager,
@@ -711,11 +741,19 @@ describe('melcloud home API', () => {
       setupSuccessfulLogin()
       const api = await createApi()
       /*
-       * First attempt rejects with 401, reauth succeeds, retry succeeds
-       * with the mockContext payload.
+       * First attempt rejects with 401. The reactive handler tries
+       * refresh first (refreshToken is set) — that succeeds. The
+       * retry dispatch then succeeds with mockContext.
        */
       mockRequest.mockRejectedValueOnce(axiosUnauthorized())
-      setupSuccessfulLogin()
+      // Refresh succeeds
+      mockAxiosPost.mockResolvedValueOnce(
+        mockResponse({
+          ...mockTokenResponse,
+          access_token: 'refreshed-after-401',
+        }),
+      )
+      // Retry dispatch
       mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
       const buildings = await api.list()
 
@@ -726,11 +764,18 @@ describe('melcloud home API', () => {
       setupSuccessfulLogin()
       const api = await createApi()
       /*
-       * First 401: retry budget consumed, reauth succeeds, retry succeeds.
+       * First 401: retry budget consumed, refresh succeeds, retry succeeds.
        * Second 401 in the same retry window: no reauth, list() returns [].
        */
       mockRequest.mockRejectedValueOnce(axiosUnauthorized())
-      setupSuccessfulLogin()
+      // Refresh succeeds
+      mockAxiosPost.mockResolvedValueOnce(
+        mockResponse({
+          ...mockTokenResponse,
+          access_token: 'refreshed-after-401',
+        }),
+      )
+      // Retry dispatch
       mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
       await api.list()
 
@@ -740,14 +785,13 @@ describe('melcloud home API', () => {
       expect(second).toStrictEqual([])
     })
 
-    it('should not trigger reactive retry during the OIDC flow (LOGIN_PATH)', async () => {
+    it('should not trigger reactive retry during the OIDC flow', async () => {
       /*
-       * First attempt at /bff/login rejects with 401. `#shouldRetryAuth`
-       * must return false (LOGIN_PATH is exempt), so the failure surfaces
-       * via the @authenticate decorator's error path.
+       * PAR request fails with a network error. The @authenticate
+       * decorator catches and logs it, returning false.
        */
       const logger = createLogger()
-      mockRequest.mockRejectedValueOnce(axiosUnauthorized())
+      mockAxiosPost.mockRejectedValueOnce(axiosUnauthorized())
       const api = await melCloudHomeApi.create({
         baseURL: BASE_URL,
         logger,
@@ -766,14 +810,12 @@ describe('melcloud home API', () => {
       setupSuccessfulLogin()
       const api = await createApi()
       /*
-       * 401 on list → reactive retry → reauth itself fails (OIDC rejects
-       * the login form). `authenticate()` returns false, so the original
-       * 401 is re-thrown and list()'s own catch swallows it to return [].
+       * 401 on list -> reactive retry -> reauth itself fails (PAR rejects).
+       * `authenticate()` returns false, so the original 401 is re-thrown
+       * and list()'s own catch swallows it to return [].
        */
       mockRequest.mockRejectedValueOnce(axiosUnauthorized())
-      mockRequest.mockResolvedValueOnce(
-        mockResponse('<html>no form here</html>', {}, 200),
-      )
+      mockAxiosPost.mockRejectedValueOnce(new Error('PAR failed'))
       const buildings = await api.list()
 
       expect(buildings).toStrictEqual([])
@@ -785,10 +827,10 @@ describe('melcloud home API', () => {
 
       mockRequest.mockRejectedValueOnce(
         Object.assign(new Error('Server Error'), {
-          config: { url: '/api/user/context' },
+          config: { url: '/context' },
           isAxiosError: true,
           response: {
-            config: { url: '/api/user/context' },
+            config: { url: '/context' },
             data: undefined,
             headers: {},
             status: 500,
@@ -858,11 +900,6 @@ describe('melcloud home API', () => {
     it('should not retry POST/PUT on 5xx (non-idempotent)', async () => {
       setupSuccessfulLogin()
       const api = await createApi({ autoSyncInterval: null })
-      /*
-       * SetValues() calls list() internally on success, which would consume
-       * mocks; the first PUT failure triggers list() to be skipped via
-       * setValues's catch → only one request made.
-       */
       const {
         mock: {
           calls: { length: callCountBefore },
@@ -887,10 +924,6 @@ describe('melcloud home API', () => {
           },
         } = mockRequest
 
-        /*
-         * 429 is NOT transient-5xx, so the retry wrapper gives up immediately.
-         * A single failure is enough to close the gate.
-         */
         const rateLimited = axiosServerError(429, { 'retry-after': '2' })
         mockRequest.mockRejectedValueOnce(rateLimited)
 
@@ -942,11 +975,11 @@ describe('melcloud home API', () => {
       expect(startEvent?.correlationId).toBeTypeOf('string')
 
       expect(startEvent?.method).toBe('GET')
-      expect(startEvent?.url).toBe('/api/user/context')
+      expect(startEvent?.url).toBe('/context')
       expect(completeEvent?.correlationId).toBe(startEvent?.correlationId)
       expect(completeEvent?.method).toBe('GET')
       expect(completeEvent?.status).toBe(200)
-      expect(completeEvent?.url).toBe('/api/user/context')
+      expect(completeEvent?.url).toBe('/context')
 
       expect(completeEvent?.durationMs).toBeTypeOf('number')
 
@@ -1020,46 +1053,17 @@ describe('melcloud home API', () => {
   })
 
   describe('redirect handling', () => {
-    it('should stop on empty location header', async () => {
-      mockRequest
-        .mockResolvedValueOnce(mockResponse('', { location: '' }, 302))
-        .mockResolvedValueOnce(mockResponse(userClaims, {}, 200))
-      const api = await melCloudHomeApi.create({
-        baseURL: BASE_URL,
-        password: 'pass',
-        username: 'user@test.com',
-      })
-
-      expect(api.isAuthenticated()).toBe(false)
-    })
-
-    it('should stop on missing location header in redirect chain', async () => {
-      mockRequest
-        .mockResolvedValueOnce(
-          mockResponse('', { location: `${BASE_URL}/step1` }, 302),
-        )
-        .mockResolvedValueOnce(mockResponse('', {}, 302))
-      const logger = createLogger()
-      const api = await melCloudHomeApi.create({
-        baseURL: BASE_URL,
-        logger,
-        password: 'pass',
-        username: 'user@test.com',
-      })
-
-      expect(api.isAuthenticated()).toBe(false)
-      expect(logger.error).toHaveBeenCalledWith(
-        'Authentication failed:',
-        expect.any(Error),
+    it('should stop on too many redirects', async () => {
+      // PAR succeeds
+      mockAxiosPost.mockResolvedValueOnce(
+        mockResponse({ request_uri: 'urn:test' }),
       )
-    })
-
-    it('should throw on too many redirects', async () => {
+      // 21 redirects to exhaust the limit
       Array.from({ length: 21 }, (_unused, index) =>
-        mockRequest.mockResolvedValueOnce(
+        mockAxiosRequest.mockResolvedValueOnce(
           mockResponse(
             '',
-            { location: `${BASE_URL}/redirect-${String(index)}` },
+            { location: `${AUTH_BASE}/redirect-${String(index)}` },
             302,
           ),
         ),
@@ -1083,12 +1087,19 @@ describe('melcloud home API', () => {
     })
 
     it('should resolve relative redirect URLs', async () => {
-      mockRequest
+      // PAR succeeds
+      mockAxiosPost.mockResolvedValueOnce(
+        mockResponse({ request_uri: 'urn:test' }),
+      )
+      mockAxiosRequest
         .mockResolvedValueOnce(
-          mockResponse('', { location: `${BASE_URL}/auth-redirect` }, 302),
+          mockResponse('', { location: `${AUTH_BASE}/auth-redirect` }, 302),
         )
         .mockResolvedValueOnce(
           mockResponse('', { location: '/relative-path' }, 302),
+        )
+        .mockResolvedValueOnce(
+          mockResponse('', { location: `${COGNITO}/login?client_id=test` }, 302),
         )
         .mockResolvedValueOnce(
           mockResponse(
@@ -1097,6 +1108,7 @@ describe('melcloud home API', () => {
             200,
           ),
         )
+        // Credential POST
         .mockResolvedValueOnce(
           mockResponse(
             '',
@@ -1107,14 +1119,25 @@ describe('melcloud home API', () => {
             302,
           ),
         )
-        .mockResolvedValueOnce(mockResponse('', {}, 200))
-        .mockResolvedValueOnce(mockResponse(userClaims, {}, 200))
+        // Callback chain -> melcloudhome://
+        .mockResolvedValueOnce(
+          mockResponse(
+            '',
+            { location: 'melcloudhome://?code=auth-code&state=y' },
+            302,
+          ),
+        )
+      // Token exchange
+      mockAxiosPost.mockResolvedValueOnce(mockResponse(mockTokenResponse))
+      // GET /context
+      mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
+
       const api = await createApi()
 
       expect(api.isAuthenticated()).toBe(true)
-      expect(mockRequest).toHaveBeenCalledWith(
+      expect(mockAxiosRequest).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: `${BASE_URL}/relative-path`,
+          url: `${AUTH_BASE}/relative-path`,
         }),
       )
     })
@@ -1122,7 +1145,12 @@ describe('melcloud home API', () => {
 
   describe('form parsing', () => {
     it('should throw when form action is missing', async () => {
-      mockRequest.mockResolvedValueOnce(
+      // PAR succeeds
+      mockAxiosPost.mockResolvedValueOnce(
+        mockResponse({ request_uri: 'urn:test' }),
+      )
+      // Redirect chain lands on a page with no form
+      mockAxiosRequest.mockResolvedValueOnce(
         mockResponse('<html>no form here</html>', {}, 200),
       )
       const logger = createLogger()
@@ -1141,7 +1169,12 @@ describe('melcloud home API', () => {
     })
 
     it('should prefix relative form action with Cognito authority', async () => {
-      mockRequest
+      // PAR succeeds
+      mockAxiosPost.mockResolvedValueOnce(
+        mockResponse({ request_uri: 'urn:test' }),
+      )
+      // Directly to login page (no redirects before)
+      mockAxiosRequest
         .mockResolvedValueOnce(
           mockResponse(
             cognitoLoginPage('/login?client_id=test&amp;state=abc'),
@@ -1149,6 +1182,7 @@ describe('melcloud home API', () => {
             200,
           ),
         )
+        // Credential POST
         .mockResolvedValueOnce(
           mockResponse(
             '',
@@ -1159,11 +1193,22 @@ describe('melcloud home API', () => {
             302,
           ),
         )
-        .mockResolvedValueOnce(mockResponse('', {}, 200))
-        .mockResolvedValueOnce(mockResponse(userClaims, {}, 200))
+        // Callback -> melcloudhome://
+        .mockResolvedValueOnce(
+          mockResponse(
+            '',
+            { location: 'melcloudhome://?code=auth-code&state=y' },
+            302,
+          ),
+        )
+      // Token exchange
+      mockAxiosPost.mockResolvedValueOnce(mockResponse(mockTokenResponse))
+      // GET /context
+      mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
+
       await createApi()
 
-      expect(mockRequest).toHaveBeenCalledWith(
+      expect(mockAxiosRequest).toHaveBeenCalledWith(
         expect.objectContaining({
           url: `${COGNITO}/login?client_id=test&state=abc`,
         }),
@@ -1177,8 +1222,13 @@ describe('melcloud home API', () => {
         '<input type="hidden" value="orphan"/>' +
         '<input type="hidden" name="noValue"/>' +
         '</form>'
-      mockRequest
+      // PAR
+      mockAxiosPost.mockResolvedValueOnce(
+        mockResponse({ request_uri: 'urn:test' }),
+      )
+      mockAxiosRequest
         .mockResolvedValueOnce(mockResponse(htmlWithEdgeCases, {}, 200))
+        // Credential POST
         .mockResolvedValueOnce(
           mockResponse(
             '',
@@ -1189,47 +1239,35 @@ describe('melcloud home API', () => {
             302,
           ),
         )
-        .mockResolvedValueOnce(mockResponse('', {}, 200))
-        .mockResolvedValueOnce(mockResponse(userClaims, {}, 200))
+        // Callback -> melcloudhome://
+        .mockResolvedValueOnce(
+          mockResponse(
+            '',
+            { location: 'melcloudhome://?code=auth-code&state=y' },
+            302,
+          ),
+        )
+      // Token exchange
+      mockAxiosPost.mockResolvedValueOnce(mockResponse(mockTokenResponse))
+      // GET /context
+      mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
+
       const api = await createApi()
 
       expect(api.isAuthenticated()).toBe(true)
     })
 
-    it('should handle missing claim types with empty string fallback', async () => {
-      const partialClaims: HomeClaim[] = [
-        { type: 'email', value: 'only@email.com', valueType: 'null' },
-      ]
-      mockRequest
-        .mockResolvedValueOnce(mockResponse(cognitoLoginPage(), {}, 200))
-        .mockResolvedValueOnce(
-          mockResponse(
-            '',
-            {
-              location:
-                'https://auth.melcloudhome.com/signin-oidc-meu?code=x&state=y',
-            },
-            302,
-          ),
-        )
-        .mockResolvedValueOnce(mockResponse('', {}, 200))
-        .mockResolvedValueOnce(mockResponse(partialClaims, {}, 200))
-      const api = await createApi()
-
-      expect(api.user).toStrictEqual({
-        email: 'only@email.com',
-        firstName: '',
-        lastName: '',
-        sub: '',
-      })
-    })
-
     it('should use absolute form action as-is', async () => {
       const absoluteAction = `${COGNITO}/login?client_id=test`
-      mockRequest
+      // PAR
+      mockAxiosPost.mockResolvedValueOnce(
+        mockResponse({ request_uri: 'urn:test' }),
+      )
+      mockAxiosRequest
         .mockResolvedValueOnce(
           mockResponse(cognitoLoginPage(absoluteAction), {}, 200),
         )
+        // Credential POST
         .mockResolvedValueOnce(
           mockResponse(
             '',
@@ -1240,38 +1278,63 @@ describe('melcloud home API', () => {
             302,
           ),
         )
-        .mockResolvedValueOnce(mockResponse('', {}, 200))
-        .mockResolvedValueOnce(mockResponse(userClaims, {}, 200))
+        // Callback -> melcloudhome://
+        .mockResolvedValueOnce(
+          mockResponse(
+            '',
+            { location: 'melcloudhome://?code=auth-code&state=y' },
+            302,
+          ),
+        )
+      // Token exchange
+      mockAxiosPost.mockResolvedValueOnce(mockResponse(mockTokenResponse))
+      // GET /context
+      mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
+
       await createApi()
 
-      expect(mockRequest).toHaveBeenCalledWith(
+      expect(mockAxiosRequest).toHaveBeenCalledWith(
         expect.objectContaining({ url: absoluteAction }),
       )
     })
 
     it('should handle missing location header from credential submission', async () => {
-      mockRequest
+      // PAR
+      mockAxiosPost.mockResolvedValueOnce(
+        mockResponse({ request_uri: 'urn:test' }),
+      )
+      mockAxiosRequest
         .mockResolvedValueOnce(mockResponse(cognitoLoginPage(), {}, 200))
+        // Credential POST -> no location header
         .mockResolvedValueOnce(mockResponse('', {}, 302))
-        .mockResolvedValueOnce(mockResponse('', {}, 200))
-        .mockResolvedValueOnce(mockResponse(userClaims, {}, 200))
-      const api = await createApi()
 
-      expect(api.isAuthenticated()).toBe(true)
+      const logger = createLogger()
+      const api = await melCloudHomeApi.create({
+        baseURL: BASE_URL,
+        logger,
+        password: 'pass',
+        username: 'user@test.com',
+      })
+
+      expect(api.isAuthenticated()).toBe(false)
+      expect(logger.error).toHaveBeenCalledWith(
+        'Authentication failed:',
+        expect.any(Error),
+      )
     })
   })
 
   describe('session persistence', () => {
     it('should reuse persisted session and skip OIDC re-login', async () => {
-      const cookies = await buildSerializedJar()
       const futureExpiry = new Date(Date.now() + HOUR_MS).toISOString()
       const { settingManager } = createSettingStore({
-        cookies,
+        accessToken: 'persisted-token',
         expiry: futureExpiry,
         password: 'pass',
+        refreshToken: 'persisted-refresh',
         username: 'user@test.com',
       })
-      mockRequest.mockResolvedValueOnce(mockResponse(userClaims, {}, 200))
+      mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
 
       const api = await melCloudHomeApi.create({
         baseURL: BASE_URL,
@@ -1281,20 +1344,20 @@ describe('melcloud home API', () => {
       expect(api.isAuthenticated()).toBe(true)
       expect(mockRequest).toHaveBeenCalledTimes(1)
       expect(mockRequest).toHaveBeenCalledWith(
-        expect.objectContaining({ url: '/bff/user' }),
+        expect.objectContaining({ url: '/context' }),
       )
     })
 
     it('should fall back to OIDC when persisted session is rejected', async () => {
-      const cookies = await buildSerializedJar()
       const futureExpiry = new Date(Date.now() + HOUR_MS).toISOString()
       const { settingManager } = createSettingStore({
-        cookies,
+        accessToken: 'persisted-token',
         expiry: futureExpiry,
         password: 'pass',
+        refreshToken: 'persisted-refresh',
         username: 'user@test.com',
       })
-      // First getUser() call fails → triggers fallback to full authenticate()
+      // First getUser() call fails -> triggers fallback to full authenticate()
       mockRequest.mockRejectedValueOnce(new Error('401 Unauthorized'))
       setupSuccessfulLogin()
 
@@ -1307,16 +1370,11 @@ describe('melcloud home API', () => {
     })
 
     it('should wipe persisted state when rejected session has no credentials', async () => {
-      /*
-       * Without credentials, @authenticate short-circuits to false. The
-       * dead cookies/expiry must be cleared before the fallback so a
-       * subsequent boot doesn't loop forever retrying the same bad session.
-       */
-      const cookies = await buildSerializedJar()
       const futureExpiry = new Date(Date.now() + HOUR_MS).toISOString()
       const { setSpy, settingManager } = createSettingStore({
-        cookies,
+        accessToken: 'dead-token',
         expiry: futureExpiry,
+        refreshToken: 'dead-refresh',
       })
       mockRequest.mockRejectedValueOnce(new Error('401 Unauthorized'))
 
@@ -1326,19 +1384,13 @@ describe('melcloud home API', () => {
       })
 
       expect(api.isAuthenticated()).toBe(false)
-      expect(setSpy).toHaveBeenCalledWith('cookies', '')
+      expect(setSpy).toHaveBeenCalledWith('accessToken', '')
+      expect(setSpy).toHaveBeenCalledWith('refreshToken', '')
       expect(setSpy).toHaveBeenCalledWith('expiry', '')
     })
 
-    it('should skip getUser when expiry is set but cookies are empty', async () => {
-      /*
-       * Edge case (e.g. after a settings migration where `cookies` didn't
-       * exist previously): an unexpired `expiry` alone must not trigger a
-       * getUser() attempt with an empty cookie jar.
-       */
-      const futureExpiry = new Date(Date.now() + HOUR_MS).toISOString()
+    it('should skip getUser when expiry is empty and no tokens', async () => {
       const { settingManager } = createSettingStore({
-        expiry: futureExpiry,
         password: 'pass',
         username: 'user@test.com',
       })
@@ -1350,10 +1402,8 @@ describe('melcloud home API', () => {
       })
 
       expect(api.isAuthenticated()).toBe(true)
-      // First call must be the OIDC entry (/bff/login), not /bff/user.
-      expect(mockRequest.mock.calls[0]?.[0]).toStrictEqual(
-        expect.objectContaining({ url: '/bff/login' }),
-      )
+      // First call must be PAR (axios.post), not GET /context
+      expect(mockAxiosPost.mock.calls[0]?.[0]).toContain('/connect/par')
     })
 
     it('wires a consumer AbortSignal into outgoing requests', async () => {
@@ -1361,21 +1411,26 @@ describe('melcloud home API', () => {
       const controller = new AbortController()
       await createApi({ abortSignal: controller.signal })
 
-      expect(mockRequest).toHaveBeenCalledWith(
+      // The auth flow requests use the signal
+      expect(mockAxiosPost).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(String),
         expect.objectContaining({ signal: controller.signal }),
       )
     })
 
     it('should fall back to OIDC when expiry is in the past', async () => {
-      const cookies = await buildSerializedJar()
       const pastExpiry = new Date(Date.now() - HOUR_MS).toISOString()
       const { settingManager } = createSettingStore({
-        cookies,
+        accessToken: 'expired-token',
         expiry: pastExpiry,
         password: 'pass',
+        refreshToken: 'old-refresh',
         username: 'user@test.com',
       })
-      setupSuccessfulLogin()
+      // Refresh token attempt — simulated via #hasPersistedSession returning true
+      // since refreshToken is set, getUser is tried
+      mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
 
       const api = await melCloudHomeApi.create({
         baseURL: BASE_URL,
@@ -1385,120 +1440,213 @@ describe('melcloud home API', () => {
       expect(api.isAuthenticated()).toBe(true)
     })
 
-    it('should recover from corrupted cookies and fall back to OIDC', async () => {
+    it('should persist tokens via settingManager after login', async () => {
+      const { setSpy, settingManager } = createSettingStore()
+      setupSuccessfulLogin()
+
+      await melCloudHomeApi.create({
+        baseURL: BASE_URL,
+        password: 'pass',
+        settingManager,
+        username: 'user@test.com',
+      })
+
+      const tokenCalls = setSpy.mock.calls.filter(
+        ([key]) => key === 'accessToken',
+      )
+      const lastToken = tokenCalls.at(-1)?.[1] ?? ''
+
+      expect(lastToken).not.toBe('')
+      expect(lastToken).toBe('test-access-token')
+
+      const refreshCalls = setSpy.mock.calls.filter(
+        ([key]) => key === 'refreshToken',
+      )
+      const lastRefresh = refreshCalls.at(-1)?.[1] ?? ''
+
+      expect(lastRefresh).toBe('test-refresh-token')
+    })
+
+    it('should clear persisted tokens at the start of authenticate()', async () => {
+      /*
+       * Create an API with persisted tokens, then explicitly call
+       * authenticate() with new credentials. The first thing authenticate()
+       * does is call #clearPersistedSession(), wiping the old tokens.
+       */
       const futureExpiry = new Date(Date.now() + HOUR_MS).toISOString()
       const { setSpy, settingManager } = createSettingStore({
-        cookies: 'not-valid-json',
+        accessToken: 'old-token',
         expiry: futureExpiry,
         password: 'pass',
+        refreshToken: 'old-refresh',
         username: 'user@test.com',
       })
-      setupSuccessfulLogin()
-
+      // getUser() succeeds with existing token — no OIDC needed for create()
+      mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
       const api = await melCloudHomeApi.create({
         baseURL: BASE_URL,
         settingManager,
       })
+      setSpy.mockClear()
 
-      expect(api.isAuthenticated()).toBe(true)
-      /*
-       * Self-heal: corrupted cookies + paired expiry must be wiped so the
-       * bad value is not retried on subsequent boots.
-       */
-      expect(setSpy).toHaveBeenCalledWith('cookies', '')
-      expect(setSpy).toHaveBeenCalledWith('expiry', '')
-    })
-
-    it('should persist cookies via settingManager after login', async () => {
-      /*
-       * Inject a Set-Cookie header on the Cognito login page response so that
-       * #onResponse triggers #persistJar(). The rest of the OIDC chain is
-       * identical to setupSuccessfulLogin().
-       */
-      const callbackUrl =
-        'https://auth.melcloudhome.com/signin-oidc-meu?code=abc&state=xyz'
-      mockRequest
-        .mockResolvedValueOnce(
-          mockResponse('', { location: `${BASE_URL}/auth-redirect` }, 302),
-        )
-        .mockResolvedValueOnce(
-          mockResponse(
-            '',
-            { location: `${COGNITO}/oauth2/authorize?client_id=test` },
-            302,
-          ),
-        )
-        .mockResolvedValueOnce(
-          mockResponse(
-            '',
-            { location: `${COGNITO}/login?client_id=test` },
-            302,
-          ),
-        )
-        .mockResolvedValueOnce(
-          mockResponse(
-            cognitoLoginPage(),
-            { 'set-cookie': ['session=abc; Path=/; Secure'] },
-            200,
-          ),
-        )
-        .mockResolvedValueOnce(mockResponse('', { location: callbackUrl }, 302))
-        .mockResolvedValueOnce(
-          mockResponse(
-            '',
-            {
-              location: 'https://auth.melcloudhome.com/ExternalLogin/Callback',
-            },
-            302,
-          ),
-        )
-        .mockResolvedValueOnce(
-          mockResponse(
-            '',
-            { location: `${BASE_URL}/signin-oidc?code=final` },
-            302,
-          ),
-        )
-        .mockResolvedValueOnce(mockResponse('', {}, 200))
-        .mockResolvedValueOnce(mockResponse(userClaims, {}, 200))
-      const { setSpy, settingManager } = createSettingStore()
-
-      await melCloudHomeApi.create({
-        baseURL: BASE_URL,
-        password: 'pass',
-        settingManager,
-        username: 'user@test.com',
-      })
-
-      const cookiesCalls = setSpy.mock.calls.filter(
-        ([key]) => key === 'cookies',
-      )
-      const lastCookies = cookiesCalls.at(-1)?.[1] ?? ''
-
-      expect(lastCookies).not.toBe('')
-      expect(() => CookieJar.deserializeSync(lastCookies)).not.toThrow()
-    })
-
-    it('should clear persisted cookies at the start of authenticate()', async () => {
-      const { setSpy, settingManager } = createSettingStore({
-        cookies: await buildSerializedJar(),
-      })
+      // Now explicitly authenticate → clears old tokens first
       setupSuccessfulLogin()
-
-      await melCloudHomeApi.create({
-        baseURL: BASE_URL,
-        password: 'pass',
-        settingManager,
-        username: 'user@test.com',
+      await api.authenticate({
+        password: 'new-pass',
+        username: 'new@test.com',
       })
 
-      expect(setSpy).toHaveBeenCalledWith('cookies', '')
+      const tokenCalls = setSpy.mock.calls.filter(
+        ([key]) => key === 'accessToken',
+      )
+      // First call sets '' (clear), subsequent call sets the new token
+      expect(tokenCalls[0]?.[1]).toBe('')
+      expect(tokenCalls.at(-1)?.[1]).toBe('test-access-token')
     })
   })
 
-  describe('cookie handling', () => {
-    it('should store and send Set-Cookie headers across requests', async () => {
-      mockRequest
+  describe('token refresh', () => {
+    it('should refresh access token when expired instead of full re-auth', async () => {
+      vi.useFakeTimers()
+      try {
+        setupSuccessfulLogin()
+        const api = await createApi({ autoSyncInterval: null })
+
+        // Advance past token expiry
+        vi.advanceTimersByTime(3601 * MILLISECONDS_IN_SECOND)
+
+        // Refresh token request succeeds
+        mockAxiosPost.mockResolvedValueOnce(
+          mockResponse({
+            ...mockTokenResponse,
+            access_token: 'refreshed-token',
+          }),
+        )
+        mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
+        const buildings = await api.list()
+
+        expect(buildings).toStrictEqual([mockBuilding])
+        // Should have used refresh, not full OIDC (no axios.request calls for redirects)
+        const postCalls = mockAxiosPost.mock.calls
+        const lastPostUrl = postCalls.at(-1)?.[0] as string
+
+        expect(lastPostUrl).toContain('/connect/token')
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('should fall back to full OIDC when token refresh fails', async () => {
+      vi.useFakeTimers()
+      try {
+        setupSuccessfulLogin()
+        const api = await createApi({ autoSyncInterval: null })
+
+        // Advance past token expiry
+        vi.advanceTimersByTime(3601 * MILLISECONDS_IN_SECOND)
+
+        // Refresh fails
+        mockAxiosPost.mockRejectedValueOnce(new Error('refresh failed'))
+        // Full re-auth succeeds
+        setupSuccessfulLogin()
+        mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
+        const buildings = await api.list()
+
+        expect(buildings).toStrictEqual([mockBuilding])
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('should try token refresh on 401 before full re-auth', async () => {
+      setupSuccessfulLogin()
+      const api = await createApi({ autoSyncInterval: null })
+
+      // API call fails with 401
+      mockRequest.mockRejectedValueOnce(axiosUnauthorized())
+      // Refresh succeeds
+      mockAxiosPost.mockResolvedValueOnce(
+        mockResponse({
+          ...mockTokenResponse,
+          access_token: 'refreshed-after-401',
+        }),
+      )
+      // Retry after refresh succeeds
+      mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
+      const buildings = await api.list()
+
+      expect(buildings).toStrictEqual([mockBuilding])
+    })
+  })
+
+  describe('PAR and token exchange failures', () => {
+    it('should handle PAR failure gracefully', async () => {
+      const logger = createLogger()
+      mockAxiosPost.mockRejectedValueOnce(new Error('PAR endpoint down'))
+      const api = await melCloudHomeApi.create({
+        baseURL: BASE_URL,
+        logger,
+        password: 'pass',
+        username: 'user@test.com',
+      })
+
+      expect(api.isAuthenticated()).toBe(false)
+      expect(logger.error).toHaveBeenCalledWith(
+        'Authentication failed:',
+        expect.any(Error),
+      )
+    })
+
+    it('should handle token exchange failure gracefully', async () => {
+      const logger = createLogger()
+      // PAR succeeds
+      mockAxiosPost.mockResolvedValueOnce(
+        mockResponse({ request_uri: 'urn:test' }),
+      )
+      // Redirect chain to login page
+      mockAxiosRequest
+        .mockResolvedValueOnce(mockResponse(cognitoLoginPage(), {}, 200))
+        // Credential POST
+        .mockResolvedValueOnce(
+          mockResponse(
+            '',
+            { location: 'https://auth.melcloudhome.com/callback?code=x' },
+            302,
+          ),
+        )
+        // Callback -> melcloudhome://
+        .mockResolvedValueOnce(
+          mockResponse(
+            '',
+            { location: 'melcloudhome://?code=auth-code&state=y' },
+            302,
+          ),
+        )
+      // Token exchange fails
+      mockAxiosPost.mockRejectedValueOnce(new Error('token exchange failed'))
+
+      const api = await melCloudHomeApi.create({
+        baseURL: BASE_URL,
+        logger,
+        password: 'pass',
+        username: 'user@test.com',
+      })
+
+      expect(api.isAuthenticated()).toBe(false)
+      expect(logger.error).toHaveBeenCalledWith(
+        'Authentication failed:',
+        expect.any(Error),
+      )
+    })
+  })
+
+  describe('cookie handling in auth flow', () => {
+    it('should store and send Set-Cookie headers across redirect requests', async () => {
+      // PAR
+      mockAxiosPost.mockResolvedValueOnce(
+        mockResponse({ request_uri: 'urn:test' }),
+      )
+      mockAxiosRequest
         .mockResolvedValueOnce(
           mockResponse(
             '',
@@ -1512,6 +1660,7 @@ describe('melcloud home API', () => {
         .mockResolvedValueOnce(
           mockResponse(cognitoLoginPage(`${COGNITO}/login?id=test`), {}, 200),
         )
+        // Credential POST
         .mockResolvedValueOnce(
           mockResponse(
             '',
@@ -1522,15 +1671,30 @@ describe('melcloud home API', () => {
             302,
           ),
         )
-        .mockResolvedValueOnce(mockResponse('', {}, 200))
-        .mockResolvedValueOnce(mockResponse(userClaims, {}, 200))
+        // Callback -> melcloudhome://
+        .mockResolvedValueOnce(
+          mockResponse(
+            '',
+            { location: 'melcloudhome://?code=auth-code&state=y' },
+            302,
+          ),
+        )
+      // Token exchange
+      mockAxiosPost.mockResolvedValueOnce(mockResponse(mockTokenResponse))
+      // GET /context
+      mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
+
       const api = await createApi()
 
       expect(api.isAuthenticated()).toBe(true)
     })
 
     it('should ignore invalid Set-Cookie values', async () => {
-      mockRequest
+      // PAR
+      mockAxiosPost.mockResolvedValueOnce(
+        mockResponse({ request_uri: 'urn:test' }),
+      )
+      mockAxiosRequest
         .mockResolvedValueOnce(
           mockResponse(
             cognitoLoginPage(`${COGNITO}/login?id=test`),
@@ -1538,6 +1702,7 @@ describe('melcloud home API', () => {
             200,
           ),
         )
+        // Credential POST
         .mockResolvedValueOnce(
           mockResponse(
             '',
@@ -1548,8 +1713,18 @@ describe('melcloud home API', () => {
             302,
           ),
         )
-        .mockResolvedValueOnce(mockResponse('', {}, 200))
-        .mockResolvedValueOnce(mockResponse(userClaims, {}, 200))
+        // Callback -> melcloudhome://
+        .mockResolvedValueOnce(
+          mockResponse(
+            '',
+            { location: 'melcloudhome://?code=auth-code&state=y' },
+            302,
+          ),
+        )
+      // Token exchange
+      mockAxiosPost.mockResolvedValueOnce(mockResponse(mockTokenResponse))
+      // GET /context
+      mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
 
       await expect(createApi()).resolves.toBeDefined()
     })
@@ -1568,10 +1743,6 @@ describe('melcloud home API', () => {
       const messages = calls.map(([message]) => String(message))
 
       expect(messages.length).toBeGreaterThan(0)
-      /*
-       * Symmetric request/response logging — every dispatched call emits
-       * one "API request" line and one "API response" line.
-       */
       expect(messages.some((message) => message.includes('API request'))).toBe(
         true,
       )


### PR DESCRIPTION
## Summary

- Replace the cookie-based web BFF (`melcloudhome.com`, subject to 503 outages) with the token-based mobile BFF (`mobile.bff.melcloudhome.com`) using Bearer authentication via IdentityServer
- Auth flow: PAR → Cognito headless login → PKCE token exchange, with refresh token support
- Settings: `accessToken` + `refreshToken` replace serialized `CookieJar` (`cookies`), aligning with Classic API's `contextKey` pattern
- Extract `BaseAPI` abstract class for shared infrastructure (lifecycle, rate limiting, retry guard, `@setting` accessors, events) between `HomeAPI` and `ClassicAPI`
- Extract `token-auth.ts` module for the OIDC flow (PAR, Cognito login, token exchange, refresh)
- Factor shared test helpers (`createLogger`, `mockResponse`, `createAxiosError`) into `tests/helpers.ts`

## Mobile BFF endpoints

| Web BFF (down) | Mobile BFF |
|---|---|
| `/api/user/context` | `/context` |
| `/api/v1/report/trendsummary` | `/report/trendsummary` |
| `/api/ataunit/{id}` | `/monitor/ataunit/{id}` |
| `/api/ataunit/{id}/errorlog` | `/monitor/ataunit/{id}/errorlog` |
| `/api/telemetry/energy/{id}` | `/monitor/telemetry/energy/{id}` |
| `/api/telemetry/actual/{id}` | `/monitor/telemetry/actual/{id}` |

## Breaking changes

- `HomeAPISettings.cookies` replaced by `accessToken` + `refreshToken` — existing sessions will require re-authentication once

## Test plan

- [x] TypeScript compiles cleanly
- [x] All 502 tests pass (27 files)
- [ ] Integration test with real MELCloud Home credentials
- [ ] Verify telemetry/energy/signal paths on mobile BFF (only `/context`, `/report/trendsummary`, `/monitor/ataunit` confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)