### PR TITLE
ci: run CI on Dependabot PRs and harden all workflows

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -3,7 +3,7 @@ jobs:
     name: Audit
     permissions:
       contents: read
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,24 @@
+jobs:
+  audit:
+    name: Audit
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-node-and-install
+        with:
+          install: 'false'
+          node-version: lts/*
+      - run: npm audit --audit-level=high --omit=dev
+    timeout-minutes: 15
+name: Audit
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch: {}
+permissions: {}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ concurrency:
   group: ci-${{ github.ref }}
 jobs:
   audit:
-    if: github.actor != 'dependabot[bot]'
     name: Audit
     permissions:
       contents: read
@@ -17,8 +16,8 @@ jobs:
           install: 'false'
           node-version: lts/*
       - run: npm audit --audit-level=high --omit=dev
+    timeout-minutes: 15
   check:
-    if: github.actor != 'dependabot[bot]'
     name: Check
     permissions:
       contents: read
@@ -34,8 +33,8 @@ jobs:
       - run: npm run lint
       - run: npm run format
       - run: npm run docs
+    timeout-minutes: 15
   test:
-    if: github.actor != 'dependabot[bot]'
     name: Test (Node ${{ matrix.node-version }})
     permissions:
       contents: read
@@ -49,7 +48,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm test -- --coverage
-      - if: matrix.node-version == 'latest'
+      - if: matrix.node-version == 'latest' && (github.event_name == 'push' || (github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository))
         uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -57,6 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [22, latest, lts/*]
+    timeout-minutes: 20
 name: CI
 on:
   pull_request: {}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,27 +1,12 @@
 concurrency:
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
   group: ci-${{ github.ref }}
 jobs:
-  audit:
-    name: Audit
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/setup-node-and-install
-        with:
-          install: 'false'
-          node-version: lts/*
-      - run: npm audit --audit-level=high --omit=dev
-    timeout-minutes: 15
   check:
     name: Check
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -38,7 +23,7 @@ jobs:
     name: Test (Node ${{ matrix.node-version }})
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     name: Check
     permissions:
       contents: read
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -23,7 +23,7 @@ jobs:
     name: Test (Node ${{ matrix.node-version }})
     permissions:
       contents: read
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,7 +13,7 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,3 +1,6 @@
+concurrency:
+  cancel-in-progress: true
+  group: claude-review-${{ github.event.pull_request.number }}
 jobs:
   review:
     if: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,7 +13,7 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: write
       issues: read
       pull-requests: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: write
       issues: read
       pull-requests: read
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -5,7 +5,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - id: metadata
         name: Dependabot metadata

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -16,6 +16,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: gh pr merge --auto --merge --delete-branch "$PR_URL"
+    timeout-minutes: 10
 name: Dependabot
 on: pull_request
 permissions: {}

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -5,7 +5,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - id: metadata
         name: Dependabot metadata

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
         with:
           path: docs
+    timeout-minutes: 15
   deploy:
     environment:
       name: github-pages
@@ -31,6 +32,7 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128
+    timeout-minutes: 10
 name: Generate & deploy docs
 on:
   release:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ jobs:
     name: Build docs
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -28,7 +28,7 @@ jobs:
     permissions:
       id-token: write
       pages: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ jobs:
     name: Build docs
     permissions:
       contents: read
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -28,7 +28,7 @@ jobs:
     permissions:
       id-token: write
       pages: write
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,6 @@
+concurrency:
+  cancel-in-progress: false
+  group: publish
 jobs:
   publish:
     name: Publish package to GitHub Packages
@@ -17,6 +20,7 @@ jobs:
           IS_PRERELEASE: ${{ github.event.release.prerelease }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm publish ${{ github.event.release.prerelease && '--tag next' || '' }}
+    timeout-minutes: 15
 name: Publish package to GitHub Packages
 on:
   release:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,11 +3,12 @@ concurrency:
   group: publish
 jobs:
   publish:
+    environment: npm
     name: Publish package to GitHub Packages
     permissions:
       contents: read
       packages: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,5 +1,5 @@
 concurrency:
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
   group: zizmor-${{ github.ref }}
 jobs:
   zizmor:
@@ -8,7 +8,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -8,7 +8,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -15,6 +15,7 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
       - uses: zizmorcore/zizmor-action@b572f7b1a1c2d41efaab43d504f68d215c3cd727
+    timeout-minutes: 15
 name: Zizmor
 on:
   pull_request: {}


### PR DESCRIPTION
Inspired by the spirit of [`OlivierZal/com.melcloud@262779e`](https://github.com/OlivierZal/com.melcloud/commit/262779e298d532487e9890cd2125f5552e3c0fc5) — *"Run CI on Dependabot PRs and harden all workflows"* — then extended with a broader workflow best-practices pass.

## 1. Run CI on Dependabot PRs
- Removed the `if: github.actor != 'dependabot[bot]'` exclusions from the **check** and **test** jobs in `ci.yml`, so dependency-bump PRs are validated.
- Guarded the **SonarQube** step so it only runs on pushes or non-Dependabot, non-fork PRs (i.e. only when `SONAR_TOKEN` is available):
  ```yaml
  if: matrix.node-version == 'latest' && (github.event_name == 'push' || (github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository))
  ```

## 2. Harden all workflows
- **`timeout-minutes`** added to every job that lacked one (`ci`, `docs`, `dependabot`, `publish`, `zizmor`, `audit`).
- **`concurrency`** added to `claude-code-review` (cancel superseded runs per PR) and `publish` (serialize, never cancel).
- `permissions: {}` at root, SHA-pinned actions and `persist-credentials: false` were already in place.

## 3. Modern best-practices pass
- **`npm audit` moved out of the per-PR gate** into a dedicated scheduled workflow (`audit.yml`: weekly cron + push to `main` + `workflow_dispatch`). A PR is no longer blocked by external advisory churn unrelated to its changes; Dependabot delivers the actual fixes.
- **Publish gated behind a protected `npm` environment** for secret scoping and optional manual approval.
- **Default-branch CI/zizmor no longer self-cancel**: `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` — PRs still cancel superseded runs, but every commit to `main` keeps a complete check history.
- **Runners pinned to `ubuntu-24.04`** instead of the floating `ubuntu-latest` for reproducibility.

### Deliberately not applied
- **npm provenance (`--provenance`)** — would break publishing here, as it targets **GitHub Packages** (not npmjs.org, where provenance/Sigstore attestation is supported). Adding `id-token: write` without it would only widen permissions for no benefit.
- **`step-security/harden-runner` (runtime egress filtering)** — complements `zizmor` (static), but it's invasive (intercepts all runner traffic), needs a verified pinned SHA, and is a network-policy decision. Left out pending a deliberate call.

## :warning: Repo-settings follow-ups (cannot be done from the PR)
- If **`Audit`** was a *required* status check in branch protection, update it — audit no longer runs on PRs (it's now scheduled/`main`-only).
- Create the **`npm` environment** in *Settings → Environments* and add protection rules (required reviewers / scoped secrets) to get the benefit of the new `environment:` reference.
- The advisory **`Review`** (Claude) check should stay **non-required** rather than using `continue-on-error` (which would mask its true status).

## Validation
- `prettier .github/workflows --check` — clean.
- `eslint .github/workflows` (incl. `eslint-plugin-yml`) — no findings.

https://claude.ai/code/session_019RuNbY4qGC4P4fUicyBsB1