### PR TITLE
ci: pin runners to ubuntu-24.04

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -3,7 +3,7 @@ jobs:
     name: Audit
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     name: Check
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -23,7 +23,7 @@ jobs:
     name: Test (Node ${{ matrix.node-version }})
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,7 +13,7 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,7 +22,7 @@ jobs:
       id-token: write
       issues: read
       pull-requests: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -5,7 +5,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - id: metadata
         name: Dependabot metadata

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ jobs:
     name: Build docs
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -28,7 +28,7 @@ jobs:
     permissions:
       id-token: write
       pages: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -8,7 +8,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:


### PR DESCRIPTION
## Summary

Companion to [`com.melcloud#1324`](https://github.com/OlivierZal/com.melcloud/pull/1324) (workflow harmonization pass across both repos).

Pins every workflow runner to \`ubuntu-24.04\` instead of the floating \`ubuntu-latest\`. Mentioned in #1516 as already applied but the change was never actually committed.

This is GitHub's own documented recommendation — \`ubuntu-latest\` will eventually flip to 26.04 and surface unexpected diffs at the worst possible moment (a release, a Dependabot bump). Explicit pin → reproducible builds. Bumps happen on intent, not by surprise.

The rest of the patterns from #1516 (composite action, conditional concurrency, etc.) are already in place here — only the runner pin was outstanding.

## Validation

- \`prettier --check .github/workflows .github/actions\` ✓
- \`eslint .github/workflows .github/actions\` ✓
- \`zizmor .github/workflows .github/actions\` → No findings to report

## Test plan

- [ ] CI green (Check + Test matrix + Zizmor)
- [ ] Docs job still builds on the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)