### PR TITLE
Modernize Dependabot: squash auto-merge and grouped github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,10 @@ updates:
   - cooldown:
       default-days: 7
     directory: /
+    groups:
+      actions:
+        patterns:
+          - '*'
     package-ecosystem: github-actions
     schedule:
       interval: weekly

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -15,7 +15,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr merge --auto --merge --delete-branch "$PR_URL"
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
     timeout-minutes: 10
 name: Dependabot
 on: pull_request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Other
 
+- Dependabot modernization (mirrors [OlivierZal/com.melcloud#1363](https://github.com/OlivierZal/com.melcloud/pull/1363)): auto-merge now squashes instead of creating merge commits (one commit per bump on `main`), all `github-actions` updates are grouped into a single weekly PR, and npm updates keep the 7-day cooldown as supply-chain protection (compromised releases are typically unpublished within days; security updates bypass the cooldown).
 - Toolchain and CI hardening (practices already adopted in [OlivierZal/com.melcloud#1359](https://github.com/OlivierZal/com.melcloud/pull/1359)):
   - `tsconfig.json` now declares `"strict": true` explicitly — it is the TypeScript 6 default, but third-party tools that read the config shouldn't have to know that.
   - CI runs coverage and the Sonar upload only on the current-LTS matrix leg (`lts/*` — modern yet stable, and always blocking so the quality gate cannot be skipped silently), and the `latest` leg is `continue-on-error` so brand-new Node releases never block CI.


### PR DESCRIPTION
## Summary

Modernizes the Dependabot configuration to mirror [OlivierZal/com.melcloud#1363](https://github.com/OlivierZal/com.melcloud/pull/1363): auto-merge now squashes each dependency bump into a single commit on `main`, and all `github-actions` updates are grouped into one weekly PR.

## Changes

- `.github/workflows/dependabot.yml`: the auto-merge command now uses `--squash` instead of `--merge`, so every Dependabot bump lands as one commit on `main`.
- `.github/dependabot.yml`: added a `groups.actions` block (patterns: `'*'`) to the `github-actions` ecosystem so all action bumps arrive as a single grouped PR. The npm ecosystem already had its groups and both ecosystems already had the 7-day `cooldown` (supply-chain protection — compromised releases are typically unpublished within days, and security updates bypass the cooldown).
- `CHANGELOG.md`: recorded the change under `## [Unreleased]` → `### Other`.

## Breaking changes

None.

## Checklist

- [x] `npm run typecheck` passes (no source changes)
- [x] `npm run lint` passes (`eslint` + `prettier --check` on the touched YAML/Markdown files)
- [x] `npm run format` passes
- [x] `npm test` passes (coverage thresholds remain at 100%; no source changes)
- [x] [`CHANGELOG.md`](../CHANGELOG.md) updated under `## [Unreleased]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAnQehLabAhwPmnXAbRCrb

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAnQehLabAhwPmnXAbRCrb)_