### PR TITLE
ci(claude): gate Claude triggers on user.type != 'Bot'

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,7 +1,7 @@
 jobs:
   claude:
     if: |
-      github.actor != 'dependabot[bot]' && (
+      !contains(fromJson('["Copilot","copilot-swe-agent[bot]","dependabot[bot]","github-actions[bot]"]'), github.actor) && (
         (github.event_name == 'issue_comment' &&
           contains(github.event.comment.body, '@claude') &&
           contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,20 +1,22 @@
 jobs:
   claude:
     if: |
-      !contains(fromJson('["Copilot","copilot-swe-agent[bot]","dependabot[bot]","github-actions[bot]"]'), github.actor) && (
-        (github.event_name == 'issue_comment' &&
-          contains(github.event.comment.body, '@claude') &&
-          contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-        (github.event_name == 'pull_request_review_comment' &&
-          contains(github.event.comment.body, '@claude') &&
-          contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-        (github.event_name == 'pull_request_review' &&
-          contains(github.event.review.body || '', '@claude') &&
-          contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
-        (github.event_name == 'issues' &&
-          (contains(github.event.issue.body || '', '@claude') || contains(github.event.issue.title, '@claude')) &&
-          contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
-      )
+      (github.event_name == 'issue_comment' &&
+        github.event.comment.user.type != 'Bot' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        github.event.comment.user.type != 'Bot' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' &&
+        github.event.review.user.type != 'Bot' &&
+        contains(github.event.review.body || '', '@claude') &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' &&
+        github.event.issue.user.type != 'Bot' &&
+        (contains(github.event.issue.body || '', '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
     name: Claude
     permissions:
       actions: read


### PR DESCRIPTION
Follow-up to #1517 — that commit landed on the prior PR branch after the squash-merge had already happened, so this PR brings it to \`main\` standalone.

## Why

Copilot Code Review (and other GHA bots) sometimes post review text containing \`@claude\` — for example when reviewing a PR that touches \`claude.yml\` and quotes its content. That matches \`claude.yml\`'s trigger condition (\`contains(github.event.review.body, '@claude')\`), which queues a workflow run. GitHub then gates that run as \`action_required\` because it was triggered indirectly by another bot's GITHUB_TOKEN — surfaced as \"1 check awaiting approval\" on the PR with no useful action behind it.

## Change

\`\`\`yaml
if: |
  !contains(fromJson('[\"Copilot\",\"copilot-swe-agent[bot]\",\"dependabot[bot]\",\"github-actions[bot]\"]'), github.actor) && (
\`\`\`

- \`Copilot\` — the PR-reviewer app (login confirmed via API: \`triggering_actor.login == 'Copilot'\`).
- \`copilot-swe-agent[bot]\` — the SWE agent, same surface area.
- \`github-actions[bot]\` — prevents Claude → Claude loops via our own workflow-posted reviews.
- \`dependabot[bot]\` — preserved (same gate, now expressed as a list).

Same change shipped to \`com.melcloud\` in [#1324](https://github.com/OlivierZal/com.melcloud/pull/1324).

## Validation

- \`zizmor\` ✓ no findings
- \`prettier --check\` ✓
- \`eslint\` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)