### PR TITLE
ci: add zizmor workflow for GitHub Actions security audit

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,23 @@
+concurrency:
+  cancel-in-progress: true
+  group: zizmor-${{ github.ref }}
+jobs:
+  zizmor:
+    name: Zizmor
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@b572f7b1a1c2d41efaab43d504f68d215c3cd727
+name: Zizmor
+on:
+  pull_request: {}
+  push:
+    branches: [main]
+permissions: {}


### PR DESCRIPTION
## Contexte

Évaluation de la pertinence d'ajouter **zizmor** (linter de sécurité pour workflows GitHub Actions) et **CodeQL** au dépôt.

- **CodeQL** : déjà activé via le *Default Setup* de GitHub Code Scanning → aucun workflow à ajouter.
- **zizmor** : pertinent malgré la posture déjà saine du repo (SHA pinning systématique, `permissions: {}` au root + grants par job, pas de `pull_request_target`/`workflow_run`, SonarCloud actif). Il verrouille cette posture contre les régressions futures et cible explicitement la surface des workflows `claude.yml` / `claude-code-review.yml` qui interpolent du contenu utilisateur (`comment.body`, `issue.title`, `review.body`).

## Approche

Workflow dédié `.github/workflows/zizmor.yml` utilisant l'action officielle **`zizmorcore/zizmor-action`** SHA-pinnée à v0.5.4 (`b572f7b1…`), avec ses défauts :

- `advanced-security: true` → SARIF généré et **uploadé automatiquement** vers le Security tab, où les findings cohabiteront avec ceux de CodeQL.
- `persona: regular` (pas d'`auditor`, trop bruyant pour un premier run).
- **Pas** de fail-on-findings : le triage se fait dans l'UI Code Scanning, pas en bloquant la CI. Si plus tard un blocage par sévérité est souhaité, le faire via branch protection sur le check Code Scanning.

Le workflow respecte les conventions existantes du repo :

- `permissions: {}` au root + grants au niveau job (`actions: read`, `contents: read`, `security-events: write`).
- Triggers `pull_request: {}` + `push: branches: [main]` (miroir de `ci.yml`).
- `concurrency` avec `cancel-in-progress: true`.
- `actions/checkout` au même SHA que partout ailleurs, avec `persist-credentials: false` et `fetch-depth: 1` (zizmor ne lit que `.github/`).
- **Pas** de fichier `.github/zizmor.yml` initial — les éventuels false positives se dismissent via l'UI Code Scanning.

## Hors scope

- Pas de CodeQL workflow (déjà couvert par Default Setup).
- Pas d'actionlint ni de pre-commit hooks (non demandés, le repo n'a pas de framework pre-commit).

## Test plan

- [ ] Le check « Zizmor / Zizmor » apparaît et passe sur cette PR.
- [ ] Logs : le step `zizmor-action` exécute l'audit et upload le SARIF avec succès (PR intra-repo).
- [ ] Après merge sur `main`, ouvrir **Security → Code scanning alerts**, filtrer **Tool = zizmor** : vérifier que les findings (ou l'enregistrement de l'outil) apparaissent à côté de ceux de CodeQL.
- [ ] Triager en priorité les éventuels findings sur `claude.yml` / `claude-code-review.yml` (interpolations de contenu utilisateur, déjà guardées par `author_association` et `head.repo.full_name`).
- [ ] Vérifier qu'une PR de fork (si elle survient) ne red-cross pas le run (l'upload SARIF soft-skippe sans tokens en écriture, c'est attendu).
- [ ] Dependabot (config `github-actions` déjà active) bumpera ensuite le SHA automatiquement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019bPuWEsYwsk4YKQ1qRqtg6)_