### PR TITLE
refactor(api): symmetric Adapter contract for Home and Classic

### DIFF
--- a/src/api/home-types.ts
+++ b/src/api/home-types.ts
@@ -14,15 +14,16 @@ import type { BaseAPIConfig } from './types.ts'
 /**
  * Injectable contract for the MELCloud Home API client.
  *
- * Exists alongside the `HomeAPI` class with the same name (declaration
- * merging). This interface uses property-with-arrow syntax so facades,
- * mocks, and tests can reference methods safely (`expect(api.updateValues)`,
- * `mock<HomeAPI>({...})`) without triggering `unbound-method` lint —
- * the class has real methods that carry `this`, whereas the interface
- * shape declares them as plain functions with no implicit binding.
- * @internal
+ * Mirrors the public surface of the {@link HomeAPI} class with
+ * property-with-arrow syntax so facades, mocks, and tests can
+ * reference methods safely (`expect(api.updateValues)`,
+ * `mock<HomeAPIAdapter>({...})`) without triggering `unbound-method`
+ * lint — the class has real methods that carry `this`, whereas this
+ * interface declares them as plain functions with no implicit
+ * binding.
+ * @category Configuration
  */
-export interface HomeAPI {
+export interface HomeAPIAdapter {
   /**
    * Whether the upstream rate-limit gate is currently holding a pause
    * window. `true` means the SDK is intentionally failing fast to

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -23,7 +23,7 @@ import {
   HomeErrorLogEntryListSchema,
   HomeReportDataSchema,
 } from '../validation/index.ts'
-import type { HomeAPIConfig, HomeAPI as HomeAPIContract } from './home-types.ts'
+import type { HomeAPIAdapter, HomeAPIConfig } from './home-types.ts'
 import { BaseAPI, normalizeUnauthorized } from './base.ts'
 import { performTokenAuth, refreshAccessToken } from './token-auth.ts'
 
@@ -72,7 +72,7 @@ const toTelemetryDate = (iso: string): string =>
  * Uses a private constructor — create instances via {@link HomeAPI.create}.
  * @category API Clients
  */
-export class HomeAPI extends BaseAPI implements HomeAPIContract {
+export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
   /**
    * Latest `/context` payload from the BFF, or `null` before the
    * first successful call. Populated by {@link authenticate} and

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,7 +6,11 @@ export type {
   ClassicErrorLog,
   ClassicErrorLogQuery,
 } from './classic-types.ts'
-export type { HomeAPIConfig, HomeAPISettings } from './home-types.ts'
+export type {
+  HomeAPIAdapter,
+  HomeAPIConfig,
+  HomeAPISettings,
+} from './home-types.ts'
 export type {
   BaseAPIConfig,
   LifecycleEvents,

--- a/src/facades/home-device-ata.ts
+++ b/src/facades/home-device-ata.ts
@@ -1,4 +1,4 @@
-import type { HomeAPI } from '../api/home-types.ts'
+import type { HomeAPIAdapter } from '../api/home-types.ts'
 import type { HomeDevice } from '../entities/home-device.ts'
 import type {
   HomeAtaValues,
@@ -162,7 +162,7 @@ export class HomeDeviceAtaFacade {
     return this.#setting('VaneVerticalDirection')
   }
 
-  readonly #api: HomeAPI
+  readonly #api: HomeAPIAdapter
 
   readonly #model: HomeDevice
 
@@ -172,7 +172,7 @@ export class HomeDeviceAtaFacade {
    * @param api - Home API client.
    * @param model - Backing device model.
    */
-  public constructor(api: HomeAPI, model: HomeDevice) {
+  public constructor(api: HomeAPIAdapter, model: HomeDevice) {
     this.#api = api
     this.#model = model
   }

--- a/src/facades/home-device-ata.ts
+++ b/src/facades/home-device-ata.ts
@@ -1,4 +1,4 @@
-import type { HomeAPIAdapter } from '../api/home-types.ts'
+import type { HomeAPIAdapter } from '../api/index.ts'
 import type { HomeDevice } from '../entities/home-device.ts'
 import type {
   HomeAtaValues,

--- a/src/facades/home-manager.ts
+++ b/src/facades/home-manager.ts
@@ -1,4 +1,4 @@
-import type { HomeAPI } from '../api/home-types.ts'
+import type { HomeAPIAdapter } from '../api/home-types.ts'
 import type { HomeDevice } from '../entities/home-device.ts'
 import { HomeDeviceAtaFacade } from './home-device-ata.ts'
 
@@ -8,7 +8,7 @@ import { HomeDeviceAtaFacade } from './home-device-ata.ts'
  * @category Facades
  */
 export class HomeFacadeManager {
-  readonly #api: HomeAPI
+  readonly #api: HomeAPIAdapter
 
   readonly #facades = new WeakMap<HomeDevice, HomeDeviceAtaFacade>()
 
@@ -17,7 +17,7 @@ export class HomeFacadeManager {
    * it returns share this reference.
    * @param api - Home API client.
    */
-  public constructor(api: HomeAPI) {
+  public constructor(api: HomeAPIAdapter) {
     this.#api = api
   }
 

--- a/src/facades/home-manager.ts
+++ b/src/facades/home-manager.ts
@@ -1,4 +1,4 @@
-import type { HomeAPIAdapter } from '../api/home-types.ts'
+import type { HomeAPIAdapter } from '../api/index.ts'
 import type { HomeDevice } from '../entities/home-device.ts'
 import { HomeDeviceAtaFacade } from './home-device-ata.ts'
 

--- a/src/home.ts
+++ b/src/home.ts
@@ -5,6 +5,7 @@
  * as `home.API`, `home.Device`, `home.DeviceType`, etc.
  */
 export {
+  type HomeAPIAdapter as APIAdapter,
   type HomeAPIConfig as APIConfig,
   type HomeAPISettings as APISettings,
   type HomeAtaValues as AtaValues,

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,7 @@ export {
   type ClassicErrorDetails,
   type ClassicErrorLog,
   type ClassicErrorLogQuery,
+  type HomeAPIAdapter,
   type HomeAPIConfig,
   type HomeAPISettings,
   type LifecycleEvents,

--- a/tests/unit/home-device-ata-facade.test.ts
+++ b/tests/unit/home-device-ata-facade.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import type { HomeAPI } from '../../src/api/home-types.ts'
+import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
 import type { HomeDeviceCapabilities } from '../../src/types/index.ts'
 import { NoChangesError } from '../../src/errors/index.ts'
 import { HomeDeviceAtaFacade } from '../../src/facades/home-device-ata.ts'
@@ -20,13 +20,13 @@ const createModel = (
     settings,
   })
 
-const createApi = (): HomeAPI =>
-  mock<HomeAPI>({
-    getEnergy: vi.fn<HomeAPI['getEnergy']>(),
-    getErrorLog: vi.fn<HomeAPI['getErrorLog']>(),
-    getSignal: vi.fn<HomeAPI['getSignal']>(),
-    getTemperatures: vi.fn<HomeAPI['getTemperatures']>(),
-    updateValues: vi.fn<HomeAPI['updateValues']>().mockResolvedValue(true),
+const createApi = (): HomeAPIAdapter =>
+  mock<HomeAPIAdapter>({
+    getEnergy: vi.fn<HomeAPIAdapter['getEnergy']>(),
+    getErrorLog: vi.fn<HomeAPIAdapter['getErrorLog']>(),
+    getSignal: vi.fn<HomeAPIAdapter['getSignal']>(),
+    getTemperatures: vi.fn<HomeAPIAdapter['getTemperatures']>(),
+    updateValues: vi.fn<HomeAPIAdapter['updateValues']>().mockResolvedValue(true),
   })
 
 describe('home device ata facade', () => {

--- a/tests/unit/home-device-ata-facade.test.ts
+++ b/tests/unit/home-device-ata-facade.test.ts
@@ -26,7 +26,9 @@ const createApi = (): HomeAPIAdapter =>
     getErrorLog: vi.fn<HomeAPIAdapter['getErrorLog']>(),
     getSignal: vi.fn<HomeAPIAdapter['getSignal']>(),
     getTemperatures: vi.fn<HomeAPIAdapter['getTemperatures']>(),
-    updateValues: vi.fn<HomeAPIAdapter['updateValues']>().mockResolvedValue(true),
+    updateValues: vi
+      .fn<HomeAPIAdapter['updateValues']>()
+      .mockResolvedValue(true),
   })
 
 describe('home device ata facade', () => {

--- a/tests/unit/home-facade-manager.test.ts
+++ b/tests/unit/home-facade-manager.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import type { HomeAPI } from '../../src/api/home-types.ts'
+import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
 import { HomeDeviceAtaFacade } from '../../src/facades/home-device-ata.ts'
 import { HomeFacadeManager } from '../../src/facades/home-manager.ts'
 import { mock } from '../helpers.ts'
@@ -9,13 +9,13 @@ import { homeDevice } from '../home-fixtures.ts'
 const createModel = (): ReturnType<typeof homeDevice> =>
   homeDevice({ id: 'device-1', name: 'Test ClassicDevice' })
 
-const createApi = (): HomeAPI =>
-  mock<HomeAPI>({
-    getEnergy: vi.fn<HomeAPI['getEnergy']>(),
-    getErrorLog: vi.fn<HomeAPI['getErrorLog']>(),
-    getSignal: vi.fn<HomeAPI['getSignal']>(),
-    getTemperatures: vi.fn<HomeAPI['getTemperatures']>(),
-    updateValues: vi.fn<HomeAPI['updateValues']>(),
+const createApi = (): HomeAPIAdapter =>
+  mock<HomeAPIAdapter>({
+    getEnergy: vi.fn<HomeAPIAdapter['getEnergy']>(),
+    getErrorLog: vi.fn<HomeAPIAdapter['getErrorLog']>(),
+    getSignal: vi.fn<HomeAPIAdapter['getSignal']>(),
+    getTemperatures: vi.fn<HomeAPIAdapter['getTemperatures']>(),
+    updateValues: vi.fn<HomeAPIAdapter['updateValues']>(),
   })
 
 describe('home facade manager', () => {

--- a/typedoc.config.js
+++ b/typedoc.config.js
@@ -37,15 +37,12 @@ const config = {
     'TransportConfig',
     'TypedHomeDeviceData',
     'UpdatePatchKind',
-    // Declaration-merged interfaces sharing a name with their public
+    // Facade declaration-merged interfaces sharing a name with their
     // class. The class side carries the public surface; TypeDoc sees
     // the interface as a separate symbol and would warn otherwise.
-    // No symmetric Classic entry: `ClassicAPI` implements the
-    // differently-named `ClassicAPIAdapter`, so no merge happens.
     'ClassicBuildingFacade',
     'ClassicDeviceAtwFacade',
     'ClassicDeviceAtwHasZone2Facade',
-    'HomeAPI',
   ],
   markdownLinkExternal: true,
   name: 'MELCloud & MELCloud Home API for Node.js',


### PR DESCRIPTION
> Stacked on top of #1493. Rebase onto `main` once #1493 merges; the diff against `main` then becomes only the 9 files in this PR.

## Summary

Drops the cross-file declaration merging on the Home API side and aligns it with the Classic-side `Adapter` convention.

**Before**
```ts
// home-types.ts
export interface HomeAPI { ... }

// home.ts
import type { HomeAPI as HomeAPIContract } from './home-types.ts'
export class HomeAPI extends BaseAPI implements HomeAPIContract { ... }
```

**After**
```ts
// home-types.ts
export interface HomeAPIAdapter { ... }

// home.ts
import type { HomeAPIAdapter } from './home-types.ts'
export class HomeAPI extends BaseAPI implements HomeAPIAdapter { ... }
```

Symmetric with the existing `class ClassicAPI implements ClassicAPIAdapter`.

## Why

- **Cross-file declaration merging is discouraged** by the Google TS Style Guide and most internal TS style guides. It's a niche TypeScript feature designed for extending built-ins (`Window`, `Array`, etc.), not for application code.
- **Tooling clarity**: TypeDoc, IDEs, refactor tools all see the merged symbols as separate. The previous setup forced a `intentionallyNotExported: ['HomeAPI', ...]` entry to silence a warning.
- **Symmetry**: the API adapters now follow one convention. New contributors don't have to wonder why one side uses same-name merging and the other doesn't.
- **Explicit naming**: `HomeAPIAdapter` tells consumers this is the typing contract, not the runtime class.

## Files

- `src/api/home-types.ts` — rename `interface HomeAPI` → `HomeAPIAdapter`, update doc.
- `src/api/home.ts` — drop the `as HomeAPIContract` import alias.
- `src/api/index.ts` — re-export `HomeAPIAdapter` (was internal-only).
- `src/index.ts` — re-export `HomeAPIAdapter` from the public root barrel (matches `ClassicAPIAdapter`).
- `src/facades/home-device-ata.ts`, `src/facades/home-manager.ts` — type imports.
- `tests/unit/home-device-ata-facade.test.ts`, `tests/unit/home-facade-manager.test.ts` — `mock<HomeAPI>` → `mock<HomeAPIAdapter>`.
- `typedoc.config.js` — drop `'HomeAPI'` from `intentionallyNotExported` (interface no longer exists under that name).

## Breaking change for typings

Consumers writing `mock<HomeAPI>({...})` (or any other type-position usage of the merged interface) need to switch to `mock<HomeAPIAdapter>({...})`. The runtime class import `import { HomeAPI } from '@olivierzal/melcloud-api'` is unchanged.

This matches the existing pattern: `mock<ClassicAPIAdapter>({...})` on the Classic side. Worth flagging in the next major version's CHANGELOG.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — clean (was 62 errors mid-refactor before tests/* were updated)
- [x] `npm test` — 33 files / 648 tests
- [x] `npm run docs` — clean with `treatValidationWarningsAsErrors: true`


---
_Generated by [Claude Code](https://claude.ai/code/session_01VFuTUdGPm5fJbUfckNU5Rn)_