### PR TITLE
ci(claude): drop concurrency block to match upstream template

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,6 +1,3 @@
-concurrency:
-  cancel-in-progress: true
-  group: claude-review-${{ github.event.pull_request.number }}
 jobs:
   review:
     if: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,3 @@
-concurrency:
-  cancel-in-progress: true
-  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
 jobs:
   claude:
     if: |


### PR DESCRIPTION
## Contexte

Le bloc `concurrency:` dans `claude.yml` et `claude-code-review.yml` a été ajouté par l'assistant `/install-github-app` mais n'existe **pas** dans les templates upstream :
- [`anthropics/claude-code-action/examples/claude.yml`](https://github.com/anthropics/claude-code-action/blob/main/examples/claude.yml) — pas de `concurrency:`
- [`anthropics/claude-code-action/examples/pr-review-comprehensive.yml`](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml) — pas de `concurrency:`

## Problème observé

Avec `group: claude-${pr_number}` partagé entre tous les triggers et `cancel-in-progress: true`, des runs de bots tiers (Copilot review, etc.) bloqués en "Awaiting approval" squattent le concurrency group et annulent les `@claude` légitimes avec :

```
Canceling since a higher priority waiting request for claude-<n> exists
```

Ex : [com.melcloud run #25195209375](https://github.com/OlivierZal/com.melcloud/actions/runs/25195209375).

## Fix

Suppression du bloc `concurrency:` dans les deux workflows pour s'aligner sur le template upstream. Identique à [OlivierZal/com.melcloud#1295](https://github.com/OlivierZal/com.melcloud/pull/1295).

## Note

Remplace #1489 (qui appliquait `cancel-in-progress: false`, fix incomplet et hors-template).


---
_Generated by [Claude Code](https://claude.ai/code/session_01TFmZ8EZnY8xpfyHSJQ8s5n)_