### PR TITLE
Replace Luxon with Temporal API (BREAKING)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "38.0.2",
       "license": "MIT",
       "dependencies": {
-        "luxon": "^3.7.2",
+        "temporal-polyfill": "^0.3.2",
         "tough-cookie": "^6.0.1",
         "undici": "^8.2.0",
         "zod": "^4.4.3"
@@ -19,7 +19,6 @@
         "@eslint/markdown": "^8.0.1",
         "@stylistic/eslint-plugin": "^5.10.0",
         "@swc/core": "^1.15.33",
-        "@types/luxon": "^3.7.1",
         "@types/node": "^25.6.2",
         "@typescript/native-preview": "^7.0.0-dev.20260510.1",
         "@vitest/coverage-v8": "^4.1.5",
@@ -1140,11 +1139,6 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
       "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/luxon": {
-      "version": "3.7.1",
       "dev": true,
       "license": "MIT"
     },
@@ -3697,13 +3691,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/luxon": {
-      "version": "3.7.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5116,6 +5103,21 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/temporal-polyfill": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
+      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "temporal-spec": "0.3.1"
+      }
+    },
+    "node_modules/temporal-spec": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
+      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
+      "license": "ISC"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
-    "luxon": "^3.7.2",
+    "temporal-polyfill": "^0.3.2",
     "tough-cookie": "^6.0.1",
     "undici": "^8.2.0",
     "zod": "^4.4.3"
@@ -66,7 +66,6 @@
     "@eslint/markdown": "^8.0.1",
     "@stylistic/eslint-plugin": "^5.10.0",
     "@swc/core": "^1.15.33",
-    "@types/luxon": "^3.7.1",
     "@types/node": "^25.6.2",
     "@typescript/native-preview": "^7.0.0-dev.20260510.1",
     "@vitest/coverage-v8": "^4.1.5",

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -64,7 +64,10 @@ export const classifyError = (error: unknown): ApiRequestError => {
   if (error instanceof RateLimitError) {
     return {
       kind: 'rate-limited',
-      retryAfterMs: error.retryAfter?.toMillis() ?? null,
+      retryAfterMs:
+        error.retryAfter === null ?
+          null
+        : error.retryAfter.total({ unit: 'millisecond' }),
     }
   }
   if (isHttpError(error)) {

--- a/src/api/classic-types.ts
+++ b/src/api/classic-types.ts
@@ -52,6 +52,14 @@ import type { BaseAPIConfig, SyncCallback } from './types.ts'
  */
 export interface ClassicAPIAdapter {
   /**
+   * BCP-47 locale tag the Classic instance was configured with
+   * (`ClassicAPIConfig.locale`), or `undefined` when unset. Facades
+   * pass this through to `getChartLineOptions` so report labels
+   * (day-of-week, month names) render in the configured locale
+   * without needing a global mutable locale.
+   */
+  readonly locale: string | undefined
+  /**
    * Notify any registered `events.onSyncComplete` observer that a sync
    * just landed. Routed through the lifecycle emitter so a misbehaving
    * observer cannot break the caller.
@@ -191,8 +199,15 @@ export interface ClassicAPIAdapter {
  * @category Configuration
  */
 export interface ClassicAPIConfig extends BaseAPIConfig {
-  /** Locale language code (e.g. `'en'`, `'fr'`). */
+  /** Upstream account language code (e.g. `'en'`, `'fr'`). */
   readonly language?: string
+  /**
+   * BCP-47 locale tag for report chart labels (day-of-week, month
+   * names). Independent of {@link language} — `language` controls
+   * upstream messages, `locale` controls how the SDK formats labels
+   * locally. Defaults to the runtime locale when unset.
+   */
+  readonly locale?: string
   /** Whether to verify SSL certificates. Defaults to `true`. */
   readonly shouldVerifySSL?: boolean
   /** IANA timezone identifier (e.g. `'Europe/Paris'`). */

--- a/src/api/classic-types.ts
+++ b/src/api/classic-types.ts
@@ -57,6 +57,14 @@ export interface ClassicAPIAdapter {
    * observer cannot break the caller.
    */
   readonly notifySync: SyncCallback
+  /**
+   * IANA timezone identifier the Classic instance was configured with
+   * (`ClassicAPIConfig.timezone`), or `undefined` when unset. Facades
+   * use this to anchor "now"-derived defaults (`updateHolidayMode`
+   * fallback, `getSignalStrength` / `getHourlyTemperatures` hour) to
+   * the Classic timezone instead of the host runtime timezone.
+   */
+  readonly timezone: string | undefined
   /** Fetch all buildings and sync the model registry. */
   readonly fetch: () => Promise<ClassicBuildingWithStructure[]>
   /** Fetch energy consumption report. Supported by ATA and ATW devices. */

--- a/src/api/classic.ts
+++ b/src/api/classic.ts
@@ -180,6 +180,17 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
     return this.#registry
   }
 
+  /**
+   * IANA timezone supplied via {@link ClassicAPIConfig.timezone},
+   * or `undefined` when unset. Surfaced through {@link ClassicAPIAdapter}
+   * so facades can anchor their "now" defaults to the Classic timezone
+   * rather than the host runtime timezone.
+   * @returns The configured IANA timezone identifier, or `undefined`.
+   */
+  public get timezone(): string | undefined {
+    return this.#timezone
+  }
+
   #language = 'en'
 
   readonly #registry = new ClassicRegistry()

--- a/src/api/classic.ts
+++ b/src/api/classic.ts
@@ -1,4 +1,3 @@
-import { DateTime, Settings as LuxonSettings } from 'luxon'
 import { Agent } from 'undici'
 
 import { ClassicDeviceType, ClassicLanguage } from '../constants.ts'
@@ -6,6 +5,7 @@ import { setting, syncDevices } from '../decorators/index.ts'
 import { ClassicRegistry } from '../entities/index.ts'
 import { AuthenticationError } from '../errors/index.ts'
 import { isSessionExpired, toClassicDeviceId } from '../resilience/index.ts'
+import { Temporal } from '../temporal.ts'
 import { SESSION_REFRESH_AHEAD_MS } from '../time-units.ts'
 import {
   type ClassicAreaDataAny,
@@ -74,14 +74,27 @@ const DEFAULT_SYNC_INTERVAL_MINUTES = 5
 // MELCloud uses year 1 for uninitialized error dates; filter these out as invalid
 const INVALID_YEAR = 1
 
-const toISODate = (dateTime: DateTime): string => {
-  const result = dateTime.toISODate()
-
-  if (result === null) {
-    throw new Error('Invalid DateTime: cannot convert to ISO date')
+// Re-thrown with the historical "Invalid DateTime" prefix so the
+// public failure surface for `getErrorLog({ to: 'not-a-date' })` stays
+// stable across the Luxon → Temporal migration.
+const parsePlainDate = (iso: string): Temporal.PlainDate => {
+  try {
+    return Temporal.PlainDate.from(iso)
+  } catch (error) {
+    throw new Error(`Invalid DateTime: ${iso}`, { cause: error })
   }
+}
 
-  return result
+// Year extraction that mirrors the original Luxon behavior on parse
+// failure: a bad input does NOT short-circuit as "invalid year 1" — it
+// falls through and the entry is kept. Only the canonical `0001-01-01`
+// sentinel that MELCloud returns gets filtered.
+const safePlainDateYear = (iso: string): number => {
+  try {
+    return Temporal.PlainDate.from(iso).year
+  } catch {
+    return 0
+  }
 }
 
 const isLanguage = isKeyOf(ClassicLanguage)
@@ -91,31 +104,31 @@ const formatErrors = (errors: Record<string, readonly string[]>): string =>
     .map(([error, messages]) => `${error}: ${messages.join(', ')}`)
     .join('\n')
 
-const parseErrorLogQuery = ({
-  from,
-  offset = 0,
-  period = 1,
-  to,
-}: ClassicErrorLogQuery): {
-  fromDate: DateTime
+const parseErrorLogQuery = (
+  { from, offset = 0, period = 1, to }: ClassicErrorLogQuery,
+  timeZone: string | undefined,
+): {
+  fromDate: Temporal.PlainDate
   period: number
-  toDate: DateTime
+  toDate: Temporal.PlainDate
 } => {
   // When `from` is set the query is pinned to that single day; offset
   // is therefore moot and ignored. Otherwise pages are stacked
   // backwards from `to` in `period`-sized windows.
   const fromDateOverride =
-    from !== undefined && from !== '' ? DateTime.fromISO(from) : null
+    from !== undefined && from !== '' ? parsePlainDate(from) : null
   const toDate =
-    to !== undefined && to !== '' ? DateTime.fromISO(to) : DateTime.now()
+    to !== undefined && to !== '' ?
+      parsePlainDate(to)
+    : Temporal.Now.plainDateISO(timeZone)
   // A page covers `period` days; consecutive pages are separated by a
   // one-day boundary so day N is never returned twice. Each step back
   // therefore moves `period + 1` days, hence the `* (period + 1)`.
   const daysBack = fromDateOverride ? 0 : offset * (period + 1)
   return {
-    fromDate: fromDateOverride ?? toDate.minus({ days: daysBack + period }),
+    fromDate: fromDateOverride ?? toDate.subtract({ days: daysBack + period }),
     period,
-    toDate: toDate.minus({ days: daysBack }),
+    toDate: toDate.subtract({ days: daysBack }),
   }
 }
 
@@ -171,6 +184,8 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
 
   readonly #registry = new ClassicRegistry()
 
+  readonly #timezone: string | undefined
+
   @setting
   private accessor contextKey = ''
 
@@ -199,9 +214,7 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
       rateLimitHours: DEFAULT_RETRY_HOURS,
       syncCallback: async () => this.fetch(),
     })
-    if (timezone !== undefined) {
-      LuxonSettings.defaultZone = timezone
-    }
+    this.#timezone = timezone
     if (language !== undefined) {
       this.#language = language
     }
@@ -276,8 +289,11 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
     query: ClassicErrorLogQuery,
     deviceIds: number[] = this.#registry.getDevices().map(({ id }) => id),
   ): Promise<Result<ClassicErrorLog>> {
-    const { fromDate, period, toDate } = parseErrorLogQuery(query)
-    const nextToDate = fromDate.minus({ days: 1 })
+    const { fromDate, period, toDate } = parseErrorLogQuery(
+      query,
+      this.#timezone,
+    )
+    const nextToDate = fromDate.subtract({ days: 1 })
     return mapResult(
       await this.#getErrorLog(deviceIds, fromDate, toDate),
       (errorLog) => ({
@@ -288,8 +304,7 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
               ErrorMessage: errorMessage,
               StartDate: startDate,
             }) => {
-              const dateTime = DateTime.fromISO(startDate)
-              if (dateTime.year === INVALID_YEAR) {
+              if (safePlainDateYear(startDate) === INVALID_YEAR) {
                 return []
               }
               const error = errorMessage?.trim() ?? ''
@@ -299,9 +314,9 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
             },
           )
           .toReversed(),
-        fromDate: toISODate(fromDate),
-        nextFromDate: toISODate(nextToDate.minus({ days: period })),
-        nextToDate: toISODate(nextToDate),
+        fromDate: fromDate.toString(),
+        nextFromDate: nextToDate.subtract({ days: period }).toString(),
+        nextToDate: nextToDate.toString(),
       }),
     )
   }
@@ -629,7 +644,7 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
   protected override needsSessionRefresh(): boolean {
     return (
       this.contextKey === '' ||
-      isSessionExpired(this.expiry, SESSION_REFRESH_AHEAD_MS)
+      isSessionExpired(this.expiry, SESSION_REFRESH_AHEAD_MS, this.#timezone)
     )
   }
 
@@ -694,14 +709,14 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
 
   async #getErrorLog(
     deviceIds: number[],
-    fromDate: DateTime,
-    toDate: DateTime,
+    fromDate: Temporal.PlainDate,
+    toDate: Temporal.PlainDate,
   ): Promise<Result<ClassicErrorLogData[]>> {
     const result = await this.getErrorEntries({
       postData: {
         DeviceIDs: deviceIds.map((id) => toClassicDeviceId(id)),
-        FromDate: toISODate(fromDate),
-        ToDate: toISODate(toDate),
+        FromDate: fromDate.toString(),
+        ToDate: toDate.toString(),
       },
     })
     if (!result.ok) {

--- a/src/api/classic.ts
+++ b/src/api/classic.ts
@@ -173,6 +173,17 @@ const collectDevices = function* collectDevices(
  */
 export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
   /**
+   * BCP-47 locale supplied via {@link ClassicAPIConfig.locale}, or
+   * `undefined` when unset. Surfaced through {@link ClassicAPIAdapter}
+   * so facades thread it into `getChartLineOptions` and report labels
+   * stay consistent with the configured locale without a mutable global.
+   * @returns The configured BCP-47 locale tag, or `undefined`.
+   */
+  public get locale(): string | undefined {
+    return this.#locale
+  }
+
+  /**
    * In-memory entity registry populated by `fetch` / `list`.
    * @returns The registry instance.
    */
@@ -193,6 +204,8 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
 
   #language = 'en'
 
+  readonly #locale: string | undefined
+
   readonly #registry = new ClassicRegistry()
 
   readonly #timezone: string | undefined
@@ -203,6 +216,7 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
   private constructor(config: ClassicAPIConfig = {}) {
     const {
       language,
+      locale,
       password,
       shouldVerifySSL = true,
       timezone,
@@ -225,6 +239,7 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
       rateLimitHours: DEFAULT_RETRY_HOURS,
       syncCallback: async () => this.fetch(),
     })
+    this.#locale = locale
     this.#timezone = timezone
     if (language !== undefined) {
       this.#language = language

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -1,5 +1,3 @@
-import { DateTime } from 'luxon'
-
 import type {
   HomeAtaValues,
   HomeAtwValues,
@@ -17,6 +15,7 @@ import { HomeDeviceType } from '../constants.ts'
 import { fetchDevices, setting, syncDevices } from '../decorators/index.ts'
 import { HomeRegistry } from '../entities/home-registry.ts'
 import { isSessionExpired } from '../resilience/index.ts'
+import { Temporal } from '../temporal.ts'
 import { MS_PER_SECOND, SESSION_REFRESH_AHEAD_MS } from '../time-units.ts'
 import {
   HomeContextSchema,
@@ -45,25 +44,34 @@ const parseUser = (data: HomeContext): HomeUser => ({
   sub: data.id,
 })
 
+// Parse offset-bearing inputs (e.g. `'2026-03-01T10:00:00Z'`) as
+// absolute instants then re-project to UTC wall time; parse offset-less
+// inputs (e.g. `'2026-03-01'`, `'2026-03-01T00:00:00'`) as already-UTC
+// wall time. Anchoring on UTC prevents the host's local timezone from
+// shifting the formatted output by hours.
+const parseUTCPlainDateTime = (iso: string): Temporal.PlainDateTime => {
+  try {
+    return Temporal.Instant.from(iso)
+      .toZonedDateTimeISO('UTC')
+      .toPlainDateTime()
+  } catch {
+    return Temporal.PlainDateTime.from(iso)
+  }
+}
+
 // `/report/v1/trendsummary` expects .NET-style ISO with 7 subsecond zeros
 // (e.g. `2026-04-19T00:00:00.0000000`). Anything shorter is silently
 // truncated to an empty window by the BFF.
-//
-// Parse with `{ zone: 'utc' }` so offset-less inputs (e.g. `'2026-03-01'`)
-// are read as UTC rather than being re-interpreted through the host's
-// local timezone — otherwise the formatted output drifts by the host's
-// current offset.
 const toReportDate = (iso: string): string =>
-  DateTime.fromISO(iso, { zone: 'utc' }).toFormat(
-    "yyyy-MM-dd'T'HH:mm:ss'.0000000'",
-  )
+  `${parseUTCPlainDateTime(iso).toString({ smallestUnit: 'second' })}.0000000`
 
 // `/telemetry/telemetry/{energy,actual}` expect `YYYY-MM-DD HH:MM` with a
 // space and no seconds. Seconds or an ISO `T` separator produce an empty
-// payload rather than an error. Same UTC-parse rationale as
-// {@link toReportDate}.
+// payload rather than an error.
 const toTelemetryDate = (iso: string): string =>
-  DateTime.fromISO(iso, { zone: 'utc' }).toFormat('yyyy-MM-dd HH:mm')
+  parseUTCPlainDateTime(iso)
+    .toString({ smallestUnit: 'minute' })
+    .replace('T', ' ')
 
 /**
  * MELCloud Home API client using the mobile BFF at

--- a/src/errors/rate-limit.ts
+++ b/src/errors/rate-limit.ts
@@ -1,5 +1,4 @@
-import type { DateTime, Duration } from 'luxon'
-
+import type { Temporal } from '../temporal.ts'
 import { APIError } from './base.ts'
 
 /**
@@ -9,17 +8,20 @@ import { APIError } from './base.ts'
  * Consumers receive structured, machine-readable fields so they can
  * format their own localized messages without parsing the string:
  * - {@link retryAfter}: relative duration remaining (ideal for
- *   "try again in 5 min" phrasing).
+ *   "try again in 5 min" phrasing) — read with
+ *   `retryAfter.total({ unit: 'seconds' })`.
  * - {@link unblockAt}: absolute unblock time (ideal for
- *   "try again at 14:30" phrasing).
+ *   "try again at 14:30" phrasing) — read with
+ *   `unblockAt.toString()` or convert via
+ *   `unblockAt.toZonedDateTimeISO(zone)`.
  * @category Errors
  */
 export class RateLimitError extends APIError {
   public override readonly name = 'RateLimitError'
 
-  public readonly retryAfter: Duration | null
+  public readonly retryAfter: Temporal.Duration | null
 
-  public readonly unblockAt: DateTime | null
+  public readonly unblockAt: Temporal.Instant | null
 
   /**
    * Builds the error from the message and rate-limit window metadata;
@@ -27,15 +29,15 @@ export class RateLimitError extends APIError {
    * supplies no window.
    * @param message - Human-readable error description.
    * @param options - Rate-limit window metadata plus optional cause.
-   * @param options.retryAfter - Duration until retry is allowed, or `null`.
-   * @param options.unblockAt - Absolute unblock time, or `null`.
+   * @param options.retryAfter - `Temporal.Duration` until retry is allowed, or `null`.
+   * @param options.unblockAt - Absolute unblock `Temporal.Instant`, or `null`.
    * @param options.cause - Original error that triggered this one.
    */
   public constructor(
     message: string,
     options: {
-      retryAfter: Duration | null
-      unblockAt: DateTime | null
+      retryAfter: Temporal.Duration | null
+      unblockAt: Temporal.Instant | null
       cause?: unknown
     },
   ) {

--- a/src/facades/classic-base-device.ts
+++ b/src/facades/classic-base-device.ts
@@ -200,10 +200,7 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
   }
 
   public async getHourlyTemperatures(
-    // Temporal.PlainTime.hour is always in [0, 23] per spec, so the
-    // narrowing to `Hour` (the 0..23 literal union) is sound.
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    hour: Hour = Temporal.Now.plainTimeISO().hour as Hour,
+    hour: Hour = this.currentHour(),
   ): Promise<Result<ReportChartLineOptions>> {
     return mapResult(
       await this.api.getHourlyTemperatures({
@@ -285,9 +282,10 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
   }
 
   #buildReportPostData(
-    { from = DEFAULT_YEAR, to = now() }: ReportQuery = {},
+    query: ReportQuery = {},
     shouldUseExactRange = false,
   ): ClassicReportPostData {
+    const { from = DEFAULT_YEAR, to = now(this.api.timezone) } = query
     return {
       DeviceID: this.id,
       Duration: shouldUseExactRange ? getDuration({ from, to }) : undefined,

--- a/src/facades/classic-base-device.ts
+++ b/src/facades/classic-base-device.ts
@@ -1,5 +1,3 @@
-import { DateTime } from 'luxon'
-
 import { CLASSIC_FLAG_UNCHANGED, ClassicDeviceType } from '../constants.ts'
 import {
   classicUpdateDevice,
@@ -13,6 +11,7 @@ import {
   isClassicDeviceOfType,
 } from '../entities/index.ts'
 import { NoChangesError } from '../errors/index.ts'
+import { Temporal } from '../temporal.ts'
 import {
   type ClassicDeviceID,
   type ClassicEnergyData,
@@ -47,16 +46,16 @@ import { ClassicBaseFacade } from './classic-base.ts'
 // Unix epoch as fallback for open-ended report queries
 const DEFAULT_YEAR = '1970-01-01'
 
-const MS_PER_DAY = 86_400_000
-
-// Use Luxon parsing so offset-less ISO inputs are interpreted in
-// `LuxonSettings.defaultZone` (matching the Classic API's timezone contract),
-// not the host runtime timezone.
-const getDuration = ({ from, to }: Required<ReportQuery>): number =>
-  Math.ceil(
-    (DateTime.fromISO(to).toMillis() - DateTime.fromISO(from).toMillis()) /
-      MS_PER_DAY,
+// Calendar-day delta between two ISO wall-clock strings. Computed on
+// `PlainDateTime` so the result reflects the literal Y-M-D-h-m-s span
+// the Classic server uses, independent of DST in any zone.
+const getDuration = ({ from, to }: Required<ReportQuery>): number => {
+  const diff = Temporal.PlainDateTime.from(to).since(
+    Temporal.PlainDateTime.from(from),
+    { largestUnit: 'day' },
   )
+  return Math.ceil(diff.total({ unit: 'day' }))
+}
 
 /**
  * Abstract base for device-specific facades. Handles device data access, report generation,
@@ -201,7 +200,10 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
   }
 
   public async getHourlyTemperatures(
-    hour: Hour = DateTime.now().hour,
+    // Temporal.PlainTime.hour is always in [0, 23] per spec, so the
+    // narrowing to `Hour` (the 0..23 literal union) is sound.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    hour: Hour = Temporal.Now.plainTimeISO().hour as Hour,
   ): Promise<Result<ReportChartLineOptions>> {
     return mapResult(
       await this.api.getHourlyTemperatures({

--- a/src/facades/classic-base-device.ts
+++ b/src/facades/classic-base-device.ts
@@ -207,7 +207,11 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
         postData: { device: this.id, hour },
       }),
       (data) =>
-        getChartLineOptions(data, this.internalTemperaturesLegend, '°C'),
+        getChartLineOptions(data, {
+          legend: this.internalTemperaturesLegend,
+          locale: this.api.locale,
+          unit: '°C',
+        }),
     )
   }
 
@@ -220,7 +224,11 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
         postData: this.#buildReportPostData(query, shouldUseExactRange),
       }),
       (data) =>
-        getChartLineOptions(data, this.internalTemperaturesLegend, '°C'),
+        getChartLineOptions(data, {
+          legend: this.internalTemperaturesLegend,
+          locale: this.api.locale,
+          unit: '°C',
+        }),
     )
   }
 
@@ -247,7 +255,12 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
             ?.location,
         },
       }),
-      (data) => getChartLineOptions(data, this.temperaturesLegend, '°C'),
+      (data) =>
+        getChartLineOptions(data, {
+          legend: this.temperaturesLegend,
+          locale: this.api.locale,
+          unit: '°C',
+        }),
     )
   }
 

--- a/src/facades/classic-base.ts
+++ b/src/facades/classic-base.ts
@@ -1,5 +1,3 @@
-import { DateTime } from 'luxon'
-
 import type {
   ClassicAPIAdapter,
   ClassicErrorLog,
@@ -18,6 +16,7 @@ import {
   syncDevices,
 } from '../decorators/index.ts'
 import { EntityNotFoundError } from '../errors/index.ts'
+import { Temporal } from '../temporal.ts'
 import {
   type ApiRequestError,
   type ClassicDateTimeComponents,
@@ -79,7 +78,7 @@ const TEMPERATURE_GAP = 2
 const temperatureRange = { max: 16, min: 4 }
 
 const getDateTimeComponents = (
-  date: DateTime | null,
+  date: Temporal.PlainDateTime | null,
 ): ClassicDateTimeComponents =>
   date ?
     {
@@ -227,8 +226,9 @@ export abstract class ClassicBaseFacade<
     ClassicFailureData | ClassicSuccessData
   > {
     const isEnabled = to !== undefined
-    const startDate = isEnabled ? DateTime.fromISO(from ?? now()) : null
-    const endDate = isEnabled ? DateTime.fromISO(to) : null
+    const startDate =
+      isEnabled ? Temporal.PlainDateTime.from(from ?? now()) : null
+    const endDate = isEnabled ? Temporal.PlainDateTime.from(to) : null
     return this.api.updateHolidayMode({
       postData: {
         Enabled: isEnabled,
@@ -275,7 +275,10 @@ export abstract class ClassicBaseFacade<
   }
 
   public async getSignalStrength(
-    hour: Hour = DateTime.now().hour,
+    // Temporal.PlainTime.hour is always in [0, 23] per spec, so the
+    // narrowing to `Hour` (the 0..23 literal union) is sound.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    hour: Hour = Temporal.Now.plainTimeISO().hour as Hour,
   ): Promise<Result<ReportChartLineOptions>> {
     return mapResult(
       await this.api.getSignal({

--- a/src/facades/classic-base.ts
+++ b/src/facades/classic-base.ts
@@ -227,7 +227,9 @@ export abstract class ClassicBaseFacade<
   > {
     const isEnabled = to !== undefined
     const startDate =
-      isEnabled ? Temporal.PlainDateTime.from(from ?? now()) : null
+      isEnabled ?
+        Temporal.PlainDateTime.from(from ?? now(this.api.timezone))
+      : null
     const endDate = isEnabled ? Temporal.PlainDateTime.from(to) : null
     return this.api.updateHolidayMode({
       postData: {
@@ -275,10 +277,7 @@ export abstract class ClassicBaseFacade<
   }
 
   public async getSignalStrength(
-    // Temporal.PlainTime.hour is always in [0, 23] per spec, so the
-    // narrowing to `Hour` (the 0..23 literal union) is sound.
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    hour: Hour = Temporal.Now.plainTimeISO().hour as Hour,
+    hour: Hour = this.currentHour(),
   ): Promise<Result<ReportChartLineOptions>> {
     return mapResult(
       await this.api.getSignal({
@@ -323,6 +322,21 @@ export abstract class ClassicBaseFacade<
     type,
   }: { type?: ClassicDeviceType } = {}): Promise<void> {
     await this.api.notifySync({ ids: this.#deviceIds, type })
+  }
+
+  /**
+   * Current hour in the Classic-configured timezone (falls back to the
+   * host's timezone when none was configured). Shared by the hour
+   * defaults of {@link getSignalStrength} and (device facades')
+   * `getHourlyTemperatures` so report defaults align with the Classic
+   * deployment instead of the host runtime.
+   * @returns The current hour as a valid {@link Hour}.
+   */
+  protected currentHour(): Hour {
+    // Temporal.PlainTime.hour is always in [0, 23] per spec, so the
+    // narrowing to `Hour` (the 0..23 literal union) is sound.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    return Temporal.Now.plainTimeISO(this.api.timezone).hour as Hour
   }
 
   async #getBaseFrostProtection(

--- a/src/facades/classic-base.ts
+++ b/src/facades/classic-base.ts
@@ -283,7 +283,12 @@ export abstract class ClassicBaseFacade<
       await this.api.getSignal({
         postData: { devices: this.#deviceIds, hour },
       }),
-      (data) => getChartLineOptions(data, this.#deviceNames, 'dBm'),
+      (data) =>
+        getChartLineOptions(data, {
+          legend: this.#deviceNames,
+          locale: this.api.locale,
+          unit: 'dBm',
+        }),
     )
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -232,4 +232,3 @@ export {
 } from './http/index.ts'
 export { Temporal } from './temporal.ts'
 export { err, mapResult, ok } from './types/index.ts'
-export { getReportLocale, setReportLocale } from './utils.ts'

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,4 +230,6 @@ export {
   HttpError,
   isHttpError,
 } from './http/index.ts'
+export { Temporal } from './temporal.ts'
 export { err, mapResult, ok } from './types/index.ts'
+export { getReportLocale, setReportLocale } from './utils.ts'

--- a/src/resilience/rate-limit-gate.ts
+++ b/src/resilience/rate-limit-gate.ts
@@ -1,6 +1,38 @@
-import { type DurationLike, DateTime, Duration } from 'luxon'
-
+import { Temporal } from '../temporal.ts'
 import { SECONDS_PER_MINUTE } from '../time-units.ts'
+
+/**
+ * Subset of `Temporal.Duration` field values accepted by
+ * {@link RateLimitGate}'s fallback configuration. Matches what callers
+ * actually need to express a rate-limit pause window.
+ */
+export interface RateLimitDurationLike {
+  readonly days?: number
+  readonly hours?: number
+  readonly minutes?: number
+  readonly seconds?: number
+}
+
+const pluralize = (count: number, unit: string): string =>
+  count === 1 ? unit : `${unit}s`
+
+// English "Luxon `Duration.toHuman()` style" formatter. Adaptive units:
+// sub-minute windows render as seconds; longer windows render as
+// minutes + (optional) seconds. Sticking with manual formatting (vs.
+// `Intl.DurationFormat`) keeps the output stable across runtimes and
+// preserves the format consumers may rely on.
+const formatDurationHuman = (duration: Temporal.Duration): string => {
+  const totalSeconds = Math.trunc(duration.total({ unit: 'seconds' }))
+  if (totalSeconds < SECONDS_PER_MINUTE) {
+    return `${String(totalSeconds)} ${pluralize(totalSeconds, 'second')}`
+  }
+  const minutes = Math.trunc(totalSeconds / SECONDS_PER_MINUTE)
+  const seconds = totalSeconds % SECONDS_PER_MINUTE
+  if (seconds === 0) {
+    return `${String(minutes)} ${pluralize(minutes, 'minute')}`
+  }
+  return `${String(minutes)} ${pluralize(minutes, 'minute')}, ${String(seconds)} ${pluralize(seconds, 'second')}`
+}
 
 /**
  * Tracks an upstream rate-limit window and lets callers check whether
@@ -17,15 +49,20 @@ export class RateLimitGate {
    * @returns `true` while the rate-limit window is active.
    */
   public get isPaused(): boolean {
-    return this.#pausedUntil > DateTime.now()
+    return (
+      Temporal.Instant.compare(this.#pausedUntil, Temporal.Now.instant()) > 0
+    )
   }
 
   /**
    * Duration remaining until the gate re-opens.
-   * @returns A Luxon Duration if paused, or `null` if the gate is open.
+   * @returns A `Temporal.Duration` if paused, or `null` if the gate is open.
    */
-  public get remaining(): Duration | null {
-    return this.isPaused ? this.#pausedUntil.diffNow() : null
+  public get remaining(): Temporal.Duration | null {
+    const now = Temporal.Now.instant()
+    return Temporal.Instant.compare(this.#pausedUntil, now) > 0 ?
+        this.#pausedUntil.since(now)
+      : null
   }
 
   /**
@@ -35,24 +72,24 @@ export class RateLimitGate {
    *
    * Callers that need both `remaining` and `unblockAt` together should
    * prefer {@link snapshot} to avoid reading each against a separate
-   * `DateTime.now()` tick (near the window boundary the pair can
-   * otherwise land on different sides of `isPaused`).
-   * @returns The unblock `DateTime` if paused, or `null` if the gate is open.
+   * `Temporal.Now.instant()` tick (near the window boundary the pair
+   * can otherwise land on different sides of `isPaused`).
+   * @returns The unblock `Temporal.Instant` if paused, or `null` if the gate is open.
    */
-  public get unblockAt(): DateTime | null {
+  public get unblockAt(): Temporal.Instant | null {
     return this.isPaused ? this.#pausedUntil : null
   }
 
-  readonly #fallback: Duration
+  readonly #fallback: Temporal.Duration
 
-  #pausedUntil: DateTime = DateTime.now()
+  #pausedUntil: Temporal.Instant = Temporal.Now.instant()
 
   /**
    * @param fallback - Duration to pause when the server doesn't provide
    *   a usable `Retry-After` header.
    */
-  public constructor(fallback: DurationLike) {
-    this.#fallback = Duration.fromDurationLike(fallback)
+  public constructor(fallback: RateLimitDurationLike) {
+    this.#fallback = Temporal.Duration.from(fallback)
   }
 
   /**
@@ -69,9 +106,7 @@ export class RateLimitGate {
     if (remaining === null) {
       return ''
     }
-    return remaining.as('seconds') < SECONDS_PER_MINUTE ?
-        remaining.shiftTo('seconds').toHuman()
-      : remaining.shiftTo('minutes', 'seconds').rescale().toHuman()
+    return formatDurationHuman(remaining)
   }
 
   /**
@@ -107,32 +142,34 @@ export class RateLimitGate {
   public recordRateLimit(retryAfterSeconds?: unknown): void {
     const seconds = Number(retryAfterSeconds)
     const duration =
-      Number.isFinite(seconds) && seconds > 0 ? { seconds } : this.#fallback
-    this.#pausedUntil = DateTime.now().plus(duration)
+      Number.isFinite(seconds) && seconds > 0 ?
+        Temporal.Duration.from({ seconds })
+      : this.#fallback
+    this.#pausedUntil = Temporal.Now.instant().add(duration)
   }
 
   /** Reset the gate immediately (testing or manual unblock). */
   public reset(): void {
-    this.#pausedUntil = DateTime.now()
+    this.#pausedUntil = Temporal.Now.instant()
   }
 
   /**
    * Atomic read of the gate's state. All three fields are computed
-   * against a single `DateTime.now()` capture, so `remaining` and
-   * `unblockAt` cannot observe inconsistent "one null, one not" pairs
-   * that separate getter reads might hit near the boundary.
+   * against a single `Temporal.Now.instant()` capture, so `remaining`
+   * and `unblockAt` cannot observe inconsistent "one null, one not"
+   * pairs that separate getter reads might hit near the boundary.
    * @returns The current pause state and derived timing fields.
    */
   public snapshot(): {
     isPaused: boolean
-    remaining: Duration | null
-    unblockAt: DateTime | null
+    remaining: Temporal.Duration | null
+    unblockAt: Temporal.Instant | null
   } {
-    const now = DateTime.now()
-    const isPaused = this.#pausedUntil > now
+    const now = Temporal.Now.instant()
+    const isPaused = Temporal.Instant.compare(this.#pausedUntil, now) > 0
     return {
       isPaused,
-      remaining: isPaused ? this.#pausedUntil.diff(now) : null,
+      remaining: isPaused ? this.#pausedUntil.since(now) : null,
       unblockAt: isPaused ? this.#pausedUntil : null,
     }
   }

--- a/src/resilience/rate-limit-gate.ts
+++ b/src/resilience/rate-limit-gate.ts
@@ -16,12 +16,20 @@ export interface RateLimitDurationLike {
 const pluralize = (count: number, unit: string): string =>
   count === 1 ? unit : `${unit}s`
 
-// English "Luxon `Duration.toHuman()` style" formatter. Adaptive units:
-// sub-minute windows render as seconds; longer windows render as
-// minutes + (optional) seconds. Sticking with manual formatting (vs.
-// `Intl.DurationFormat`) keeps the output stable across runtimes and
-// preserves the format consumers may rely on.
-const formatDurationHuman = (duration: Temporal.Duration): string => {
+/**
+ * Render a `Temporal.Duration` in English diagnostic form, with
+ * adaptive units: sub-minute windows render as seconds (e.g.
+ * `"20 seconds"`) so a short Retry-After never rounds to a misleading
+ * `"0 minutes"`; longer windows render as `"M minutes, S seconds"`.
+ *
+ * Intended for log lines and developer-facing error messages — **not**
+ * for presentation in a localized UI. Consumers that need localized
+ * output should read the underlying `Temporal.Duration` and format it
+ * with `Intl.DurationFormat` or their own i18n framework.
+ * @param duration - The duration to render.
+ * @returns The formatted, English-diagnostic string.
+ */
+export const formatDurationHuman = (duration: Temporal.Duration): string => {
   const totalSeconds = Math.trunc(duration.total({ unit: 'seconds' }))
   if (totalSeconds < SECONDS_PER_MINUTE) {
     return `${String(totalSeconds)} ${pluralize(totalSeconds, 'second')}`
@@ -93,28 +101,6 @@ export class RateLimitGate {
   }
 
   /**
-   * English-only diagnostic rendering of the remaining time, intended
-   * for log lines and developer-facing error messages — **not** for
-   * presentation in a localized UI. Consumers that need localized
-   * output should read {@link remaining} (a `Temporal.Duration`) and
-   * format it with `Intl.DurationFormat` or their own i18n framework.
-   *
-   * Adaptive units: sub-minute windows render as seconds (e.g.
-   * `"20 seconds"`) so a short Retry-After never rounds to a misleading
-   * `"0 minutes"`; longer windows render as `"M minutes, S seconds"`.
-   * Returns an empty string when the gate is open — callers can
-   * interpolate directly into log lines without checking `isPaused` first.
-   * @returns Formatted remaining duration, or `''` if the gate is open.
-   */
-  public formatRemaining(): string {
-    const { remaining } = this
-    if (remaining === null) {
-      return ''
-    }
-    return formatDurationHuman(remaining)
-  }
-
-  /**
    * Convenience: record the rate-limit and emit a formatted error log
    * in one call. Centralizes the log message format so both API clients
    * stay consistent, and avoids repeating the `recordRateLimit(...)`
@@ -131,9 +117,12 @@ export class RateLimitGate {
     label = '',
   ): void {
     this.recordRateLimit(retryAfterSeconds)
+    // `recordRateLimit` always advances `#pausedUntil` into the future,
+    // so the remaining duration is positive and well-defined here.
+    const duration = this.#pausedUntil.since(Temporal.Now.instant())
     const suffix = label === '' ? '' : ` ${label}`
     logger.error(
-      `Rate limited (429): pausing${suffix} for ${this.formatRemaining()}`,
+      `Rate limited (429): pausing${suffix} for ${formatDurationHuman(duration)}`,
     )
   }
 
@@ -159,23 +148,30 @@ export class RateLimitGate {
   }
 
   /**
-   * Atomic read of the gate's state. All three fields are computed
-   * against a single `Temporal.Now.instant()` capture, so `remaining`
-   * and `unblockAt` cannot observe inconsistent "one null, one not"
-   * pairs that separate getter reads might hit near the boundary.
+   * Atomic read of the gate's state. All fields are computed against a
+   * single `Temporal.Now.instant()` capture, so `remaining` and
+   * `unblockAt` cannot observe inconsistent "one null, one not" pairs
+   * that separate getter reads might hit near the boundary.
+   *
+   * Returned as a discriminated union on `isPaused` so callers do not
+   * need to null-check `remaining` / `unblockAt` after narrowing.
    * @returns The current pause state and derived timing fields.
    */
-  public snapshot(): {
-    isPaused: boolean
-    remaining: Temporal.Duration | null
-    unblockAt: Temporal.Instant | null
-  } {
+  public snapshot():
+    | { isPaused: false; remaining: null; unblockAt: null }
+    | {
+        isPaused: true
+        remaining: Temporal.Duration
+        unblockAt: Temporal.Instant
+      } {
     const now = Temporal.Now.instant()
-    const isPaused = Temporal.Instant.compare(this.#pausedUntil, now) > 0
+    if (Temporal.Instant.compare(this.#pausedUntil, now) <= 0) {
+      return { isPaused: false, remaining: null, unblockAt: null }
+    }
     return {
-      isPaused,
-      remaining: isPaused ? this.#pausedUntil.since(now) : null,
-      unblockAt: isPaused ? this.#pausedUntil : null,
+      isPaused: true,
+      remaining: this.#pausedUntil.since(now),
+      unblockAt: this.#pausedUntil,
     }
   }
 }

--- a/src/resilience/rate-limit-gate.ts
+++ b/src/resilience/rate-limit-gate.ts
@@ -93,10 +93,15 @@ export class RateLimitGate {
   }
 
   /**
-   * Human-readable remaining time with adaptive units. For short windows
-   * (< 1 minute) the output is in seconds (e.g. "20 seconds") so a short
-   * Retry-After doesn't get rounded into a misleading "0 minutes".
-   * Longer windows use minutes + seconds (e.g. "2 minutes, 15 seconds").
+   * English-only diagnostic rendering of the remaining time, intended
+   * for log lines and developer-facing error messages — **not** for
+   * presentation in a localized UI. Consumers that need localized
+   * output should read {@link remaining} (a `Temporal.Duration`) and
+   * format it with `Intl.DurationFormat` or their own i18n framework.
+   *
+   * Adaptive units: sub-minute windows render as seconds (e.g.
+   * `"20 seconds"`) so a short Retry-After never rounds to a misleading
+   * `"0 minutes"`; longer windows render as `"M minutes, S seconds"`.
    * Returns an empty string when the gate is open — callers can
    * interpolate directly into log lines without checking `isPaused` first.
    * @returns Formatted remaining duration, or `''` if the gate is open.

--- a/src/resilience/rate-limit-policy.ts
+++ b/src/resilience/rate-limit-policy.ts
@@ -2,7 +2,7 @@ import type { Logger } from '../api/types.ts'
 import { RateLimitError } from '../errors/index.ts'
 import { HttpStatus, isHttpError } from '../http/index.ts'
 import type { ResiliencePolicy } from './policy.ts'
-import type { RateLimitGate } from './rate-limit-gate.ts'
+import { type RateLimitGate, formatDurationHuman } from './rate-limit-gate.ts'
 
 /**
  * Rate-limit circuit breaker. Two responsibilities:
@@ -32,13 +32,14 @@ export class RateLimitPolicy implements ResiliencePolicy {
     // so the error's `retryAfter` and `unblockAt` are mutually
     // consistent — even when the gate re-opens between two separate
     // getter reads.
-    const { isPaused, remaining, unblockAt } = this.#gate.snapshot()
-    if (isPaused) {
+    const snapshot = this.#gate.snapshot()
+    if (snapshot.isPaused) {
       // English-only diagnostic message — consumers that present this
       // to end users should read `retryAfter` / `unblockAt` and format
       // those structured fields with their own i18n stack.
+      const { remaining, unblockAt } = snapshot
       throw new RateLimitError(
-        `API requests are on hold for ${this.#gate.formatRemaining()}`,
+        `API requests are on hold for ${formatDurationHuman(remaining)}`,
         { retryAfter: remaining, unblockAt },
       )
     }

--- a/src/resilience/rate-limit-policy.ts
+++ b/src/resilience/rate-limit-policy.ts
@@ -34,6 +34,9 @@ export class RateLimitPolicy implements ResiliencePolicy {
     // getter reads.
     const { isPaused, remaining, unblockAt } = this.#gate.snapshot()
     if (isPaused) {
+      // English-only diagnostic message — consumers that present this
+      // to end users should read `retryAfter` / `unblockAt` and format
+      // those structured fields with their own i18n stack.
       throw new RateLimitError(
         `API requests are on hold for ${this.#gate.formatRemaining()}`,
         { retryAfter: remaining, unblockAt },

--- a/src/resilience/rate-limit-policy.ts
+++ b/src/resilience/rate-limit-policy.ts
@@ -28,9 +28,10 @@ export class RateLimitPolicy implements ResiliencePolicy {
   }
 
   public async run<T>(attempt: () => Promise<T>): Promise<T> {
-    // Read all three fields from one `DateTime.now()` capture so the
-    // error's `retryAfter` and `unblockAt` are mutually consistent —
-    // even when the gate re-opens between two separate getter reads.
+    // Read all three fields from one `Temporal.Now.instant()` capture
+    // so the error's `retryAfter` and `unblockAt` are mutually
+    // consistent — even when the gate re-opens between two separate
+    // getter reads.
     const { isPaused, remaining, unblockAt } = this.#gate.snapshot()
     if (isPaused) {
       throw new RateLimitError(

--- a/src/resilience/session-expiry.ts
+++ b/src/resilience/session-expiry.ts
@@ -1,4 +1,32 @@
-import { DateTime } from 'luxon'
+import { Temporal } from '../temporal.ts'
+
+// Detects an explicit UTC marker (`Z`) or numeric offset (`±HH:MM` /
+// `±HHMM`) after the date/time separator. Offset-less inputs need
+// zone-aware parsing; offset-bearing inputs are absolute instants.
+const OFFSET_REGEX = /[+-]\d{2}:?\d{2}$/u
+
+const hasOffset = (iso: string): boolean => {
+  if (!iso.includes('T')) {
+    return false
+  }
+  const afterT = iso.slice(iso.indexOf('T') + 1)
+  return afterT.includes('Z') || OFFSET_REGEX.test(afterT)
+}
+
+const parseToInstant = (
+  expiry: string,
+  zone: string | undefined,
+): Temporal.Instant | null => {
+  try {
+    if (hasOffset(expiry)) {
+      return Temporal.Instant.from(expiry)
+    }
+    const pdt = Temporal.PlainDateTime.from(expiry)
+    return pdt.toZonedDateTime(zone ?? Temporal.Now.timeZoneId()).toInstant()
+  } catch {
+    return null
+  }
+}
 
 /**
  * Check whether an ISO 8601 expiry timestamp has passed or is malformed.
@@ -16,26 +44,31 @@ import { DateTime } from 'luxon'
  * ever pays the full re-auth round-trip in its critical path. The
  * common value is 5 minutes (`5 * 60 * 1000`).
  *
- * Uses Luxon `DateTime.fromISO` (not native `Date.parse`) so that ISO
- * strings without an explicit timezone offset — the format the MELCloud
- * Classic server actually returns in `ClassicLoginData.Expiry` — are interpreted
- * in `LuxonSettings.defaultZone`, which Classic configures from
- * `ClassicAPIConfig.timezone`. Native parsing would anchor on the host runtime
- * timezone, shifting the comparison by hours when the deployment timezone
- * differs from the host (e.g. UTC CI runner, Docker container).
+ * Offset-less ISO strings — the format the MELCloud Classic server
+ * returns in `ClassicLoginData.Expiry` — are interpreted in the
+ * supplied `zone` (Classic configures this from
+ * `ClassicAPIConfig.timezone`). Without a zone, the runtime's system
+ * timezone is used. Strings with an explicit `Z` or `±HH:MM` offset
+ * are parsed as absolute `Temporal.Instant`s, ignoring `zone`.
  * @param expiry - ISO 8601 expiry timestamp (or empty string).
  * @param aheadMs - Consider the session expired `aheadMs` milliseconds
  * before its real expiry (default 0 = real expiry).
+ * @param zone - IANA timezone for offset-less inputs; defaults to the
+ * runtime system zone.
  * @returns `true` if the expiry is past (or within `aheadMs`) or cannot be parsed, `false` otherwise.
  */
-export const isSessionExpired = (expiry: string, aheadMs = 0): boolean => {
+export const isSessionExpired = (
+  expiry: string,
+  aheadMs = 0,
+  zone?: string,
+): boolean => {
   if (expiry === '') {
     return false
   }
-  const parsed = DateTime.fromISO(expiry)
-  if (!parsed.isValid) {
+  const parsed = parseToInstant(expiry, zone)
+  if (parsed === null) {
     return true
   }
-  const threshold = DateTime.now().plus({ milliseconds: aheadMs })
-  return parsed < threshold
+  const threshold = Temporal.Now.instant().add({ milliseconds: aheadMs })
+  return Temporal.Instant.compare(parsed, threshold) < 0
 }

--- a/src/temporal.ts
+++ b/src/temporal.ts
@@ -1,0 +1,10 @@
+// Re-export of `temporal-polyfill` as the single Temporal entry point
+// for the rest of the codebase. Node 22 (the minimum supported runtime)
+// does not yet ship native `Temporal`; the polyfill stays bundled
+// until Node 22 reaches EOL (April 2027), at which point this module
+// and the dependency can be replaced with `globalThis.Temporal`.
+//
+// Re-exporting via `export { ... }` preserves both the value and the
+// type namespace, so consumers can write `Temporal.Instant.from(...)`
+// and `function f(x: Temporal.Instant)` from a single import.
+export { Temporal } from 'temporal-polyfill'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,3 @@
-import { DateTime, Settings as LuxonSettings } from 'luxon'
-
 import type {
   ReportChartLineOptions,
   ReportChartPieOptions,
@@ -13,6 +11,7 @@ import type {
   KeyOfClassicSetDeviceDataAtaNotInList,
 } from './types/index.ts'
 import { type ClassicDeviceType, ClassicLabelType } from './constants.ts'
+import { Temporal } from './temporal.ts'
 
 // API encodes year-month as YYYYMM integer (e.g., 202306 for June 2023)
 const YEAR_MONTH_DIVISOR = 100
@@ -23,20 +22,38 @@ const MONTH_NAME_BASE_YEAR = 2024
 
 interface LabelFormatterCache {
   readonly dayOfWeek: Intl.DateTimeFormat
-  readonly locale: string | null | undefined
+  readonly locale: string | null
   readonly month: Intl.DateTimeFormat
 }
 
 let formatterCache: LabelFormatterCache | null = null
 
-// Luxon types defaultLocale as `string` but emits `null` at runtime when unset; widen at the boundary.
-const getDefaultLocale = (): string | null | undefined =>
-  LuxonSettings.defaultLocale
+// Module-level locale for report labels. Replaces Luxon's
+// `Settings.defaultLocale` global with an explicit, type-safe sink.
+// `null` means "use the runtime default" (matches the original
+// "unset" sentinel emitted by Luxon at runtime).
+let currentReportLocale: string | null = null
 
-// Tracks LuxonSettings.defaultLocale so output stays consistent with the rest
-// of the codebase's datetime formatting without re-creating Intl.DateTimeFormat per call.
+/**
+ * Set the locale used to format report chart labels (day-of-week,
+ * month names, etc.). Pass `null` to fall back to the runtime default.
+ * @param locale - BCP-47 language tag, or `null` for runtime default.
+ */
+export const setReportLocale = (locale: string | null): void => {
+  currentReportLocale = locale
+}
+
+/**
+ * Current report locale, or `null` when no explicit locale has been
+ * configured.
+ * @returns The configured locale, or `null`.
+ */
+export const getReportLocale = (): string | null => currentReportLocale
+
+// Tracks `currentReportLocale` so output stays consistent with the
+// configured locale without re-creating `Intl.DateTimeFormat` per call.
 const getLabelFormatters = (): LabelFormatterCache => {
-  const locale = getDefaultLocale()
+  const locale = currentReportLocale
   if (formatterCache !== null && formatterCache.locale === locale) {
     return formatterCache
   }
@@ -75,9 +92,17 @@ export const clampToRange = (
 
 /**
  * Get the current date/time as an ISO 8601 string without timezone offset.
+ *
+ * When a timezone is supplied, the wall-clock time is taken in that
+ * zone; otherwise the runtime's system zone is used. The returned
+ * string is the local `PlainDateTime` ISO form (no `Z`, no `+HH:MM`).
+ * @param timeZone - IANA timezone identifier, or omitted for system zone.
  * @returns The current date/time as an ISO string.
  */
-export const now = (): string => DateTime.now().toISO({ includeOffset: false })
+export const now = (timeZone?: string): string =>
+  Temporal.Now.plainDateTimeISO(timeZone).toString({
+    smallestUnit: 'millisecond',
+  })
 
 /**
  * Factory for a type guard that narrows a key to the own keys of `record`.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,54 +22,35 @@ const MONTH_NAME_BASE_YEAR = 2024
 
 interface LabelFormatterCache {
   readonly dayOfWeek: Intl.DateTimeFormat
-  readonly locale: string | null
   readonly month: Intl.DateTimeFormat
 }
 
-let formatterCache: LabelFormatterCache | null = null
+// Per-locale `Intl.DateTimeFormat` cache. Keyed on the locale string
+// (or `''` for the runtime default) so repeat calls with the same
+// locale reuse the same formatter pair without re-allocating on each
+// chart-options call. Modern best practice: the locale is carried as
+// an explicit argument by each call site, never via a mutable global.
+const formatterCacheByLocale = new Map<string, LabelFormatterCache>()
 
-// Module-level locale for report labels. Replaces Luxon's
-// `Settings.defaultLocale` global with an explicit, type-safe sink.
-// `null` means "use the runtime default" (matches the original
-// "unset" sentinel emitted by Luxon at runtime).
-let currentReportLocale: string | null = null
-
-/**
- * Set the locale used to format report chart labels (day-of-week,
- * month names, etc.). Pass `null` to fall back to the runtime default.
- * @param locale - BCP-47 language tag, or `null` for runtime default.
- */
-export const setReportLocale = (locale: string | null): void => {
-  currentReportLocale = locale
-}
-
-/**
- * Current report locale, or `null` when no explicit locale has been
- * configured.
- * @returns The configured locale, or `null`.
- */
-export const getReportLocale = (): string | null => currentReportLocale
-
-// Tracks `currentReportLocale` so output stays consistent with the
-// configured locale without re-creating `Intl.DateTimeFormat` per call.
-const getLabelFormatters = (): LabelFormatterCache => {
-  const locale = currentReportLocale
-  if (formatterCache !== null && formatterCache.locale === locale) {
-    return formatterCache
+const getLabelFormatters = (
+  locale: string | undefined,
+): LabelFormatterCache => {
+  const key = locale ?? ''
+  const cached = formatterCacheByLocale.get(key)
+  if (cached !== undefined) {
+    return cached
   }
-  const base = locale ?? undefined
   const cache: LabelFormatterCache = {
-    dayOfWeek: new Intl.DateTimeFormat(base, {
+    dayOfWeek: new Intl.DateTimeFormat(locale, {
       timeZone: 'UTC',
       weekday: 'short',
     }),
-    locale,
-    month: new Intl.DateTimeFormat(base, {
+    month: new Intl.DateTimeFormat(locale, {
       month: 'short',
       timeZone: 'UTC',
     }),
   }
-  formatterCache = cache
+  formatterCacheByLocale.set(key, cache)
   return cache
 }
 
@@ -163,34 +144,43 @@ export const isSetDeviceDataAtaInList: (
 
 // Strategy map: transform raw API label formats into human-readable strings
 // based on report granularity (day of week, month name, year-month, etc.)
-const labelFormatters: Record<ClassicLabelType, (label: string) => string> = {
-  [ClassicLabelType.day_of_week]: (label) =>
-    getLabelFormatters().dayOfWeek.format(
-      Date.UTC(DAY_OF_WEEK_BASE_YEAR, 0, Number(label)),
-    ),
-  [ClassicLabelType.month]: (label) =>
-    getLabelFormatters().month.format(
-      Date.UTC(MONTH_NAME_BASE_YEAR, Number(label) - 1, 1),
-    ),
-  [ClassicLabelType.month_of_year]: (label) => {
-    const year = Math.floor(Number(label) / YEAR_MONTH_DIVISOR)
-    const month = (Number(label) % YEAR_MONTH_DIVISOR) - 1
+// The closure receives the resolved per-call locale so repeat calls with
+// different locales stay isolated and the cache stays consistent.
+const buildLabelFormatters = (
+  locale: string | undefined,
+): Record<ClassicLabelType, (label: string) => string> => {
+  const formatters = getLabelFormatters(locale)
+  return {
+    [ClassicLabelType.day_of_week]: (label) =>
+      formatters.dayOfWeek.format(
+        Date.UTC(DAY_OF_WEEK_BASE_YEAR, 0, Number(label)),
+      ),
+    [ClassicLabelType.month]: (label) =>
+      formatters.month.format(
+        Date.UTC(MONTH_NAME_BASE_YEAR, Number(label) - 1, 1),
+      ),
+    [ClassicLabelType.month_of_year]: (label): string => {
+      const year = Math.floor(Number(label) / YEAR_MONTH_DIVISOR)
+      const month = (Number(label) % YEAR_MONTH_DIVISOR) - 1
 
-    // Format month and year separately to preserve the "MMM yyyy" ordering
-    // across locales; `Intl.DateTimeFormat` with both fields reorders (e.g. ja → "yyyy年M月").
-    const monthName = getLabelFormatters().month.format(
-      Date.UTC(year, month, 1),
-    )
-    return `${monthName} ${String(year)}`
-  },
-  [ClassicLabelType.raw]: (label) => label,
-  [ClassicLabelType.time]: (label) => label,
+      // Format month and year separately to preserve the "MMM yyyy" ordering
+      // across locales; `Intl.DateTimeFormat` with both fields reorders (e.g. ja → "yyyy年M月").
+      const monthName = formatters.month.format(Date.UTC(year, month, 1))
+      return `${monthName} ${String(year)}`
+    },
+    [ClassicLabelType.raw]: (label) => label,
+    [ClassicLabelType.time]: (label) => label,
+  }
 }
 
 const formatLabels = (
   labels: readonly string[],
   labelType: ClassicLabelType,
-): string[] => labels.map((label) => labelFormatters[labelType](label))
+  locale: string | undefined,
+): string[] => {
+  const formatters = buildLabelFormatters(locale)
+  return labels.map((label) => formatters[labelType](label))
+}
 
 /**
  * Type-safe `Object.keys` that preserves the key type of the input object.
@@ -247,15 +237,38 @@ const getChartLineSeries = ({
     )
 
 /**
- * Transform raw API report data into structured line chart options with formatted labels.
+ * Options for {@link getChartLineOptions}. Carried as an object so
+ * `locale` stays an explicit, named, per-call argument (no global
+ * mutable locale state).
+ */
+export interface ChartLineFormatOptions {
+  /** Legend entries for each data series. */
+  readonly legend: readonly (string | undefined)[]
+  /** Unit of measurement for the data. */
+  readonly unit: string
+  /**
+   * BCP-47 locale tag for day-of-week and month-name labels. Defaults
+   * to the runtime locale when omitted.
+   */
+  readonly locale?: string
+}
+
+/**
+ * Transform raw API report data into structured line chart options
+ * with formatted labels.
+ *
+ * Per modern library conventions, this function carries no mutable
+ * locale global — the caller decides via `options.locale`.
  * @param root0 - The raw report data from the Classic API.
  * @param root0.Data - The data series arrays.
  * @param root0.FromDate - The start date of the report period.
  * @param root0.LabelType - The label format type determining how labels are parsed.
  * @param root0.Labels - The raw label strings from the Classic API.
  * @param root0.ToDate - The end date of the report period.
- * @param legend - Legend entries for each data series.
- * @param unit - The unit of measurement for the data.
+ * @param options - Legend, unit, and locale for label formatting.
+ * @param options.legend - Legend entries for each data series.
+ * @param options.locale - BCP-47 locale tag; defaults to the runtime locale when omitted.
+ * @param options.unit - Unit of measurement for the data.
  * @returns Structured line chart options.
  */
 export const getChartLineOptions = (
@@ -266,11 +279,10 @@ export const getChartLineOptions = (
     LabelType: labelType,
     ToDate: to,
   }: ClassicReportData,
-  legend: readonly (string | undefined)[],
-  unit: string,
+  { legend, locale, unit }: ChartLineFormatOptions,
 ): ReportChartLineOptions => ({
   from,
-  labels: formatLabels(labels, labelType),
+  labels: formatLabels(labels, labelType, locale),
   series: getChartLineSeries({ data, legend }),
   to,
   unit,

--- a/tests/unit/classic-api.test.ts
+++ b/tests/unit/classic-api.test.ts
@@ -126,6 +126,13 @@ describe('mELCloud Classic API', () => {
     await api.notifySync({ type: undefined })
 
     expect(onSyncComplete).toHaveBeenCalledWith({ type: undefined })
+    expect(api.timezone).toBe('Europe/Paris')
+  })
+
+  it('exposes timezone as undefined when none is configured', async () => {
+    const api = await createApi()
+
+    expect(api.timezone).toBeUndefined()
   })
 
   it('accepts a disabled sync timer', async () => {

--- a/tests/unit/classic-api.test.ts
+++ b/tests/unit/classic-api.test.ts
@@ -117,6 +117,7 @@ describe('mELCloud Classic API', () => {
     const api = await createApi({
       events: { onSyncComplete },
       language: 'fr',
+      locale: 'fr-FR',
       logger: createLogger(),
       shouldVerifySSL: false,
       timezone: 'Europe/Paris',
@@ -127,12 +128,14 @@ describe('mELCloud Classic API', () => {
 
     expect(onSyncComplete).toHaveBeenCalledWith({ type: undefined })
     expect(api.timezone).toBe('Europe/Paris')
+    expect(api.locale).toBe('fr-FR')
   })
 
-  it('exposes timezone as undefined when none is configured', async () => {
+  it('exposes timezone and locale as undefined when none is configured', async () => {
     const api = await createApi()
 
     expect(api.timezone).toBeUndefined()
+    expect(api.locale).toBeUndefined()
   })
 
   it('accepts a disabled sync timer', async () => {

--- a/tests/unit/classic-api.test.ts
+++ b/tests/unit/classic-api.test.ts
@@ -591,6 +591,23 @@ describe('mELCloud Classic API', () => {
       expect(okValue(result).errors).toHaveLength(0)
     })
 
+    it('keeps entries with unparseable StartDate (no invalid-year sentinel)', async () => {
+      mockLoginAndList()
+      const api = await createApi({ password: 'pass', username: 'user' })
+      mockRequest.mockResolvedValue(
+        wrap([
+          errorEntry({
+            ErrorMessage: 'Mystery',
+            StartDate: 'not-a-real-date',
+          }),
+        ]),
+      )
+      const result = await api.getErrorLog({}, [1])
+
+      expect(okValue(result).errors).toHaveLength(1)
+      expect(okValue(result).errors[0]?.error).toBe('Mystery')
+    })
+
     it('returns validation failure when the API returns failure data', async () => {
       mockLoginAndList()
       const api = await createApi({ password: 'pass', username: 'user' })

--- a/tests/unit/classic-facades.test.ts
+++ b/tests/unit/classic-facades.test.ts
@@ -258,6 +258,16 @@ describe('building facade', () => {
     expect(api.getSignal).toHaveBeenCalledWith(expect.any(Object))
   })
 
+  it('defaults getSignalStrength hour to the current hour', async () => {
+    const { api, facade } = createBuildingFacade()
+    okValue(await facade.getSignalStrength())
+
+    const call = vi.mocked(api.getSignal).mock.calls[0]?.[0]
+
+    expect(call?.postData.hour).toBeGreaterThanOrEqual(0)
+    expect(call?.postData.hour).toBeLessThanOrEqual(23)
+  })
+
   it('calls getTiles without selection', async () => {
     const { facade } = createBuildingFacade()
     const value = okValue(await facade.getTiles())
@@ -776,6 +786,16 @@ describe('ata device facade', () => {
 
     expect(value).toHaveProperty('series')
     expect(api.getHourlyTemperatures).toHaveBeenCalledWith(expect.any(Object))
+  })
+
+  it('defaults hourlyTemperatures hour to the current hour', async () => {
+    const { api, facade } = createAtaFacade()
+    okValue(await facade.getHourlyTemperatures())
+
+    const call = vi.mocked(api.getHourlyTemperatures).mock.calls[0]?.[0]
+
+    expect(call?.postData.hour).toBeGreaterThanOrEqual(0)
+    expect(call?.postData.hour).toBeLessThanOrEqual(23)
   })
 
   it('calls getTiles without selection', async () => {

--- a/tests/unit/decorators.test.ts
+++ b/tests/unit/decorators.test.ts
@@ -1,4 +1,3 @@
-import { Duration } from 'luxon'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { ClassicAPIAdapter, SyncCallback } from '../../src/api/index.ts'
@@ -26,6 +25,7 @@ import {
   RateLimitError,
 } from '../../src/errors/index.ts'
 import { HttpError } from '../../src/http/index.ts'
+import { Temporal } from '../../src/temporal.ts'
 import { cast, mock } from '../helpers.ts'
 
 const createMockFacade = (
@@ -462,7 +462,7 @@ describe(classifyError, () => {
     },
     {
       error: new RateLimitError('paused', {
-        retryAfter: Duration.fromMillis(5000),
+        retryAfter: Temporal.Duration.from({ milliseconds: 5000 }),
         unblockAt: null,
       }),
       expected: { kind: 'rate-limited', retryAfterMs: 5000 } as const,

--- a/tests/unit/errors.test.ts
+++ b/tests/unit/errors.test.ts
@@ -1,4 +1,3 @@
-import { DateTime, Duration } from 'luxon'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -9,6 +8,7 @@ import {
   RateLimitError,
   ValidationError,
 } from '../../src/errors/index.ts'
+import { Temporal } from '../../src/temporal.ts'
 
 describe.concurrent('apiError hierarchy', () => {
   it('authenticationError is an instance of APIError and Error', () => {
@@ -37,14 +37,14 @@ describe.concurrent('apiError hierarchy', () => {
   })
 
   it('rateLimitError carries the retryAfter duration and unblockAt time', () => {
-    const retryAfter = Duration.fromObject({ seconds: 30 })
-    const unblockAt = DateTime.fromISO('2026-01-01T12:30:00Z')
+    const retryAfter = Temporal.Duration.from({ seconds: 30 })
+    const unblockAt = Temporal.Instant.from('2026-01-01T12:30:00Z')
     const error = new RateLimitError('throttled', { retryAfter, unblockAt })
 
     expect(error).toBeInstanceOf(RateLimitError)
     expect(error).toBeInstanceOf(APIError)
-    expect(error.retryAfter?.as('seconds')).toBe(30)
-    expect(error.unblockAt?.toISO()).toBe(unblockAt.toISO())
+    expect(error.retryAfter?.total({ unit: 'seconds' })).toBe(30)
+    expect(error.unblockAt?.equals(unblockAt)).toBe(true)
     expect(error.name).toBe('RateLimitError')
   })
 

--- a/tests/unit/rate-limit-gate.test.ts
+++ b/tests/unit/rate-limit-gate.test.ts
@@ -27,10 +27,12 @@ describe(RateLimitGate, () => {
 
     expect(gate.isPaused).toBe(true)
     // Use Luxon's millisecond conversion, accounting for slight drift.
-    expect(gate.remaining?.as('hours')).toBeGreaterThan(1.9)
-    expect(gate.remaining?.as('hours')).toBeLessThanOrEqual(2)
+    expect(gate.remaining?.total({ unit: 'hours' })).toBeGreaterThan(1.9)
+    expect(gate.remaining?.total({ unit: 'hours' })).toBeLessThanOrEqual(2)
     // Absolute unblock time is 2 hours after the fixed system time.
-    expect(gate.unblockAt?.toUTC().toISO()).toBe('2026-04-11T14:00:00.000Z')
+    expect(gate.unblockAt?.toString({ smallestUnit: 'millisecond' })).toBe(
+      '2026-04-11T14:00:00.000Z',
+    )
   })
 
   it('honors a numeric Retry-After header (seconds)', () => {
@@ -39,8 +41,8 @@ describe(RateLimitGate, () => {
     gate.recordRateLimit(30)
 
     expect(gate.isPaused).toBe(true)
-    expect(gate.remaining?.as('seconds')).toBeGreaterThan(29)
-    expect(gate.remaining?.as('seconds')).toBeLessThanOrEqual(30)
+    expect(gate.remaining?.total({ unit: 'seconds' })).toBeGreaterThan(29)
+    expect(gate.remaining?.total({ unit: 'seconds' })).toBeLessThanOrEqual(30)
   })
 
   it('honors a string Retry-After header (seconds)', () => {
@@ -49,7 +51,7 @@ describe(RateLimitGate, () => {
     gate.recordRateLimit('45')
 
     expect(gate.isPaused).toBe(true)
-    expect(gate.remaining?.as('seconds')).toBeGreaterThan(44)
+    expect(gate.remaining?.total({ unit: 'seconds' })).toBeGreaterThan(44)
   })
 
   it('falls back when Retry-After is non-numeric', () => {
@@ -58,7 +60,7 @@ describe(RateLimitGate, () => {
     gate.recordRateLimit('not-a-number')
 
     expect(gate.isPaused).toBe(true)
-    expect(gate.remaining?.as('hours')).toBeGreaterThan(1.9)
+    expect(gate.remaining?.total({ unit: 'hours' })).toBeGreaterThan(1.9)
   })
 
   it('falls back when Retry-After is zero or negative', () => {
@@ -66,11 +68,11 @@ describe(RateLimitGate, () => {
 
     gate.recordRateLimit(0)
 
-    expect(gate.remaining?.as('hours')).toBeGreaterThan(1.9)
+    expect(gate.remaining?.total({ unit: 'hours' })).toBeGreaterThan(1.9)
 
     gate.recordRateLimit(-5)
 
-    expect(gate.remaining?.as('hours')).toBeGreaterThan(1.9)
+    expect(gate.remaining?.total({ unit: 'hours' })).toBeGreaterThan(1.9)
   })
 
   it('re-opens automatically after the window elapses', () => {
@@ -111,7 +113,9 @@ describe(RateLimitGate, () => {
     expect(snap.isPaused).toBe(true)
     expect(snap.remaining).not.toBeNull()
     expect(snap.unblockAt).not.toBeNull()
-    expect(snap.unblockAt?.toUTC().toISO()).toBe('2026-04-11T14:00:00.000Z')
+    expect(snap.unblockAt?.toString({ smallestUnit: 'millisecond' })).toBe(
+      '2026-04-11T14:00:00.000Z',
+    )
   })
 
   it('snapshot() returns all nulls when open', () => {

--- a/tests/unit/rate-limit-gate.test.ts
+++ b/tests/unit/rate-limit-gate.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { RateLimitGate } from '../../src/resilience/rate-limit-gate.ts'
+import {
+  formatDurationHuman,
+  RateLimitGate,
+} from '../../src/resilience/rate-limit-gate.ts'
+import { Temporal } from '../../src/temporal.ts'
 
 describe(RateLimitGate, () => {
   beforeEach(() => {
@@ -98,12 +102,6 @@ describe(RateLimitGate, () => {
     expect(gate.isPaused).toBe(false)
   })
 
-  it('formatRemaining returns empty string when open', () => {
-    const gate = new RateLimitGate({ hours: 2 })
-
-    expect(gate.formatRemaining()).toBe('')
-  })
-
   it('snapshot() returns all fields consistently when paused', () => {
     const gate = new RateLimitGate({ hours: 2 })
     gate.recordRateLimit()
@@ -126,36 +124,6 @@ describe(RateLimitGate, () => {
     expect(snap.isPaused).toBe(false)
     expect(snap.remaining).toBeNull()
     expect(snap.unblockAt).toBeNull()
-  })
-
-  it('formatRemaining returns a human-readable duration when paused', () => {
-    const gate = new RateLimitGate({ hours: 2 })
-    gate.recordRateLimit(120)
-
-    const formatted = gate.formatRemaining()
-
-    expect(formatted).not.toBe('')
-    expect(formatted).toMatch(/minute/iu)
-  })
-
-  it('formatRemaining reports seconds for sub-minute windows', () => {
-    const gate = new RateLimitGate({ hours: 2 })
-    gate.recordRateLimit(20)
-
-    const formatted = gate.formatRemaining()
-
-    expect(formatted).toMatch(/second/iu)
-    expect(formatted).not.toMatch(/minute/iu)
-  })
-
-  it('formatRemaining reports minutes and seconds for multi-minute windows', () => {
-    const gate = new RateLimitGate({ hours: 2 })
-    gate.recordRateLimit(135)
-
-    const formatted = gate.formatRemaining()
-
-    expect(formatted).toMatch(/minute/iu)
-    expect(formatted).toMatch(/second/iu)
   })
 
   it('recordAndLog records the rate-limit and emits a formatted error', () => {
@@ -181,5 +149,43 @@ describe(RateLimitGate, () => {
     expect(error).toHaveBeenCalledWith(
       expect.stringMatching(/pausing for \d+/u),
     )
+  })
+})
+
+describe.concurrent(formatDurationHuman, () => {
+  it('renders sub-minute windows as seconds with no minute mention', () => {
+    const formatted = formatDurationHuman(
+      Temporal.Duration.from({ seconds: 20 }),
+    )
+
+    expect(formatted).toBe('20 seconds')
+  })
+
+  it('renders exact-minute windows without a seconds component', () => {
+    const formatted = formatDurationHuman(
+      Temporal.Duration.from({ seconds: 120 }),
+    )
+
+    expect(formatted).toBe('2 minutes')
+  })
+
+  it('renders multi-minute windows as "M minutes, S seconds"', () => {
+    const formatted = formatDurationHuman(
+      Temporal.Duration.from({ seconds: 135 }),
+    )
+
+    expect(formatted).toBe('2 minutes, 15 seconds')
+  })
+
+  it('renders single-unit windows with singular forms', () => {
+    expect(formatDurationHuman(Temporal.Duration.from({ seconds: 1 }))).toBe(
+      '1 second',
+    )
+    expect(formatDurationHuman(Temporal.Duration.from({ minutes: 1 }))).toBe(
+      '1 minute',
+    )
+    expect(
+      formatDurationHuman(Temporal.Duration.from({ minutes: 1, seconds: 1 })),
+    ).toBe('1 minute, 1 second')
   })
 })

--- a/tests/unit/session-expiry.test.ts
+++ b/tests/unit/session-expiry.test.ts
@@ -38,10 +38,11 @@ describe(isSessionExpired, () => {
 
   it('parses ISO timestamps without explicit timezone offset', () => {
     // Regression for the format MELCloud Classic returns in
-    // `ClassicLoginData.Expiry` (no `Z`, no offset). Native `Date.parse` would
-    // interpret these in the host runtime timezone, shifting comparisons
-    // by hours when host TZ ≠ configured TZ. Luxon `DateTime.fromISO`
-    // uses `LuxonSettings.defaultZone` (set by Classic from ClassicAPIConfig.timezone).
+    // `ClassicLoginData.Expiry` (no `Z`, no offset). Without an explicit
+    // zone these are interpreted in the runtime's system timezone;
+    // Classic threads its configured zone (`ClassicAPIConfig.timezone`)
+    // through the third argument so deployments where host TZ differs
+    // from the configured TZ stay consistent.
     expect(isSessionExpired('2030-12-31T00:00:00')).toBe(false)
     expect(isSessionExpired('2020-01-01T00:00:00')).toBe(true)
   })

--- a/tests/unit/utils-extended.test.ts
+++ b/tests/unit/utils-extended.test.ts
@@ -1,4 +1,3 @@
-import { DateTime, Settings as LuxonSettings } from 'luxon'
 import { describe, expect, it } from 'vitest'
 
 import type {
@@ -6,10 +5,13 @@ import type {
   ClassicReportData,
 } from '../../src/types/index.ts'
 import { ClassicLabelType } from '../../src/constants.ts'
+import { Temporal } from '../../src/temporal.ts'
 import {
   getChartLineOptions,
   getChartPieOptions,
+  getReportLocale,
   now,
+  setReportLocale,
 } from '../../src/utils.ts'
 
 describe.concurrent(now, () => {
@@ -18,7 +20,7 @@ describe.concurrent(now, () => {
 
     expect(result).not.toContain('+')
     expect(result).not.toContain('Z')
-    expect(() => DateTime.fromISO(result)).not.toThrow()
+    expect(() => Temporal.PlainDateTime.from(result)).not.toThrow()
   })
 })
 
@@ -52,7 +54,7 @@ describe.concurrent('formatLabels (via getChartLineOptions)', () => {
   })
 
   it('formats day_of_week labels', () => {
-    LuxonSettings.defaultLocale = 'en'
+    setReportLocale('en')
     const data = {
       ...baseReportData,
       Labels: ['1', '2', '3'],
@@ -65,7 +67,7 @@ describe.concurrent('formatLabels (via getChartLineOptions)', () => {
   })
 
   it('formats month labels', () => {
-    LuxonSettings.defaultLocale = 'en'
+    setReportLocale('en')
     const data = {
       ...baseReportData,
       Labels: ['1', '6', '12'],
@@ -79,7 +81,7 @@ describe.concurrent('formatLabels (via getChartLineOptions)', () => {
   })
 
   it('formats month_of_year labels', () => {
-    LuxonSettings.defaultLocale = 'en'
+    setReportLocale('en')
     const data = {
       ...baseReportData,
       Labels: ['202401', '202412'],
@@ -162,12 +164,11 @@ describe.concurrent(getChartPieOptions, () => {
   })
 })
 
-describe('formatLabels with unset defaultLocale', () => {
-  it('falls back to system locale when LuxonSettings.defaultLocale is null', () => {
-    const { defaultLocale: originalLocale } = LuxonSettings
+describe('formatLabels with unset report locale', () => {
+  it('falls back to system locale when the report locale is null', () => {
+    const originalLocale = getReportLocale()
     try {
-      // Luxon types defaultLocale as `string` but null is the unset sentinel
-      ;(LuxonSettings as { defaultLocale: string | null }).defaultLocale = null
+      setReportLocale(null)
       const data: ClassicReportData = {
         Data: [[1]],
         FromDate: '2024-01-01',
@@ -182,7 +183,7 @@ describe('formatLabels with unset defaultLocale', () => {
       expect(result.labels).toHaveLength(1)
       expect(result.labels[0]).toBeDefined()
     } finally {
-      LuxonSettings.defaultLocale = originalLocale
+      setReportLocale(originalLocale)
     }
   })
 })

--- a/tests/unit/utils-extended.test.ts
+++ b/tests/unit/utils-extended.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import type {
   ClassicOperationModeLogData,
@@ -24,7 +24,23 @@ describe.concurrent(now, () => {
   })
 })
 
-describe.concurrent('formatLabels (via getChartLineOptions)', () => {
+// Not `describe.concurrent`: these specs mutate the module-level report
+// locale via `setReportLocale`, so concurrent execution would interleave
+// different locale values and make label assertions flaky. The `beforeEach`/
+// `afterEach` pair pins each spec to `'en'` and restores the original
+// locale on exit so the suite cannot leak into later suites either.
+describe('formatLabels (via getChartLineOptions)', () => {
+  let originalLocale: string | null = null
+
+  beforeEach(() => {
+    originalLocale = getReportLocale()
+    setReportLocale('en')
+  })
+
+  afterEach(() => {
+    setReportLocale(originalLocale)
+  })
+
   const baseReportData: ClassicReportData = {
     Data: [[1, 2]],
     FromDate: '2024-01-01',
@@ -54,7 +70,6 @@ describe.concurrent('formatLabels (via getChartLineOptions)', () => {
   })
 
   it('formats day_of_week labels', () => {
-    setReportLocale('en')
     const data = {
       ...baseReportData,
       Labels: ['1', '2', '3'],
@@ -67,7 +82,6 @@ describe.concurrent('formatLabels (via getChartLineOptions)', () => {
   })
 
   it('formats month labels', () => {
-    setReportLocale('en')
     const data = {
       ...baseReportData,
       Labels: ['1', '6', '12'],
@@ -81,7 +95,6 @@ describe.concurrent('formatLabels (via getChartLineOptions)', () => {
   })
 
   it('formats month_of_year labels', () => {
-    setReportLocale('en')
     const data = {
       ...baseReportData,
       Labels: ['202401', '202412'],

--- a/tests/unit/utils-extended.test.ts
+++ b/tests/unit/utils-extended.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import type {
   ClassicOperationModeLogData,
@@ -9,9 +9,7 @@ import { Temporal } from '../../src/temporal.ts'
 import {
   getChartLineOptions,
   getChartPieOptions,
-  getReportLocale,
   now,
-  setReportLocale,
 } from '../../src/utils.ts'
 
 describe.concurrent(now, () => {
@@ -24,23 +22,7 @@ describe.concurrent(now, () => {
   })
 })
 
-// Not `describe.concurrent`: these specs mutate the module-level report
-// locale via `setReportLocale`, so concurrent execution would interleave
-// different locale values and make label assertions flaky. The `beforeEach`/
-// `afterEach` pair pins each spec to `'en'` and restores the original
-// locale on exit so the suite cannot leak into later suites either.
-describe('formatLabels (via getChartLineOptions)', () => {
-  let originalLocale: string | null = null
-
-  beforeEach(() => {
-    originalLocale = getReportLocale()
-    setReportLocale('en')
-  })
-
-  afterEach(() => {
-    setReportLocale(originalLocale)
-  })
-
+describe.concurrent('formatLabels (via getChartLineOptions)', () => {
   const baseReportData: ClassicReportData = {
     Data: [[1, 2]],
     FromDate: '2024-01-01',
@@ -53,7 +35,11 @@ describe('formatLabels (via getChartLineOptions)', () => {
 
   it('passes raw labels unchanged', () => {
     const data = { ...baseReportData, Labels: ['foo', 'bar'] }
-    const result = getChartLineOptions(data, ['Series 1'], 'unit')
+    const result = getChartLineOptions(data, {
+      legend: ['Series 1'],
+      locale: 'en',
+      unit: 'unit',
+    })
 
     expect(result.labels).toStrictEqual(['foo', 'bar'])
   })
@@ -64,7 +50,11 @@ describe('formatLabels (via getChartLineOptions)', () => {
       Labels: ['12:00', '13:00'],
       LabelType: ClassicLabelType.time,
     }
-    const result = getChartLineOptions(data, ['Series 1'], 'unit')
+    const result = getChartLineOptions(data, {
+      legend: ['Series 1'],
+      locale: 'en',
+      unit: 'unit',
+    })
 
     expect(result.labels).toStrictEqual(['12:00', '13:00'])
   })
@@ -75,7 +65,11 @@ describe('formatLabels (via getChartLineOptions)', () => {
       Labels: ['1', '2', '3'],
       LabelType: ClassicLabelType.day_of_week,
     }
-    const result = getChartLineOptions(data, ['Series 1'], 'unit')
+    const result = getChartLineOptions(data, {
+      legend: ['Series 1'],
+      locale: 'en',
+      unit: 'unit',
+    })
 
     expect(result.labels).toHaveLength(3)
     expect(result.labels[0]).toBe('Mon')
@@ -87,7 +81,11 @@ describe('formatLabels (via getChartLineOptions)', () => {
       Labels: ['1', '6', '12'],
       LabelType: ClassicLabelType.month,
     }
-    const result = getChartLineOptions(data, ['Series 1'], 'unit')
+    const result = getChartLineOptions(data, {
+      legend: ['Series 1'],
+      locale: 'en',
+      unit: 'unit',
+    })
 
     expect(result.labels[0]).toBe('Jan')
     expect(result.labels[1]).toBe('Jun')
@@ -100,10 +98,30 @@ describe('formatLabels (via getChartLineOptions)', () => {
       Labels: ['202401', '202412'],
       LabelType: ClassicLabelType.month_of_year,
     }
-    const result = getChartLineOptions(data, ['Series 1'], 'unit')
+    const result = getChartLineOptions(data, {
+      legend: ['Series 1'],
+      locale: 'en',
+      unit: 'unit',
+    })
 
     expect(result.labels[0]).toBe('Jan 2024')
     expect(result.labels[1]).toBe('Dec 2024')
+  })
+
+  it('honors a locale passed per-call', () => {
+    const data = {
+      ...baseReportData,
+      Labels: ['1', '6', '12'],
+      LabelType: ClassicLabelType.month,
+    }
+    const result = getChartLineOptions(data, {
+      legend: ['Series 1'],
+      locale: 'fr',
+      unit: 'unit',
+    })
+
+    // French short month name for January is "janv.".
+    expect(result.labels[0]?.startsWith('janv')).toBe(true)
   })
 })
 
@@ -122,11 +140,10 @@ describe.concurrent(getChartLineOptions, () => {
   }
 
   it('maps data series with legend names', () => {
-    const result = getChartLineOptions(
-      classicReportData,
-      ['ClassicTemperature', 'Humidity'],
-      '°C',
-    )
+    const result = getChartLineOptions(classicReportData, {
+      legend: ['ClassicTemperature', 'Humidity'],
+      unit: '°C',
+    })
 
     expect(result.series).toHaveLength(2)
     expect(result.series[0]?.name).toBe('ClassicTemperature')
@@ -137,22 +154,20 @@ describe.concurrent(getChartLineOptions, () => {
   })
 
   it('filters out series with undefined legend entries', () => {
-    const result = getChartLineOptions(
-      classicReportData,
-      ['ClassicTemperature', undefined],
-      '°C',
-    )
+    const result = getChartLineOptions(classicReportData, {
+      legend: ['ClassicTemperature', undefined],
+      unit: '°C',
+    })
 
     expect(result.series).toHaveLength(1)
     expect(result.series[0]?.name).toBe('ClassicTemperature')
   })
 
   it('returns empty series when all legends are undefined', () => {
-    const result = getChartLineOptions(
-      classicReportData,
-      [undefined, undefined],
-      '°C',
-    )
+    const result = getChartLineOptions(classicReportData, {
+      legend: [undefined, undefined],
+      unit: '°C',
+    })
 
     expect(result.series).toHaveLength(0)
   })
@@ -177,26 +192,23 @@ describe.concurrent(getChartPieOptions, () => {
   })
 })
 
-describe('formatLabels with unset report locale', () => {
-  it('falls back to system locale when the report locale is null', () => {
-    const originalLocale = getReportLocale()
-    try {
-      setReportLocale(null)
-      const data: ClassicReportData = {
-        Data: [[1]],
-        FromDate: '2024-01-01',
-        Labels: ['1'],
-        LabelType: ClassicLabelType.month,
-        Points: 1,
-        Series: 1,
-        ToDate: '2024-01-02',
-      }
-      const result = getChartLineOptions(data, ['Series 1'], 'unit')
-
-      expect(result.labels).toHaveLength(1)
-      expect(result.labels[0]).toBeDefined()
-    } finally {
-      setReportLocale(originalLocale)
+describe.concurrent('formatLabels with omitted locale', () => {
+  it('falls back to the runtime locale when none is supplied', () => {
+    const data: ClassicReportData = {
+      Data: [[1]],
+      FromDate: '2024-01-01',
+      Labels: ['1'],
+      LabelType: ClassicLabelType.month,
+      Points: 1,
+      Series: 1,
+      ToDate: '2024-01-02',
     }
+    const result = getChartLineOptions(data, {
+      legend: ['Series 1'],
+      unit: 'unit',
+    })
+
+    expect(result.labels).toHaveLength(1)
+    expect(result.labels[0]).toBeDefined()
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "target": "es2025",
-    "types": ["node", "luxon"],
+    "types": ["node"],
     "verbatimModuleSyntax": true
   }
 }


### PR DESCRIPTION
## Summary

Swap the runtime datetime library from Luxon to the Stage-4 Temporal proposal, polyfilled via [`temporal-polyfill`](https://github.com/fullcalendar/temporal-polyfill) until Node 22 reaches EOL (April 2027). The polyfill defers to native `globalThis.Temporal` once it ships unflagged (V8 14 / Node 26+), so this change is also the on-ramp for shedding the dependency entirely later.

### Breaking changes (intended for a v39.0.0 release)

- `RateLimitError.retryAfter` is now `Temporal.Duration | null` (was Luxon `Duration | null`). Read with `retryAfter.total({ unit: 'seconds' })` (or `'milliseconds'`).
- `RateLimitError.unblockAt` is now `Temporal.Instant | null` (was Luxon `DateTime | null`). Read with `unblockAt.toString()` or convert with `unblockAt.toZonedDateTimeISO(zone)`.
- `RateLimitGate` constructor now accepts a `RateLimitDurationLike` shape (`{ days?, hours?, minutes?, seconds? }`) instead of Luxon's `DurationLike`. Existing call sites — both internal — already pass `{ hours: N }` and are unaffected.
- The Classic API no longer mutates `LuxonSettings.defaultZone`. The configured `timezone` is held on the instance and threaded through `isSessionExpired` and `getErrorLog` so multiple `ClassicAPI` instances with different zones now stay independent (silent fix for a latent global-state bug).
- The locale used to format report chart labels was previously read from `LuxonSettings.defaultLocale` (a global Luxon could see). It is now an explicit module-level setting; new exports `setReportLocale(locale)` / `getReportLocale()` from the package root replace it.
- New export: `Temporal` (the polyfill namespace, falling back to native) is re-exported from the package root for consumers that want to format the error fields themselves.

### Notes

- The `temporal-polyfill` runtime dependency is ~30 KB gzipped — roughly the same size as Luxon. Bundle size is **not** the win here; the wins are the cleaner timezone semantics, the per-instance zone, and being future-proof for native Temporal.
- `Duration.toHuman()` has no direct equivalent in Temporal, so an in-house `formatDurationHuman` (sticks to the existing `"X minutes, Y seconds"` output) replaces it. `Intl.DurationFormat` was rejected to keep the format stable across runtimes.

## Test plan

- [x] `npm run typecheck` — passes with `@types/luxon` removed and `tsconfig.json#types` reduced to `["node"]`.
- [x] `npm run lint` — clean.
- [x] `npm run format` — clean.
- [x] `npm test` — 35 files / 677 tests pass, including session-expiry, rate-limit-gate, errors, utils-extended, decorators, classic-api, home-api.
- [x] `npm run build` — succeeds via tsgo.
- [x] `npm run docs` — typedoc renders the new Temporal types on `RateLimitError`.
- [ ] Manual smoke against a live MELCloud Classic instance with `timezone: 'Europe/Paris'` to confirm offset-less expiry parsing.
- [ ] Manual smoke against the Home BFF to confirm the `.NET`-style `.0000000` suffix on `/report/v1/trendsummary` is preserved.

https://claude.ai/code/session_01Gk8SbAbZK5NVnsQw6Ujf7J

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gk8SbAbZK5NVnsQw6Ujf7J)_