### PR TITLE
fix(validation): accept ATW capability shapes in Home /context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "38.0.1",
+  "version": "38.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "38.0.1",
+      "version": "38.0.2",
       "license": "MIT",
       "dependencies": {
         "luxon": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "38.0.1",
+  "version": "38.0.2",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -53,24 +53,16 @@ const HomeDeviceSettingSchema = z.looseObject({
   value: z.string(),
 })
 
-const HomeDeviceCapabilitiesSchema = z.looseObject({
-  hasAirDirection: z.boolean(),
-  hasAutomaticFanSpeed: z.boolean(),
-  hasAutoOperationMode: z.boolean(),
-  hasCoolOperationMode: z.boolean(),
-  hasDryOperationMode: z.boolean(),
-  hasHalfDegreeIncrements: z.boolean(),
-  hasHeatOperationMode: z.boolean(),
-  hasSwing: z.boolean(),
-  maxTempAutomatic: z.number(),
-  maxTempCoolDry: z.number(),
-  maxTempHeat: z.number(),
-  minTempAutomatic: z.number(),
-  minTempCoolDry: z.number(),
-  minTempHeat: z.number(),
-  numberOfFanSpeeds: z.number(),
-})
-
+// `capabilities` is structurally disjoint between ATA and ATW; strict
+// validation here would reject `/context` for any mixed-fleet account.
+// The cast keeps `HomeContextSchema` assignable to `z.ZodType<HomeContext>`
+// without narrowing the public type — only the ATA facade reads these
+// fields, and only for ATA devices, so the lie is contained.
+type HomeAnyCapabilities =
+  HomeContext['buildings'][number]['airToAirUnits'][number]['capabilities']
+const HomeDeviceCapabilitiesSchema =
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- schema is deliberately broader than the static type; see comment above
+  z.looseObject({}) as unknown as z.ZodType<HomeAnyCapabilities>
 const HomeDeviceDataSchema = z.looseObject({
   capabilities: HomeDeviceCapabilitiesSchema,
   givenDisplayName: z.string(),

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -6,6 +6,7 @@ import { ValidationError } from '../../src/errors/index.ts'
 import {
   ClassicBuildingListSchema,
   ClassicLoginDataSchema,
+  HomeContextSchema,
   HomeTokenResponseSchema,
   parseOrThrow,
 } from '../../src/validation/index.ts'
@@ -31,6 +32,31 @@ const buildingWithDeviceType = (type: unknown): unknown => [
     },
   },
 ]
+
+const baseHomeDevice = {
+  givenDisplayName: 'D',
+  id: 'd1',
+  rssi: -42,
+  settings: [],
+}
+const baseHomeBuilding = {
+  airToAirUnits: [],
+  airToWaterUnits: [],
+  id: 'b1',
+  name: 'B',
+  timezone: 'UTC',
+}
+const buildHomeContext = (overrides: Record<string, unknown>): unknown => ({
+  buildings: [],
+  country: 'FR',
+  email: 'a@b',
+  firstname: 'A',
+  guestBuildings: [],
+  id: 'u1',
+  language: 'en',
+  lastname: 'B',
+  ...overrides,
+})
 
 describe('validation/schemas', () => {
   describe(parseOrThrow, () => {
@@ -108,6 +134,57 @@ describe('validation/schemas', () => {
           token_type: 'Mac',
         }),
       ).toThrow(/token_type/u)
+    })
+  })
+
+  describe('homeContextSchema device capabilities', () => {
+    it.each([
+      {
+        capabilities: {
+          hasAirDirection: true,
+          hasAutomaticFanSpeed: true,
+          hasCoolOperationMode: true,
+          numberOfFanSpeeds: 4,
+        },
+        label: 'ATA',
+      },
+      {
+        capabilities: {
+          ftcModel: 3,
+          hasBoiler: false,
+          hasHotWater: true,
+          hasZone2: false,
+        },
+        label: 'ATW',
+      },
+    ])('accepts $label-shaped capabilities', ({ capabilities }) => {
+      expect(() =>
+        HomeContextSchema.parse(
+          buildHomeContext({
+            buildings: [
+              {
+                ...baseHomeBuilding,
+                airToWaterUnits: [{ ...baseHomeDevice, capabilities }],
+              },
+            ],
+          }),
+        ),
+      ).not.toThrow()
+    })
+
+    it('rejects non-object capabilities', () => {
+      expect(() =>
+        HomeContextSchema.parse(
+          buildHomeContext({
+            buildings: [
+              {
+                ...baseHomeBuilding,
+                airToAirUnits: [{ ...baseHomeDevice, capabilities: 'invalid' }],
+              },
+            ],
+          }),
+        ),
+      ).toThrow(/capabilities/u)
     })
   })
 


### PR DESCRIPTION
## Summary
- `HomeDeviceCapabilitiesSchema` enforced ATA-only fields (`hasAirDirection`, `numberOfFanSpeeds`, …) on every device. Mixed-fleet `/context` payloads (any account with `airToWaterUnits`) failed Zod validation, the error was swallowed silently inside `HomeAPI.list()`, `#user` stayed null, and `isAuthenticated()` reported `false` even after a successful sign-in — making `tryReuseSession`/`resumeSession` flap and the settings-page login form re-appear on every reopen.
- Schema now requires `capabilities` to be an object but does not validate its shape; only the ATA facade reads specific fields, and only for ATA devices, so the cast is contained.
- Added regression tests covering both ATA and ATW capability payloads + a non-object negative case.
- Bumped to 38.0.2.

## Test plan
- [x] `npm test` (651 passing, +3 new)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format`
- [x] Verified end-to-end against a real `/context` payload with both ATA and ATW units in the consumer app

🤖 Generated with [Claude Code](https://claude.com/claude-code)