### PR TITLE
docs(readme): fix node badge auth and bust docs-coverage cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 A typed Node.js client for the [MELCloud](https://app.melcloud.com/) and [MELCloud Home](https://melcloudhome.com/) APIs, providing access to Mitsubishi Electric air-to-air (Ata), air-to-water (Atw) and energy recovery ventilation (Erv) devices.
 
 [![License](https://img.shields.io/github/license/OlivierZal/melcloud-api)](LICENSE)
-[![Node](https://img.shields.io/node/v/@olivierzal/melcloud-api?registry_uri=https%3A%2F%2Fnpm.pkg.github.com)](package.json)
+[![Node](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2FOlivierZal%2Fmelcloud-api%2Fmain%2Fpackage.json&query=%24.engines.node&label=node&color=brightgreen)](package.json)
 [![GitHub release](https://img.shields.io/github/v/release/OlivierZal/melcloud-api?sort=semver)](https://github.com/OlivierZal/melcloud-api/releases)
 [![CI](https://img.shields.io/github/actions/workflow/status/OlivierZal/melcloud-api/ci.yml?branch=main&label=CI)](https://github.com/OlivierZal/melcloud-api/actions/workflows/ci.yml)
 
@@ -10,7 +10,7 @@ A typed Node.js client for the [MELCloud](https://app.melcloud.com/) and [MELClo
 [![Maintainability](https://sonarcloud.io/api/project_badges/measure?project=OlivierZal_melcloud-api&metric=sqale_rating)](https://sonarcloud.io/component_measures?id=OlivierZal_melcloud-api&metric=Maintainability)
 [![Security](https://sonarcloud.io/api/project_badges/measure?project=OlivierZal_melcloud-api&metric=security_rating)](https://sonarcloud.io/component_measures?id=OlivierZal_melcloud-api&metric=Security)
 [![Test coverage](https://sonarcloud.io/api/project_badges/measure?project=OlivierZal_melcloud-api&metric=coverage)](https://sonarcloud.io/component_measures?id=OlivierZal_melcloud-api&metric=coverage)
-[![Docs coverage](https://olivierzal.github.io/melcloud-api/coverage.svg)](https://olivierzal.github.io/melcloud-api/)
+[![Docs coverage](https://olivierzal.github.io/melcloud-api/coverage.svg?v=2)](https://olivierzal.github.io/melcloud-api/)
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Two README badge fixes:

1. **Node badge** showed "invalid". The shields.io `node/v/<package>` endpoint queries an npm registry for `engines.node`, but cannot authenticate to GitHub Packages (the `registry_uri` override doesn't help — shields.io has no auth). Switched to a generic `dynamic/json` badge that pulls `engines.node` directly from the public `raw.githubusercontent.com` mirror of `package.json`. Always works, no auth.

2. **Docs coverage badge** still rendered as a broken-image `?` after the docs deploy. GitHub's Camo image proxy caches by URL; it likely cached the old 404 from before `coverage.svg` existed. Appending `?v=2` makes Camo treat it as a fresh URL and refetch.

## If the docs coverage badge still doesn't render after this merge

The Camo cache-bust only helps if the file is actually deployed. Things to verify on `OlivierZal/melcloud-api`:

- **Settings → Pages**: Source must be `GitHub Actions` (not "Deploy from a branch"). The `docs.yml` workflow uses `actions/deploy-pages` which only works with the Actions source.
- **Actions → Generate & deploy docs**: latest run on `main` should be green for both the `Build docs` and `Deploy docs` jobs.
- Visit `https://olivierzal.github.io/melcloud-api/coverage.svg` directly — must return an SVG, not a 404.

## Test plan

- [ ] After merge, README on the repo home page renders the Node badge with `>=22` (green) instead of "invalid".
- [ ] Docs coverage badge resolves to the 100% SVG (or surfaces the real underlying issue if the deploy itself failed).


---
_Generated by [Claude Code](https://claude.ai/code/session_01VFuTUdGPm5fJbUfckNU5Rn)_