### PR TITLE
Enable exactOptionalPropertyTypes

### DIFF
--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -87,13 +87,13 @@ interface BaseAPIConstructorOptions {
 export abstract class BaseAPI implements Disposable {
   public readonly logger: Logger
 
-  public readonly settingManager?: SettingManager
+  public readonly settingManager: SettingManager | undefined
 
   public get isRateLimited(): boolean {
     return this.rateLimitGate.isPaused
   }
 
-  protected readonly abortSignal?: AbortSignal
+  protected readonly abortSignal: AbortSignal | undefined
 
   protected readonly api: HttpClient
 

--- a/src/decorators/setting.ts
+++ b/src/decorators/setting.ts
@@ -1,7 +1,7 @@
 import type { SettingManager } from '../api/types.ts'
 
 interface HasSettingManager {
-  settingManager?: SettingManager
+  settingManager: SettingManager | undefined
 }
 
 /**

--- a/src/decorators/sync-devices.ts
+++ b/src/decorators/sync-devices.ts
@@ -36,6 +36,6 @@ export const syncDevices =
   ): ((...args: TArgs) => Promise<TResult>) =>
     async function newTarget(this: HasNotifySync, ...args: TArgs) {
       const data = await target.call(this, ...args)
-      await this.notifySync?.({ type })
+      await this.notifySync?.(type === undefined ? {} : { type })
       return data
     }

--- a/src/entities/classic-registry.ts
+++ b/src/entities/classic-registry.ts
@@ -266,9 +266,11 @@ export class ClassicRegistry {
   }
 
   public getZones({ type }: { type?: ClassicDeviceType } = {}): ClassicZone[] {
-    return [...flattenBuildings(this.getBuildings({ type }))].toSorted(
-      compareNames,
-    )
+    return [
+      ...flattenBuildings(
+        this.getBuildings(type === undefined ? {} : { type }),
+      ),
+    ].toSorted(compareNames)
   }
 
   public syncAreas(areas: ClassicAreaDataAny[]): void {

--- a/src/facades/classic-base-device.ts
+++ b/src/facades/classic-base-device.ts
@@ -241,11 +241,13 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
     query?: ReportQuery,
     shouldUseExactRange = true,
   ): Promise<ReportChartLineOptions> {
+    const location = this.registry.buildings.getById(
+      this.device.buildingId,
+    )?.location
     const { data } = await this.api.getTemperatures({
       postData: {
         ...this.#buildReportPostData(query, shouldUseExactRange),
-        Location: this.registry.buildings.getById(this.device.buildingId)
-          ?.location,
+        ...(location !== undefined && { Location: location }),
       },
     })
     return getChartLineOptions(data, this.temperaturesLegend, '°C')
@@ -276,16 +278,15 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
   }
 
   #buildReportPostData(
-    { from, to }: ReportQuery = {},
+    query: ReportQuery = {},
     shouldUseExactRange = false,
   ): ClassicReportPostData {
-    const { from: newFrom, to: newTo } = getReportPostDataDates({ from, to })
+    const { from: newFrom, to: newTo } = getReportPostDataDates(query)
     return {
       DeviceID: this.id,
-      Duration:
-        shouldUseExactRange ?
-          getDuration({ from: newFrom, to: newTo })
-        : undefined,
+      ...(shouldUseExactRange && {
+        Duration: getDuration({ from: newFrom, to: newTo }),
+      }),
       FromDate: newFrom,
       ToDate: newTo,
     }

--- a/src/facades/classic-base.ts
+++ b/src/facades/classic-base.ts
@@ -291,7 +291,8 @@ export abstract class BaseFacade<
   public async notifySync({
     type,
   }: { type?: ClassicDeviceType } = {}): Promise<void> {
-    await this.api.notifySync({ ids: this.#deviceIds, type })
+    const ids = this.#deviceIds
+    await this.api.notifySync(type === undefined ? { ids } : { ids, type })
   }
 
   async #getBaseFrostProtection(

--- a/src/facades/classic-device-atw-dual-zone.ts
+++ b/src/facades/classic-device-atw-dual-zone.ts
@@ -78,7 +78,7 @@ export class ClassicDeviceAtwHasZone2Facade extends ClassicDeviceAtwFacade {
   ): ClassicOperationModeZoneDataAtw | null {
     const [operationModeZone1, operationModeZone2]: {
       key: keyof ClassicOperationModeZoneDataAtw
-      value?: ClassicOperationModeZone
+      value: ClassicOperationModeZone | undefined
     }[] = [
       { key: 'OperationModeZone1', value: data.OperationModeZone1 },
       { key: 'OperationModeZone2', value: data.OperationModeZone2 },

--- a/src/http/client.ts
+++ b/src/http/client.ts
@@ -183,7 +183,7 @@ export class HttpClient {
 
   readonly #defaultHeaders: Record<string, string>
 
-  readonly #dispatcher?: FetchDispatcher
+  readonly #dispatcher: FetchDispatcher | undefined
 
   public constructor({
     baseURL,
@@ -218,8 +218,8 @@ export class HttpClient {
             ...config.headers,
           },
           method: config.method ?? 'GET',
-          params: config.params,
-          url: config.url,
+          ...(config.params !== undefined && { params: config.params }),
+          ...(config.url !== undefined && { url: config.url }),
         },
       )
     }
@@ -256,8 +256,9 @@ export class HttpClient {
       ...this.#defaultHeaders,
       ...headers,
     }
+    const body = serializeBody(data, mergedHeaders)
     const init: FetchInit = {
-      body: serializeBody(data, mergedHeaders),
+      ...(body !== undefined && { body }),
       headers: mergedHeaders,
       method: method.toUpperCase(),
     }

--- a/src/http/errors.ts
+++ b/src/http/errors.ts
@@ -15,7 +15,7 @@ export interface HttpErrorRequestConfig {
  * does not need to branch on the error's origin.
  */
 export class HttpError<T = unknown> extends Error {
-  public readonly config?: HttpErrorRequestConfig
+  public readonly config: HttpErrorRequestConfig | undefined
 
   public readonly isHttpError = true
 

--- a/src/observability/context.ts
+++ b/src/observability/context.ts
@@ -88,11 +88,11 @@ const redactValue = (value: unknown): unknown => {
 export abstract class APICallLogData {
   declare public readonly dataType: string
 
-  public readonly method?: string
+  public readonly method: string | undefined
 
   public readonly params: unknown
 
-  public readonly url?: string
+  public readonly url: string | undefined
 
   protected constructor(config?: LoggableRequestConfig) {
     this.method = config?.method?.toUpperCase()

--- a/src/observability/events-emitter.ts
+++ b/src/observability/events-emitter.ts
@@ -16,7 +16,7 @@ import type {
  * blocker.
  */
 export class LifecycleEmitter {
-  readonly #events?: LifecycleEvents
+  readonly #events: LifecycleEvents | undefined
 
   readonly #logger: Logger
 

--- a/src/observability/response.ts
+++ b/src/observability/response.ts
@@ -11,7 +11,7 @@ export class APICallResponseData extends APICallLogData {
 
   public readonly responseData: unknown
 
-  public readonly status?: number
+  public readonly status: number | undefined
 
   public constructor(
     response?: HttpResponse,

--- a/src/resilience/disposable-timeout.ts
+++ b/src/resilience/disposable-timeout.ts
@@ -8,7 +8,7 @@ export class DisposableTimeout implements Disposable {
     return this.#timeout !== undefined
   }
 
-  #timeout?: ReturnType<typeof setTimeout>
+  #timeout: ReturnType<typeof setTimeout> | undefined
 
   /** Cancel the current timeout if one is active. */
   public clear(): void {

--- a/src/resilience/transient-retry-policy.ts
+++ b/src/resilience/transient-retry-policy.ts
@@ -39,7 +39,7 @@ export class TransientRetryPolicy implements ResiliencePolicy {
       ...DEFAULT_TRANSIENT_RETRY_OPTIONS,
       isRetryable: isTransientServerError,
       onRetry: this.#telemetry.onRetry,
-      signal: this.#signal,
+      ...(this.#signal !== undefined && { signal: this.#signal }),
     })
   }
 }

--- a/src/types/home.ts
+++ b/src/types/home.ts
@@ -74,11 +74,6 @@ export interface HomeDeviceSetting {
 
 export interface HomeEnergyData {
   readonly measureData: HomeEnergyMeasure[]
-  // `?: T | undefined` (rather than `?: T`) because Zod's `.optional()`
-  // produces `T | undefined` in the inferred output. Under
-  // `exactOptionalPropertyTypes` the two are no longer interchangeable,
-  // so the schema-bound interface must permit explicit `undefined` for
-  // the parsed value to satisfy this contract.
   readonly deviceId?: string | undefined
 }
 

--- a/src/types/home.ts
+++ b/src/types/home.ts
@@ -74,13 +74,18 @@ export interface HomeDeviceSetting {
 
 export interface HomeEnergyData {
   readonly measureData: HomeEnergyMeasure[]
-  readonly deviceId?: string
+  // `?: T | undefined` (rather than `?: T`) because Zod's `.optional()`
+  // produces `T | undefined` in the inferred output. Under
+  // `exactOptionalPropertyTypes` the two are no longer interchangeable,
+  // so the schema-bound interface must permit explicit `undefined` for
+  // the parsed value to satisfy this contract.
+  readonly deviceId?: string | undefined
 }
 
 export interface HomeEnergyMeasure {
   readonly type: string
   readonly values: HomeEnergyPoint[]
-  readonly deviceId?: string
+  readonly deviceId?: string | undefined
 }
 
 export interface HomeEnergyPoint {
@@ -115,8 +120,8 @@ export interface HomeTokenResponse {
   readonly expires_in: number
   readonly scope: string
   readonly token_type: 'Bearer'
-  readonly id_token?: string
-  readonly refresh_token?: string
+  readonly id_token?: string | undefined
+  readonly refresh_token?: string | undefined
 }
 
 export interface HomeUser {

--- a/tests/unit/base-api.test.ts
+++ b/tests/unit/base-api.test.ts
@@ -679,7 +679,7 @@ describe('baseAPI shared request pipeline', () => {
         logger,
       })
 
-      await expect(api.notifySync({ type: undefined })).resolves.toBeUndefined()
+      await expect(api.notifySync({})).resolves.toBeUndefined()
       expect(logger.error).toHaveBeenCalledWith(
         expect.stringContaining('onSyncComplete'),
         expect.any(Error),
@@ -698,7 +698,7 @@ describe('baseAPI shared request pipeline', () => {
         logger,
       })
 
-      await api.notifySync({ type: undefined })
+      await api.notifySync({})
       // The emitter chains `.catch(...)` onto the rejected promise — give
       // the microtask a turn before asserting the log fired.
       await Promise.resolve()

--- a/tests/unit/classic-api.test.ts
+++ b/tests/unit/classic-api.test.ts
@@ -155,9 +155,9 @@ describe('mELCloud Classic API', () => {
     })
 
     onSyncComplete.mockClear()
-    await api.notifySync({ type: undefined })
+    await api.notifySync({})
 
-    expect(onSyncComplete).toHaveBeenCalledWith({ type: undefined })
+    expect(onSyncComplete).toHaveBeenCalledWith({})
   })
 
   it('accepts a disabled sync timer', async () => {

--- a/tests/unit/http-client.test.ts
+++ b/tests/unit/http-client.test.ts
@@ -186,12 +186,13 @@ describe(HttpClient, () => {
     const promise = createClient().request({
       data: { key: 1 },
       method: 'POST',
+      params: { tag: 'a' },
       url: '/x',
     })
 
     await expect(promise).rejects.toThrow(HttpError)
     await expect(promise).rejects.toMatchObject({
-      config: { method: 'POST', url: '/x' },
+      config: { method: 'POST', params: { tag: 'a' }, url: '/x' },
       isHttpError: true,
       response: {
         data: { err: 'denied' },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "declarationMap": true,
     "erasableSyntaxOnly": true,
+    "exactOptionalPropertyTypes": true,
     "isolatedDeclarations": true,
     "lib": ["ESNext"],
     "libReplacement": false,


### PR DESCRIPTION
## Summary

Activates `exactOptionalPropertyTypes` in `tsconfig.json` and fixes the 26 resulting errors across 16 files. This aligns the project with the rest of its strict-flag opt-ins (`noUncheckedIndexedAccess`, `noPropertyAccessFromIndexSignature`, `isolatedDeclarations`, `verbatimModuleSyntax`) and surfaces a distinction the SDK already cares about at runtime: *property absent* vs *property explicitly set to `undefined`*.

## Approach per call site

- **Class fields** that are always allocated but conditionally initialized (`settingManager`, `abortSignal`, `#dispatcher`, `#events`, `#timeout`, `status`, `method`, `url`, `config`) declare `T | undefined` instead of `?: T`. The slot is always present; only the value may be undefined. `HasSettingManager` (the decorator's structural constraint) follows the same pattern.
- **Function call sites** building objects from possibly-undefined locals use conditional spreads (`...(v !== undefined && { k: v })`) so the key only appears when the value is defined — instead of producing `{ k: undefined }` and tripping the new check.
- **Zod-bound schema interfaces** (`HomeTokenResponse`, `HomeEnergyData`, `HomeEnergyMeasure`) use `?: T | undefined` because Zod's `.optional()` produces `T | undefined` in the inferred output, which is no longer assignable to a bare `?: T`.
- **Tests** that called `notifySync({ type: undefined })` switch to `notifySync({})` — the type system now forbids the explicit-undefined form.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm test` — 641/641 passing
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm run format` — clean

https://claude.ai/code/session_01UfUN4eG1Todr4HxNapqy2K

---
_Generated by [Claude Code](https://claude.ai/code/session_01UfUN4eG1Todr4HxNapqy2K)_