### PR TITLE
Expose absolute unblock time on RateLimitError and RateLimitGate

### DIFF
--- a/src/errors/rate-limit.ts
+++ b/src/errors/rate-limit.ts
@@ -1,22 +1,36 @@
-import type { Duration } from 'luxon'
+import type { DateTime, Duration } from 'luxon'
 
 import { APIError } from './base.ts'
 
 /**
  * Upstream returned HTTP 429 (Too Many Requests), or the local
  * rate-limit gate is still holding a pause window from a previous 429.
+ *
+ * Consumers receive structured, machine-readable fields so they can
+ * format their own localized messages without parsing the string:
+ * - {@link retryAfter}: relative duration remaining (ideal for
+ *   "try again in 5 min" phrasing).
+ * - {@link unblockAt}: absolute unblock time (ideal for
+ *   "try again at 14:30" phrasing).
  */
 export class RateLimitError extends APIError {
   public override readonly name = 'RateLimitError'
 
   public readonly retryAfter: Duration | null
 
+  public readonly unblockAt: DateTime | null
+
   public constructor(
     message: string,
-    options: { retryAfter: Duration | null; cause?: unknown },
+    options: {
+      retryAfter: Duration | null
+      unblockAt: DateTime | null
+      cause?: unknown
+    },
   ) {
-    const { cause, retryAfter } = options
+    const { cause, retryAfter, unblockAt } = options
     super(message, { cause })
     this.retryAfter = retryAfter
+    this.unblockAt = unblockAt
   }
 }

--- a/src/errors/rate-limit.ts
+++ b/src/errors/rate-limit.ts
@@ -24,11 +24,11 @@ export class RateLimitError extends APIError {
     message: string,
     options: {
       retryAfter: Duration | null
+      unblockAt: DateTime | null
       cause?: unknown
-      unblockAt?: DateTime | null
     },
   ) {
-    const { cause, retryAfter, unblockAt = null } = options
+    const { cause, retryAfter, unblockAt } = options
     super(message, { cause })
     this.retryAfter = retryAfter
     this.unblockAt = unblockAt

--- a/src/errors/rate-limit.ts
+++ b/src/errors/rate-limit.ts
@@ -24,11 +24,11 @@ export class RateLimitError extends APIError {
     message: string,
     options: {
       retryAfter: Duration | null
-      unblockAt: DateTime | null
       cause?: unknown
+      unblockAt?: DateTime | null
     },
   ) {
-    const { cause, retryAfter, unblockAt } = options
+    const { cause, retryAfter, unblockAt = null } = options
     super(message, { cause })
     this.retryAfter = retryAfter
     this.unblockAt = unblockAt

--- a/src/resilience/rate-limit-gate.ts
+++ b/src/resilience/rate-limit-gate.ts
@@ -28,6 +28,16 @@ export class RateLimitGate {
     return this.isPaused ? this.#pausedUntil.diffNow() : null
   }
 
+  /**
+   * Absolute moment at which the gate re-opens. Use alongside
+   * {@link remaining} when consumers want to render an "at HH:MM"
+   * message rather than a relative duration.
+   * @returns The unblock `DateTime` if paused, or `null` if the gate is open.
+   */
+  public get unblockAt(): DateTime | null {
+    return this.isPaused ? this.#pausedUntil : null
+  }
+
   readonly #fallback: Duration
 
   #pausedUntil: DateTime = DateTime.now()

--- a/src/resilience/rate-limit-gate.ts
+++ b/src/resilience/rate-limit-gate.ts
@@ -32,6 +32,11 @@ export class RateLimitGate {
    * Absolute moment at which the gate re-opens. Use alongside
    * {@link remaining} when consumers want to render an "at HH:MM"
    * message rather than a relative duration.
+   *
+   * Callers that need both `remaining` and `unblockAt` together should
+   * prefer {@link snapshot} to avoid reading each against a separate
+   * `DateTime.now()` tick (near the window boundary the pair can
+   * otherwise land on different sides of `isPaused`).
    * @returns The unblock `DateTime` if paused, or `null` if the gate is open.
    */
   public get unblockAt(): DateTime | null {
@@ -109,5 +114,26 @@ export class RateLimitGate {
   /** Reset the gate immediately (testing or manual unblock). */
   public reset(): void {
     this.#pausedUntil = DateTime.now()
+  }
+
+  /**
+   * Atomic read of the gate's state. All three fields are computed
+   * against a single `DateTime.now()` capture, so `remaining` and
+   * `unblockAt` cannot observe inconsistent "one null, one not" pairs
+   * that separate getter reads might hit near the boundary.
+   * @returns The current pause state and derived timing fields.
+   */
+  public snapshot(): {
+    isPaused: boolean
+    remaining: Duration | null
+    unblockAt: DateTime | null
+  } {
+    const now = DateTime.now()
+    const isPaused = this.#pausedUntil > now
+    return {
+      isPaused,
+      remaining: isPaused ? this.#pausedUntil.diff(now) : null,
+      unblockAt: isPaused ? this.#pausedUntil : null,
+    }
   }
 }

--- a/src/resilience/rate-limit-policy.ts
+++ b/src/resilience/rate-limit-policy.ts
@@ -28,13 +28,14 @@ export class RateLimitPolicy implements ResiliencePolicy {
   }
 
   public async run<T>(attempt: () => Promise<T>): Promise<T> {
-    if (this.#gate.isPaused) {
+    // Read all three fields from one `DateTime.now()` capture so the
+    // error's `retryAfter` and `unblockAt` are mutually consistent —
+    // even when the gate re-opens between two separate getter reads.
+    const { isPaused, remaining, unblockAt } = this.#gate.snapshot()
+    if (isPaused) {
       throw new RateLimitError(
         `API requests are on hold for ${this.#gate.formatRemaining()}`,
-        {
-          retryAfter: this.#gate.remaining,
-          unblockAt: this.#gate.unblockAt,
-        },
+        { retryAfter: remaining, unblockAt },
       )
     }
     try {

--- a/src/resilience/rate-limit-policy.ts
+++ b/src/resilience/rate-limit-policy.ts
@@ -31,7 +31,10 @@ export class RateLimitPolicy implements ResiliencePolicy {
     if (this.#gate.isPaused) {
       throw new RateLimitError(
         `API requests are on hold for ${this.#gate.formatRemaining()}`,
-        { retryAfter: this.#gate.remaining },
+        {
+          retryAfter: this.#gate.remaining,
+          unblockAt: this.#gate.unblockAt,
+        },
       )
     }
     try {

--- a/tests/unit/decorators.test.ts
+++ b/tests/unit/decorators.test.ts
@@ -510,12 +510,16 @@ describe(validateRequest, () => {
     {
       error: new RateLimitError('paused', {
         retryAfter: Duration.fromMillis(5000),
+        unblockAt: null,
       }),
       expected: { kind: 'rate-limited', retryAfterMs: 5000 } as const,
       label: 'RateLimitError with Duration → rate-limited',
     },
     {
-      error: new RateLimitError('paused', { retryAfter: null }),
+      error: new RateLimitError('paused', {
+        retryAfter: null,
+        unblockAt: null,
+      }),
       expected: { kind: 'rate-limited', retryAfterMs: null } as const,
       label: 'RateLimitError with null Duration → rate-limited null',
     },

--- a/tests/unit/errors.test.ts
+++ b/tests/unit/errors.test.ts
@@ -1,4 +1,4 @@
-import { Duration } from 'luxon'
+import { DateTime, Duration } from 'luxon'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -36,27 +36,34 @@ describe.concurrent('apiError hierarchy', () => {
     expect(error.cause).toBe(cause)
   })
 
-  it('rateLimitError carries the retryAfter duration', () => {
+  it('rateLimitError carries the retryAfter duration and unblockAt time', () => {
     const retryAfter = Duration.fromObject({ seconds: 30 })
-    const error = new RateLimitError('throttled', { retryAfter })
+    const unblockAt = DateTime.fromISO('2026-01-01T12:30:00Z')
+    const error = new RateLimitError('throttled', { retryAfter, unblockAt })
 
     expect(error).toBeInstanceOf(RateLimitError)
     expect(error).toBeInstanceOf(APIError)
     expect(error.retryAfter?.as('seconds')).toBe(30)
+    expect(error.unblockAt?.toISO()).toBe(unblockAt.toISO())
     expect(error.name).toBe('RateLimitError')
   })
 
-  it('rateLimitError accepts null retryAfter when the window is unknown', () => {
-    const error = new RateLimitError('throttled', { retryAfter: null })
+  it('rateLimitError accepts null fields when the window is unknown', () => {
+    const error = new RateLimitError('throttled', {
+      retryAfter: null,
+      unblockAt: null,
+    })
 
     expect(error.retryAfter).toBeNull()
+    expect(error.unblockAt).toBeNull()
   })
 
-  it('rateLimitError preserves the cause alongside retryAfter', () => {
+  it('rateLimitError preserves the cause alongside its structured fields', () => {
     const cause = new Error('429')
     const error = new RateLimitError('throttled', {
       cause,
       retryAfter: null,
+      unblockAt: null,
     })
 
     expect(error.cause).toBe(cause)
@@ -80,7 +87,10 @@ describe.concurrent('apiError hierarchy', () => {
 describe.concurrent(isAPIError, () => {
   it.each([
     ['AuthenticationError', new AuthenticationError('x')],
-    ['RateLimitError', new RateLimitError('x', { retryAfter: null })],
+    [
+      'RateLimitError',
+      new RateLimitError('x', { retryAfter: null, unblockAt: null }),
+    ],
     ['NetworkError', new NetworkError('x')],
   ])('returns true for %s', (_name, error) => {
     expect(isAPIError(error)).toBe(true)
@@ -98,7 +108,10 @@ describe.concurrent(isAPIError, () => {
   })
 
   it('narrows the type so the subclass surface is accessible', () => {
-    const value: unknown = new RateLimitError('x', { retryAfter: null })
+    const value: unknown = new RateLimitError('x', {
+      retryAfter: null,
+      unblockAt: null,
+    })
     // Compile-time proof: `isAPIError` narrows `unknown` → `APIError`.
     const narrowed = isAPIError(value) ? value : null
 

--- a/tests/unit/rate-limit-gate.test.ts
+++ b/tests/unit/rate-limit-gate.test.ts
@@ -102,6 +102,28 @@ describe(RateLimitGate, () => {
     expect(gate.formatRemaining()).toBe('')
   })
 
+  it('snapshot() returns all fields consistently when paused', () => {
+    const gate = new RateLimitGate({ hours: 2 })
+    gate.recordRateLimit()
+
+    const snap = gate.snapshot()
+
+    expect(snap.isPaused).toBe(true)
+    expect(snap.remaining).not.toBeNull()
+    expect(snap.unblockAt).not.toBeNull()
+    expect(snap.unblockAt?.toUTC().toISO()).toBe('2026-04-11T14:00:00.000Z')
+  })
+
+  it('snapshot() returns all nulls when open', () => {
+    const gate = new RateLimitGate({ hours: 2 })
+
+    const snap = gate.snapshot()
+
+    expect(snap.isPaused).toBe(false)
+    expect(snap.remaining).toBeNull()
+    expect(snap.unblockAt).toBeNull()
+  })
+
   it('formatRemaining returns a human-readable duration when paused', () => {
     const gate = new RateLimitGate({ hours: 2 })
     gate.recordRateLimit(120)

--- a/tests/unit/rate-limit-gate.test.ts
+++ b/tests/unit/rate-limit-gate.test.ts
@@ -12,11 +12,12 @@ describe(RateLimitGate, () => {
     vi.useRealTimers()
   })
 
-  it('starts open with no remaining time', () => {
+  it('starts open with no remaining time and no unblockAt', () => {
     const gate = new RateLimitGate({ hours: 1 })
 
     expect(gate.isPaused).toBe(false)
     expect(gate.remaining).toBeNull()
+    expect(gate.unblockAt).toBeNull()
   })
 
   it('closes for the full fallback duration when no Retry-After is provided', () => {
@@ -28,6 +29,8 @@ describe(RateLimitGate, () => {
     // Use Luxon's millisecond conversion, accounting for slight drift.
     expect(gate.remaining?.as('hours')).toBeGreaterThan(1.9)
     expect(gate.remaining?.as('hours')).toBeLessThanOrEqual(2)
+    // Absolute unblock time is 2 hours after the fixed system time.
+    expect(gate.unblockAt?.toUTC().toISO()).toBe('2026-04-11T14:00:00.000Z')
   })
 
   it('honors a numeric Retry-After header (seconds)', () => {


### PR DESCRIPTION
Consumers (e.g. Homey drivers, UI shells) often need to render a localized, human-readable message like "try again at 14:30". The existing `retryAfter: Duration` gives the *relative* time left but forces every caller to re-anchor it against `DateTime.now()`. Expose the absolute moment directly:

- `RateLimitGate.unblockAt: DateTime | null` getter next to `remaining`.
- `RateLimitError.unblockAt: DateTime | null` carried alongside `retryAfter`.
- `RateLimitPolicy` forwards both fields when short-circuiting.

`cause` is left for the underlying HTTP error (ES2022 `Error.cause` convention); all metadata lives in typed fields so consumers can localize their own message without parsing strings.