### PR TITLE
38.0.1: expose Result types on root + commit .npmrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ node_modules/
 .env
 .env.*
 !.env.example
-/.npmrc
 /.vscode/*
 !/.vscode/settings.json
 /coverage/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+@olivierzal:registry=https://npm.pkg.github.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [38.0.1] - 2026-05-01
+
+### Fixed
+
+- **Root export of `Result`, `Failure`, `Success`, `ApiRequestError` types and `ok`, `err`, `mapResult` runtime helpers.** Documented in the README's _Error handling_ section but missing from `dist/index.d.ts` in `38.0.0`, so consumers couldn't type their own helpers around `Result<T>` (the discriminated narrowing on `result.ok` worked, but explicit `Result<T>` annotations did not).
+- `.npmrc` is now committed (was `.gitignore`'d). The token reference (`${NODE_AUTH_TOKEN}`) is interpolated at runtime so no secret is exposed; the file just describes the registry binding — committing it removes the friction of recreating it on every fresh clone and aligns this repo with `com.melcloud`'s setup.
+- `README.md`: harmonised the documented env var on `NODE_AUTH_TOKEN` (was `GITHUB_TOKEN`) to match the committed `.npmrc` and the publish workflow.
+
 ## [38.0.0] - 2026-04-30
 
 ### Breaking
@@ -86,5 +94,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
-[Unreleased]: https://github.com/OlivierZal/melcloud-api/compare/38.0.0...HEAD
+[Unreleased]: https://github.com/OlivierZal/melcloud-api/compare/38.0.1...HEAD
+[38.0.1]: https://github.com/OlivierZal/melcloud-api/compare/38.0.0...38.0.1
 [38.0.0]: https://github.com/OlivierZal/melcloud-api/compare/37.2.1...38.0.0

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ A typed Node.js client for the [MELCloud](https://app.melcloud.com/) and [MELClo
 This package is published to **GitHub Packages**, not the public npm registry. Configure your project so npm fetches the `@olivierzal` scope from GitHub:
 
 ```ini title=".npmrc"
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
 @olivierzal:registry=https://npm.pkg.github.com
 ```
 
-`GITHUB_TOKEN` must be a GitHub personal access token with the `read:packages` scope (export it in your shell or set it in your CI environment). Then:
+`NODE_AUTH_TOKEN` must be a GitHub personal access token with the `read:packages` scope (export it in your shell or set it in your CI environment). Then:
 
 ```sh title="install"
 npm install @olivierzal/melcloud-api

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "38.0.0",
+  "version": "38.0.1",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export type {
+  ApiRequestError,
   ClassicAreaData,
   ClassicAreaDataAny,
   ClassicAreaID,
@@ -70,6 +71,7 @@ export type {
   ClassicZoneAtw,
   ClassicZoneSettings,
   ClassicZoneState,
+  Failure,
   HomeAtaValues,
   HomeBuilding,
   HomeClaim,
@@ -88,6 +90,8 @@ export type {
   Hour,
   KeyOfClassicSetDeviceDataAtaNotInList,
   LoginCredentials,
+  Result,
+  Success,
 } from './types/index.ts'
 
 export {
@@ -207,3 +211,4 @@ export {
   HttpError,
   isHttpError,
 } from './http/index.ts'
+export { err, mapResult, ok } from './types/index.ts'


### PR DESCRIPTION
## Summary

- Expose `Result`, `Failure`, `Success`, `ApiRequestError` types and `ok`, `err`, `mapResult` runtime helpers on the root export — they are documented in the README's _Error handling_ section but were missing from `dist/index.d.ts` in 38.0.0, so consumers could not type their own helpers around `Result<T>`.
- Commit `.npmrc` and remove from `.gitignore`. The `${NODE_AUTH_TOKEN}` reference is interpolated at runtime so no secret is exposed; committing aligns this repo with `com.melcloud`'s setup and removes fresh-clone friction.
- Harmonise the README installation example on `NODE_AUTH_TOKEN` (was `GITHUB_TOKEN`) to match the committed `.npmrc` and the publish workflow.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 648/648 pass
- [x] `dist/index.d.ts` (after publish) will expose `Result`, `ApiRequestError`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)