### PR TITLE
ci: support GitHub merge queue (merge_group triggers)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
     timeout-minutes: 20
 name: CI
 on:
+  merge_group: {}
   pull_request: {}
   push:
     branches: [main]

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,6 +18,7 @@ jobs:
     timeout-minutes: 15
 name: Zizmor
 on:
+  merge_group: {}
   pull_request: {}
   push:
     branches: [main]


### PR DESCRIPTION
## Why

Today `main` requires branches to be **up to date before merging**. With Dependabot auto-merge enabled, that serializes everything: when one PR merges, every other open PR falls behind `main`, must be rebased, and re-runs the full CI matrix before it can merge — quadratic CI load, and grouped Dependabot PRs stall until rebased.

A **merge queue** solves exactly this: it speculatively tests each queued PR on top of the ones ahead of it against the latest `main`, runs CI once per entry, and merges in order — no manual rebasing, while keeping the same "tested against latest main" guarantee.

## What this PR does

Adds the `merge_group` event to the workflows that produce the required status checks, so they run on the temporary `gh-readonly-queue/*` branches the queue creates:

- `ci.yml` — Check + Test matrix
- `zizmor.yml` — workflow security scan

**Without these triggers, queued PRs never receive their required checks and stall indefinitely**, so this code change must land *before* the queue is enabled. (Mirrors what OlivierZal/com.melcloud#1332 did for the app repo.)

The Sonar step inside `ci.yml`'s `test` job is intentionally guarded by `github.event_name == 'push'` / pull-request conditions, so it does not run on `merge_group` — Sonar stays advisory, as in `com.melcloud`.

The existing `concurrency` blocks already behave correctly: on `merge_group`, `github.ref` is the unique queue-branch ref (own concurrency group) and `cancel-in-progress` evaluates to `false`, so queue builds don't cancel each other.

## Follow-up (admin)

Once this merges, the `Protect main` ruleset will be updated to:
1. Add a `merge_queue` rule (`MERGE` / `ALLGREEN` / 5-1-5-5-60).
2. Set `strict_required_status_checks_policy: false` (the queue supersedes "Require branches to be up to date").

Required contexts stay as today: `Check`, `Test (Node lts/*)`, `Zizmor`.