### PR TITLE
ci: address all zizmor findings on existing workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,13 @@
 updates:
-  - directory: /
+  - cooldown:
+      default-days: 7
+    directory: /
     package-ecosystem: github-actions
     schedule:
       interval: weekly
-    cooldown:
+  - cooldown:
       default-days: 7
-  - directory: /
+    directory: /
     groups:
       eslint:
         patterns:
@@ -33,6 +35,4 @@ updates:
     package-ecosystem: npm
     schedule:
       interval: weekly
-    cooldown:
-      default-days: 7
 version: 2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@ updates:
     package-ecosystem: github-actions
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
   - directory: /
     groups:
       eslint:
@@ -31,4 +33,6 @@ updates:
     package-ecosystem: npm
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
 version: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node-and-install
         with:
           install: 'false'
@@ -23,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node-and-install
         with:
           node-version: lts/*
@@ -40,6 +44,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: ./.github/actions/setup-node-and-install
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 1
+          persist-credentials: false
       - uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416
         with:
           claude_args: --model opus

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 1
+          persist-credentials: false
       - uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416
         with:
           additional_permissions: |

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,6 +1,6 @@
 jobs:
   dependabot:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     name: Dependabot
     permissions:
       contents: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node-and-install
       - run: npm run build
       - run: npm run docs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node-and-install
         with:
           registry-url: https://npm.pkg.github.com

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,6 @@
+rules:
+  # Not applicable: we publish to GitHub Packages with the job-scoped
+  # GITHUB_TOKEN (already OIDC-based), not to npmjs.org.
+  use-trusted-publishing:
+    ignore:
+      - publish.yml


### PR DESCRIPTION
## Contexte

Suite à l'activation de zizmor (#1513), 11 findings ont été remontés sur les workflows pré-existants. Cette PR applique **toutes les recommandations**, quelle que soit la sévérité.

## Changements

### `artipacked` (medium × 7) — `persist-credentials: false`

Ajouté sur chaque `actions/checkout` dans `ci.yml`, `docs.yml`, `publish.yml`, `claude.yml`, `claude-code-review.yml`. Aucun de ces workflows ne push vers git, donc le `GITHUB_TOKEN` persisté dans `.git/config` n'a aucune utilité fonctionnelle et constitue de la surface d'attaque inutile (échappement via dépendance compromise, etc.).

### `bot-conditions` (high × 1) — guard non-spoofable sur dependabot.yml

```diff
- if: github.actor == 'dependabot[bot]'
+ if: github.event.pull_request.user.login == 'dependabot[bot]'
```

Sur un trigger `pull_request`, `github.event.pull_request.user.login` est posé par GitHub à partir du véritable auteur de la PR et n'est pas influençable par un rerun manuel ou une chaîne de triggers — contrairement à `github.actor`. Particulièrement important ici car le job a `contents: write` + `pull-requests: write` et déclenche l'auto-merge.

### `dependabot-cooldown` (medium × 2) — cooldown supply chain

```yaml
cooldown:
  default-days: 7
```

Ajouté aux deux ecosystems (`github-actions` et `npm`) dans `.github/dependabot.yml`. Délai de 7 jours entre la publication d'une release et son adoption automatique → fenêtre de protection contre les compromissions de packages (cas récents `nx`, `ua-parser-js`, `event-stream`).

### `use-trusted-publishing` (info × 1) — suppression justifiée

Création de `.github/zizmor.yml` qui ignore cette règle sur `publish.yml`. Justification dans le fichier :

```yaml
# Not applicable: we publish to GitHub Packages with the job-scoped
# GITHUB_TOKEN (already OIDC-based), not to npmjs.org.
```

Trusted publishing OIDC est pertinent pour publier vers npmjs.org en remplacement d'un `NPM_TOKEN` statique. Ici on publie vers `npm.pkg.github.com` avec le `GITHUB_TOKEN` natif qui est déjà court-lived et job-scoped.

## Vérification

```
$ uvx zizmor --no-online-audits .github/
No findings to report. Good job! (1 ignored, 14 suppressed)
```

## Test plan

- [ ] CI verte sur cette PR (check `Zizmor / Zizmor` doit notamment passer sans aucune nouvelle alerte).
- [ ] Une fois mergé, le check Code Scanning sur `main` ne fait plus remonter aucune nouvelle alerte zizmor.
- [ ] La prochaine PR Dependabot s'auto-merge correctement (validation du nouveau guard `pull_request.user.login`).
- [ ] Les workflows `ci`, `docs`, `publish`, `claude` continuent de fonctionner normalement (aucun ne dépend des credentials git persistés).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019bPuWEsYwsk4YKQ1qRqtg6)_