### PR TITLE
ci(claude): don't cancel in-progress @claude requests

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,5 +1,5 @@
 concurrency:
-  cancel-in-progress: true
+  cancel-in-progress: false
   group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
 jobs:
   claude:


### PR DESCRIPTION
## Contexte

Deux runs Claude Actions ont échoué pour des raisons différentes :

1. **[melcloud-api #25190591871](https://github.com/OlivierZal/melcloud-api/actions/runs/25190591871/job/73859328289)** (PR #1487, job `Review`) — `Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch.`
   - Cause : la branche de PR #1487 a été synchronisée *avant* d'avoir mergé `main` après PR #1486 (qui introduisait les workflows Claude). `claude-code-action` valide par sécurité que le workflow sur la PR est identique à celui de `main`, donc l'absence de fichier sur la branche provoque l'échec.
   - Correctif : non corrigeable au niveau du workflow (c'est une garantie anti-injection de l'action). Il suffit de rebaser/merger `main` dans la branche concernée.

2. **[com.melcloud #25195209375](https://github.com/OlivierZal/com.melcloud/actions/runs/25195209375/job/73874138721)** (issue #1294, job `Claude`) — `Canceling since a higher priority waiting request for claude-<n> exists`
   - Cause : `cancel-in-progress: true` dans `claude.yml`. Plusieurs `@claude` rapprochés (commentaires successifs, commentaire pendant une review en cours, etc.) annulent la run en cours.
   - Correctif : passer à `cancel-in-progress: false` pour que les requêtes se mettent en file d'attente au lieu de s'annuler mutuellement.

## Changement

Un seul fichier : `.github/workflows/claude.yml`, `cancel-in-progress: true` → `false`.

`claude-code-review.yml` reste sur `true` : pour les reviews déclenchées par un nouveau push, on veut bien annuler la review du SHA précédent.

## Note

Ce correctif est à porter manuellement sur les autres repos qui partagent la même config (notamment `com.melcloud`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01TFmZ8EZnY8xpfyHSJQ8s5n)_