### PR TITLE
Modernize strictness, resilience edge cases, shared sync template, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,35 @@ if (!result.ok) {
 const energy = result.value
 ```
 
+## Session management
+
+Both clients keep their session alive without caller involvement:
+
+- **Pre-emptive refresh** — sessions are renewed when they come within 5 minutes of expiry, so no request pays the re-authentication round-trip on its critical path.
+- **Reactive 401 recovery** — when the server rejects a credential mid-flight, the SDK re-authenticates once (Home tries the cheap refresh-token exchange first, then falls back to a full sign-in) and replays the original request. A cooldown guard prevents retry loops.
+- **Persistence** — pass a `settingManager` (a simple `get`/`set` string store) to persist tokens and credentials across restarts; without one, everything stays in memory and a new instance signs in from scratch.
+
+> [!IMPORTANT]
+> The `SettingManager` receives the access/refresh tokens **and the account password** as plain strings. You are responsible for backing it with secure storage (encrypted settings store, OS keychain, …) — do not write it to a world-readable file. The SDK redacts credentials, tokens and cookies from its own log output.
+
+```ts title="setting-manager"
+const settings = new Map<string, string>()
+const api = await HomeAPI.create({
+  settingManager: {
+    get: (key) => settings.get(key) ?? null,
+    set: (key, value) => settings.set(key, value),
+  },
+})
+```
+
+## Resilience & retries
+
+The request pipeline applies three policies, outermost first:
+
+1. **Rate-limit gate (HTTP 429)** — a 429 response pauses all requests for the `Retry-After` window (delta-seconds and HTTP-date forms are both honored), or 2 hours when the header is absent. While paused, calls fail fast with `RateLimitError` (`retryAfter`, `unblockAt`) instead of hammering the server; check `api.isRateLimited` before issuing bursts.
+2. **Auth retry (HTTP 401)** — a single re-authentication + replay, as described above.
+3. **Transient retry (GET only)** — 502/503/504 responses are retried up to 4 times with exponential backoff and jitter (1 s initial delay, 16 s cap). Mutations (`POST`/`PUT`) are **never** retried automatically: a write that may have landed server-side must not be silently duplicated. Each retry is observable through the `onRequestRetry` lifecycle event.
+
 ## Imports
 
 Exports follow a `Classic*` / `Home*` prefix convention so the target API is obvious at the call site. The `./classic` and `./home` subpaths re-export everything with the prefix stripped — a modern alternative to TypeScript's deprecated `namespace` keyword.

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -132,7 +132,7 @@ interface BaseAPIConstructorOptions {
 export abstract class BaseAPI implements Disposable {
   public readonly logger: Logger
 
-  public readonly settingManager?: SettingManager
+  public readonly settingManager?: SettingManager | undefined
 
   /**
    * Whether the upstream rate-limit gate is currently holding a pause
@@ -143,7 +143,7 @@ export abstract class BaseAPI implements Disposable {
     return this.rateLimitGate.isPaused
   }
 
-  protected readonly abortSignal?: AbortSignal
+  protected readonly abortSignal?: AbortSignal | undefined
 
   protected readonly api: HttpClient
 

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -505,6 +505,27 @@ export abstract class BaseAPI implements Disposable {
   }
 
   /**
+   * Template for the registry-refresh heartbeat shared by Classic's
+   * `fetch()` and Home's `list()`: pause the auto-sync timer, run the
+   * subclass work, log + swallow failures (a flaky heartbeat must not
+   * crash the host — the next cycle retries), and always reschedule
+   * the next sync.
+   * @param work - Subclass closure that fetches and syncs the registry.
+   * @returns The fetched entries, or an empty array on failure.
+   */
+  protected async runSyncCycle<T>(work: () => Promise<T[]>): Promise<T[]> {
+    this.clearSync()
+    try {
+      return await work()
+    } catch (error) {
+      this.logger.error('Failed to fetch devices:', error)
+      return []
+    } finally {
+      this.syncManager.planNext()
+    }
+  }
+
+  /**
    * Run a best-effort GET/POST/… request and wrap the outcome in a
    * {@link Result}. The unwrapped response body is returned on success;
    * on failure the typed {@link ApiRequestError} variant lets callers

--- a/src/api/classic.ts
+++ b/src/api/classic.ts
@@ -269,15 +269,7 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
    */
   @syncDevices()
   public async fetch(): Promise<ClassicBuildingWithStructure[]> {
-    this.clearSync()
-    try {
-      return await this.#fetch()
-    } catch (error) {
-      this.logger.error('Failed to fetch devices:', error)
-      return []
-    } finally {
-      this.syncManager.planNext()
-    }
+    return this.runSyncCycle(async () => this.#fetch())
   }
 
   public async getEnergy<T extends ClassicDeviceType>({

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -161,8 +161,7 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
    */
   @syncDevices()
   public async list(): Promise<HomeBuilding[]> {
-    this.clearSync()
-    try {
+    return this.runSyncCycle(async () => {
       const data = await this.#fetchContext()
       const buildings = [...data.buildings, ...data.guestBuildings]
       this.#registry.sync(
@@ -178,11 +177,7 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
         ]),
       )
       return buildings
-    } catch {
-      return []
-    } finally {
-      this.syncManager.planNext()
-    }
+    })
   }
 
   /**

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -152,8 +152,8 @@ export interface SettingManager {
  * @category Configuration
  */
 export type SyncCallback = (params?: {
-  ids?: (number | string)[]
-  type?: DeviceType
+  ids?: (number | string)[] | undefined
+  type?: DeviceType | undefined
 }) => Promise<void>
 
 /**

--- a/src/decorators/setting.ts
+++ b/src/decorators/setting.ts
@@ -1,7 +1,7 @@
 import type { SettingManager } from '../api/types.ts'
 
 interface HasSettingManager {
-  settingManager?: SettingManager
+  settingManager?: SettingManager | undefined
 }
 
 /**

--- a/src/decorators/sync-devices.ts
+++ b/src/decorators/sync-devices.ts
@@ -8,8 +8,8 @@ import type { DeviceType } from '../constants.ts'
  */
 interface HasNotifySync {
   readonly notifySync?: (params?: {
-    ids?: (number | string)[]
-    type?: DeviceType
+    ids?: (number | string)[] | undefined
+    type?: DeviceType | undefined
   }) => Promise<void>
 }
 

--- a/src/entities/classic-registry.ts
+++ b/src/entities/classic-registry.ts
@@ -235,7 +235,7 @@ export class ClassicRegistry {
    */
   public getBuildings({
     type,
-  }: { type?: ClassicDeviceType } = {}): ClassicBuildingZone[] {
+  }: { type?: ClassicDeviceType | undefined } = {}): ClassicBuildingZone[] {
     return [...this.#buildings.values()]
       .filter((building) => this.#hasDevices(building.id, 'building', type))
       .map((building) => ({

--- a/src/errors/rate-limit.ts
+++ b/src/errors/rate-limit.ts
@@ -14,6 +14,11 @@ import { APIError } from './base.ts'
  *   "try again at 14:30" phrasing) — read with
  *   `unblockAt.toString()` or convert via
  *   `unblockAt.toZonedDateTimeISO(zone)`.
+ *
+ * The `Result`-based getters surface the same window as the
+ * `rate-limited` variant's plain `retryAfterMs` (milliseconds) —
+ * this class is the rich `Temporal` surface, `retryAfterMs` the
+ * dependency-free one; both are derived from the same gate snapshot.
  * @category Errors
  */
 export class RateLimitError extends APIError {

--- a/src/facades/classic-device-atw-dual-zone.ts
+++ b/src/facades/classic-device-atw-dual-zone.ts
@@ -83,7 +83,7 @@ export class ClassicDeviceAtwHasZone2Facade extends ClassicDeviceAtwFacade {
   ): ClassicOperationModeZoneDataAtw | null {
     const [operationModeZone1, operationModeZone2]: {
       key: keyof ClassicOperationModeZoneDataAtw
-      value?: ClassicOperationModeZone
+      value?: ClassicOperationModeZone | undefined
     }[] = [
       { key: 'OperationModeZone1', value: data.OperationModeZone1 },
       { key: 'OperationModeZone2', value: data.OperationModeZone2 },

--- a/src/http/client.ts
+++ b/src/http/client.ts
@@ -191,7 +191,7 @@ export class HttpClient {
 
   readonly #defaultHeaders: Record<string, string>
 
-  readonly #dispatcher?: FetchDispatcher
+  readonly #dispatcher?: FetchDispatcher | undefined
 
   /**
    * Builds an HTTP client pinned to a base URL, request-timeout budget,
@@ -279,10 +279,11 @@ export class HttpClient {
       ...this.#defaultHeaders,
       ...headers,
     }
+    const body = serializeBody(data, mergedHeaders)
     const init: FetchInit = {
-      body: serializeBody(data, mergedHeaders),
       headers: mergedHeaders,
       method: method.toUpperCase(),
+      ...(body === undefined ? {} : { body }),
     }
     this.#applySignal(init, signal)
     this.#applyDispatcher(init)

--- a/src/http/errors.ts
+++ b/src/http/errors.ts
@@ -4,10 +4,10 @@
  */
 export interface HttpErrorRequestConfig {
   readonly data?: unknown
-  readonly headers?: Record<string, string>
-  readonly method?: string
-  readonly params?: Record<string, unknown>
-  readonly url?: string
+  readonly headers?: Record<string, string> | undefined
+  readonly method?: string | undefined
+  readonly params?: Record<string, unknown> | undefined
+  readonly url?: string | undefined
 }
 
 /**
@@ -19,7 +19,7 @@ export interface HttpErrorRequestConfig {
  * @category HTTP
  */
 export class HttpError<T = unknown> extends Error {
-  public readonly config?: HttpErrorRequestConfig
+  public readonly config?: HttpErrorRequestConfig | undefined
 
   public readonly isHttpError = true
 

--- a/src/observability/context.ts
+++ b/src/observability/context.ts
@@ -9,9 +9,9 @@
 export interface LoggableRequestConfig {
   readonly data?: unknown
   readonly headers?: unknown
-  readonly method?: string
+  readonly method?: string | undefined
   readonly params?: unknown
-  readonly url?: string
+  readonly url?: string | undefined
 }
 
 // Fixed key order for consistent, readable JSON log output
@@ -88,11 +88,11 @@ const redactValue = (value: unknown): unknown => {
 export abstract class APICallLogData {
   declare public readonly dataType: string
 
-  public readonly method?: string
+  public readonly method?: string | undefined
 
   public readonly params: unknown
 
-  public readonly url?: string
+  public readonly url?: string | undefined
 
   protected constructor(config?: LoggableRequestConfig) {
     this.method = config?.method?.toUpperCase()

--- a/src/observability/context.ts
+++ b/src/observability/context.ts
@@ -57,7 +57,11 @@ const redactFormEncoded = (value: string): string | undefined => {
   }
   const params = new URLSearchParams(value)
   let hasRedacted = false
-  for (const key of params.keys()) {
+  // Snapshot the keys before mutating: `set()` collapses duplicate
+  // entries, and URLSearchParams iterators are live, so redacting a
+  // multi-valued key mid-iteration could otherwise skip the entry
+  // that shifts into the vacated slot.
+  for (const key of new Set(params.keys())) {
     if (isSensitive(key)) {
       params.set(key, REDACTED)
       hasRedacted = true

--- a/src/observability/events-emitter.ts
+++ b/src/observability/events-emitter.ts
@@ -16,7 +16,7 @@ import type {
  * blocker.
  */
 export class LifecycleEmitter {
-  readonly #events?: LifecycleEvents
+  readonly #events?: LifecycleEvents | undefined
 
   readonly #logger: Logger
 

--- a/src/observability/response.ts
+++ b/src/observability/response.ts
@@ -11,7 +11,7 @@ export class APICallResponseData extends APICallLogData {
 
   public readonly responseData: unknown
 
-  public readonly status?: number
+  public readonly status?: number | undefined
 
   public constructor(
     response?: HttpResponse,

--- a/src/resilience/disposable-timeout.ts
+++ b/src/resilience/disposable-timeout.ts
@@ -15,7 +15,7 @@ export class DisposableTimeout implements Disposable {
     return this.#timeout !== undefined
   }
 
-  #timeout?: ReturnType<typeof setTimeout>
+  #timeout?: ReturnType<typeof setTimeout> | undefined
 
   /** Cancel the current timeout if one is active. */
   public clear(): void {

--- a/src/resilience/policy.ts
+++ b/src/resilience/policy.ts
@@ -33,15 +33,17 @@ export interface ResiliencePolicy {
  * An empty composite is a no-op pass-through.
  */
 export class CompositePolicy implements ResiliencePolicy {
-  readonly #policies: readonly ResiliencePolicy[]
+  // Innermost-first ordering, computed once — `run` only re-wraps the
+  // attempt closure per call, never re-derives the pipeline.
+  readonly #reversedPolicies: readonly ResiliencePolicy[]
 
   public constructor(policies: readonly ResiliencePolicy[]) {
-    this.#policies = policies
+    this.#reversedPolicies = policies.toReversed()
   }
 
   public async run<T>(attempt: () => Promise<T>): Promise<T> {
     let wrapped: () => Promise<T> = attempt
-    for (const policy of [...this.#policies].toReversed()) {
+    for (const policy of this.#reversedPolicies) {
       const inner = wrapped
       const wrap = async (): Promise<T> => policy.run(inner)
       wrapped = wrap

--- a/src/resilience/rate-limit-gate.ts
+++ b/src/resilience/rate-limit-gate.ts
@@ -21,31 +21,41 @@ const parseDeltaSeconds = (seconds: number): Temporal.Duration | null =>
     Temporal.Duration.from({ seconds })
   : null
 
-const parseHttpDate = (value: string): Temporal.Duration | null => {
+const parseHttpDate = (
+  value: string,
+  now: Temporal.Instant,
+): Temporal.Instant | null => {
   const dateMs = Date.parse(value)
-  if (Number.isNaN(dateMs)) {
+  if (Number.isNaN(dateMs) || dateMs <= now.epochMilliseconds) {
     return null
   }
-  const milliseconds = dateMs - Date.now()
-  return milliseconds > 0 ? Temporal.Duration.from({ milliseconds }) : null
+  return Temporal.Instant.fromEpochMilliseconds(dateMs)
 }
 
-// Parse an RFC 9110 `Retry-After` value into a positive duration.
-// Delta-seconds is tried first; an HTTP-date (IMF-fixdate, handled by
-// `Date.parse`) is converted to the remaining wait from now. Returns
-// `null` for unparsable, zero, negative, or past-dated values so the
-// caller can apply its fallback window.
-const parseRetryAfter = (value: unknown): Temporal.Duration | null => {
+// Resolve an RFC 9110 `Retry-After` value into the absolute unblock
+// instant. Delta-seconds is tried first; an HTTP-date (IMF-fixdate,
+// handled by `Date.parse`) maps to that date directly. Every branch is
+// anchored on the caller's single `now` capture so the unblock time
+// cannot drift across separate clock reads. Returns `null` for
+// unparsable, zero, negative, or past-dated values so the caller can
+// apply its fallback window.
+const parseRetryAfter = (
+  value: unknown,
+  now: Temporal.Instant,
+): Temporal.Instant | null => {
   if (typeof value === 'number') {
-    return parseDeltaSeconds(value)
+    const delta = parseDeltaSeconds(value)
+    return delta === null ? null : now.add(delta)
   }
   if (typeof value !== 'string') {
     return null
   }
   const seconds = Number(value)
-  return Number.isFinite(seconds) ?
-      parseDeltaSeconds(seconds)
-    : parseHttpDate(value)
+  if (Number.isFinite(seconds)) {
+    const delta = parseDeltaSeconds(seconds)
+    return delta === null ? null : now.add(delta)
+  }
+  return parseHttpDate(value, now)
 }
 
 /**
@@ -168,9 +178,9 @@ export class RateLimitGate {
    * @param retryAfter - Header value from the 429 response.
    */
   public recordRateLimit(retryAfter?: unknown): void {
-    this.#pausedUntil = Temporal.Now.instant().add(
-      parseRetryAfter(retryAfter) ?? this.#fallback,
-    )
+    const now = Temporal.Now.instant()
+    this.#pausedUntil =
+      parseRetryAfter(retryAfter, now) ?? now.add(this.#fallback)
   }
 
   /** Reset the gate immediately (testing or manual unblock). */

--- a/src/resilience/rate-limit-gate.ts
+++ b/src/resilience/rate-limit-gate.ts
@@ -16,6 +16,38 @@ export interface RateLimitDurationLike {
 const pluralize = (count: number, unit: string): string =>
   count === 1 ? unit : `${unit}s`
 
+const parseDeltaSeconds = (seconds: number): Temporal.Duration | null =>
+  Number.isFinite(seconds) && seconds > 0 ?
+    Temporal.Duration.from({ seconds })
+  : null
+
+const parseHttpDate = (value: string): Temporal.Duration | null => {
+  const dateMs = Date.parse(value)
+  if (Number.isNaN(dateMs)) {
+    return null
+  }
+  const milliseconds = dateMs - Date.now()
+  return milliseconds > 0 ? Temporal.Duration.from({ milliseconds }) : null
+}
+
+// Parse an RFC 9110 `Retry-After` value into a positive duration.
+// Delta-seconds is tried first; an HTTP-date (IMF-fixdate, handled by
+// `Date.parse`) is converted to the remaining wait from now. Returns
+// `null` for unparsable, zero, negative, or past-dated values so the
+// caller can apply its fallback window.
+const parseRetryAfter = (value: unknown): Temporal.Duration | null => {
+  if (typeof value === 'number') {
+    return parseDeltaSeconds(value)
+  }
+  if (typeof value !== 'string') {
+    return null
+  }
+  const seconds = Number(value)
+  return Number.isFinite(seconds) ?
+      parseDeltaSeconds(seconds)
+    : parseHttpDate(value)
+}
+
 /**
  * Render a `Temporal.Duration` in English diagnostic form, with
  * adaptive units: sub-minute windows render as seconds (e.g.
@@ -107,16 +139,16 @@ export class RateLimitGate {
    * + `logger.error(...)` pair at each 429 call site.
    * @param logger - Logger used to emit the error line.
    * @param logger.error - Error-level log sink.
-   * @param retryAfterSeconds - Header value from the 429 response.
+   * @param retryAfter - Header value from the 429 response (delta-seconds or HTTP-date).
    * @param label - Short noun describing what was rate-limited
    *   (e.g. `'list operations'`, `''` for a generic "pausing for ..." line).
    */
   public recordAndLog(
     logger: { error: (...data: unknown[]) => void },
-    retryAfterSeconds: unknown,
+    retryAfter: unknown,
     label = '',
   ): void {
-    this.recordRateLimit(retryAfterSeconds)
+    this.recordRateLimit(retryAfter)
     // `recordRateLimit` always advances `#pausedUntil` into the future,
     // so the remaining duration is positive and well-defined here.
     const duration = this.#pausedUntil.since(Temporal.Now.instant())
@@ -129,17 +161,16 @@ export class RateLimitGate {
   /**
    * Record a rate-limit response from upstream.
    *
-   * Accepts the raw `Retry-After` header value (seconds). Non-numeric,
-   * zero, negative, or missing values fall back to the configured duration.
-   * @param retryAfterSeconds - Header value from the 429 response.
+   * Accepts the raw `Retry-After` header value in either RFC 9110
+   * form: delta-seconds (`"120"`) or an HTTP-date
+   * (`"Wed, 21 Oct 2026 07:28:00 GMT"`). Unparsable, zero, negative,
+   * past-dated, or missing values fall back to the configured duration.
+   * @param retryAfter - Header value from the 429 response.
    */
-  public recordRateLimit(retryAfterSeconds?: unknown): void {
-    const seconds = Number(retryAfterSeconds)
-    const duration =
-      Number.isFinite(seconds) && seconds > 0 ?
-        Temporal.Duration.from({ seconds })
-      : this.#fallback
-    this.#pausedUntil = Temporal.Now.instant().add(duration)
+  public recordRateLimit(retryAfter?: unknown): void {
+    this.#pausedUntil = Temporal.Now.instant().add(
+      parseRetryAfter(retryAfter) ?? this.#fallback,
+    )
   }
 
   /** Reset the gate immediately (testing or manual unblock). */

--- a/src/resilience/retry-backoff.ts
+++ b/src/resilience/retry-backoff.ts
@@ -77,7 +77,7 @@ export interface RetryBackoffOptions {
    * immediately — so a cancelled caller doesn't pay for an in-flight
    * delay before the next attempt would have started.
    */
-  readonly signal?: AbortSignal
+  readonly signal?: AbortSignal | undefined
   /** Predicate deciding whether a thrown error is worth retrying. */
   readonly isRetryable: (error: unknown) => boolean
   /** Optional hook invoked before the next attempt. */

--- a/src/types/classic-generic.ts
+++ b/src/types/classic-generic.ts
@@ -452,7 +452,7 @@ export interface ClassicReportPostData {
   readonly DeviceID: ClassicDeviceID
   readonly FromDate: string
   readonly ToDate: string
-  readonly Duration?: number
+  readonly Duration?: number | undefined
 }
 
 /**
@@ -505,7 +505,7 @@ export interface ClassicSuccessData {
  * @category Types
  */
 export interface ClassicTemperatureLogPostData extends ClassicReportPostData {
-  readonly Location?: number
+  readonly Location?: number | undefined
 }
 
 /**

--- a/src/types/home.ts
+++ b/src/types/home.ts
@@ -247,9 +247,9 @@ export interface HomeDeviceScheduleEntry {
   readonly power: boolean
   readonly setPoint: number
   readonly time: string
-  readonly setFanSpeed?: string
-  readonly vaneHorizontalDirection?: string
-  readonly vaneVerticalDirection?: string
+  readonly setFanSpeed?: string | undefined
+  readonly vaneHorizontalDirection?: string | undefined
+  readonly vaneVerticalDirection?: string | undefined
 }
 
 /**
@@ -267,7 +267,7 @@ export interface HomeDeviceSetting {
  */
 export interface HomeEnergyData {
   readonly measureData: HomeEnergyMeasure[]
-  readonly deviceId?: string
+  readonly deviceId?: string | undefined
 }
 
 /**
@@ -277,7 +277,7 @@ export interface HomeEnergyData {
 export interface HomeEnergyMeasure {
   readonly type: string
   readonly values: HomeEnergyPoint[]
-  readonly deviceId?: string
+  readonly deviceId?: string | undefined
 }
 
 /**
@@ -370,8 +370,8 @@ export interface HomeTokenResponse {
   readonly expires_in: number
   readonly scope: string
   readonly token_type: 'Bearer'
-  readonly id_token?: string
-  readonly refresh_token?: string
+  readonly id_token?: string | undefined
+  readonly refresh_token?: string | undefined
 }
 
 /**

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -84,6 +84,8 @@ export const mapResult = <T, TResult>(
  * - `rate-limited`: the SDK's internal rate-limit gate refused the
  *   call. `retryAfterMs` is the remaining milliseconds on the pause,
  *   or `null` when the upstream header did not carry a duration.
+ *   This is the plain-number twin of `RateLimitError.retryAfter`
+ *   (a `Temporal.Duration`); both describe the same gate window.
  * - `validation`: Zod refused the response shape. Indicates API drift
  *   server-side; not retryable on its own — investigate.
  * - `server`: any other HTTP error from the transport.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -250,7 +250,7 @@ export interface ChartLineFormatOptions {
    * BCP-47 locale tag for day-of-week and month-name labels. Defaults
    * to the runtime locale when omitted.
    */
-  readonly locale?: string
+  readonly locale?: string | undefined
 }
 
 /**

--- a/tests/unit/observability.test.ts
+++ b/tests/unit/observability.test.ts
@@ -210,6 +210,22 @@ describe('sensitive data redaction', () => {
     expect(params.get('extra')).toBe('visible')
   })
 
+  it('redacts every entry of a multi-valued sensitive key while keeping trailing pairs', () => {
+    // `URLSearchParams.set()` collapses duplicate entries while the
+    // key iterator is live; the redaction loop snapshots keys first so
+    // pairs after a duplicated sensitive key are never skipped.
+    const config = createConfig({
+      data: 'password=one&password=two&after=kept',
+    })
+    const parsed: { requestData: string } = cast(
+      JSON.parse(new APICallRequestData(config).toString()),
+    )
+    const params = new URLSearchParams(parsed.requestData)
+
+    expect(params.getAll('password')).toStrictEqual(['******'])
+    expect(params.get('after')).toBe('kept')
+  })
+
   it('passes through non-sensitive form-encoded strings unchanged', () => {
     const config = createConfig({ data: 'page=2&limit=50' })
     const parsed: { requestData: string } = cast(

--- a/tests/unit/rate-limit-gate.test.ts
+++ b/tests/unit/rate-limit-gate.test.ts
@@ -77,6 +77,46 @@ describe(RateLimitGate, () => {
     gate.recordRateLimit(-5)
 
     expect(gate.remaining?.total({ unit: 'hours' })).toBeGreaterThan(1.9)
+
+    gate.recordRateLimit('-5')
+
+    expect(gate.remaining?.total({ unit: 'hours' })).toBeGreaterThan(1.9)
+  })
+
+  it('honors a future HTTP-date Retry-After header (RFC 9110)', () => {
+    const gate = new RateLimitGate({ hours: 2 })
+
+    // 30 minutes after the fixed system time.
+    gate.recordRateLimit('Sat, 11 Apr 2026 12:30:00 GMT')
+
+    expect(gate.isPaused).toBe(true)
+    expect(gate.unblockAt?.toString({ smallestUnit: 'millisecond' })).toBe(
+      '2026-04-11T12:30:00.000Z',
+    )
+  })
+
+  it('falls back when the HTTP-date Retry-After is in the past', () => {
+    const gate = new RateLimitGate({ hours: 2 })
+
+    gate.recordRateLimit('Sat, 11 Apr 2026 11:00:00 GMT')
+
+    expect(gate.remaining?.total({ unit: 'hours' })).toBeGreaterThan(1.9)
+  })
+
+  it('falls back when Retry-After is a non-finite number', () => {
+    const gate = new RateLimitGate({ hours: 2 })
+
+    gate.recordRateLimit(Number.NaN)
+
+    expect(gate.remaining?.total({ unit: 'hours' })).toBeGreaterThan(1.9)
+  })
+
+  it('falls back when Retry-After has an unsupported type', () => {
+    const gate = new RateLimitGate({ hours: 2 })
+
+    gate.recordRateLimit(['30'])
+
+    expect(gate.remaining?.total({ unit: 'hours' })).toBeGreaterThan(1.9)
   })
 
   it('re-opens automatically after the window elapses', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "declaration": true,
     "declarationMap": true,
     "erasableSyntaxOnly": true,
+    "exactOptionalPropertyTypes": true,
     "isolatedDeclarations": true,
     "lib": ["ESNext"],
     "libReplacement": false,


### PR DESCRIPTION
Implements the improvements identified during the project review (priorities 1–5), plus the one config gap found while auditing eslint/tsdoc/tsconfig/workflows.

## Changes

### Config — `exactOptionalPropertyTypes` (tsconfig)
The codebase already followed the explicit-undefined convention everywhere (conditional spreads like `...(x === undefined ? {} : { x })`); this locks it in at the compiler level. Optional properties that are genuinely assigned `undefined` now declare `| undefined` explicitly (~16 files, no runtime change).

### Resilience & redaction edge cases
- `Retry-After` now honors **both RFC 9110 forms**: delta-seconds and HTTP-date. Past or unparsable dates keep the fallback window.
- `CompositePolicy` precomputes its reversed pipeline at construction instead of re-deriving it on every request (also drops a redundant spread before `toReversed()`).
- Form-encoded redaction snapshots `URLSearchParams` keys before mutating, so collapsing a multi-valued sensitive key can no longer skip trailing entries mid-iteration.
- The two rate-limit time surfaces (`retryAfterMs` on `Result` vs `Temporal.Duration` on `RateLimitError`) now cross-reference each other in their docs.

### Shared sync-cycle template (BaseAPI)
`ClassicAPI.fetch()` and `HomeAPI.list()` duplicated the same heartbeat shape (pause auto-sync → fetch → swallow failures → reschedule). The new `runSyncCycle` template owns that ordering; as a side benefit, Home `list()` failures are now logged like Classic's instead of being silently discarded.

### README
New **Session management** (pre-emptive refresh, reactive 401 recovery, `SettingManager` persistence and its secure-storage responsibility) and **Resilience & retries** (429 gate with both `Retry-After` forms, GET-only transient retry budget, mutations never retried) sections.

## Verified as already in place (no change needed)
- **Classic/Home dedup**: the heavy lifting (auth lifecycle, policies, request/safeRequest/Result classification) already lives in `BaseAPI`; remaining per-endpoint code is inherent, not duplication.
- **Validation**: `ClassicBuildingListSchema` already validates the minimal device header, and Home Ata/Atw schemas already share `HomeDeviceCommonFields`.
- **Auth-flow test coverage**: the full PAR → Cognito → token exchange is exercised on fixtures in `home-api.test.ts`; the refresh-token reuse path in `api-lifecycle.test.ts`.
- **Configs**: eslint (js.all + unicorn.all + ts.all + strictTypeChecked + perfectionist + TSDoc), typedoc (validation as errors, 100% doc coverage), prettier, and workflows (pinned SHAs, minimal permissions, zizmor, scheduled audit, Node matrix) are already at best-practice level.

Deliberately skipped: converting `refreshAccessToken`'s `null` return to a `Result` — its single caller collapses the outcome to a boolean and the failure cause is already logged, so the extra type would add surface without value.

## Validation
- `tsgo --noEmit` clean (with the new flag)
- 688 tests pass, coverage thresholds still at 100% (statements/branches/functions/lines)
- eslint + prettier clean, typedoc builds

https://claude.ai/code/session_01WuYTt34xR7cRJ9hDbBDZJa

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuYTt34xR7cRJ9hDbBDZJa)_