### PR TITLE
Replace the currentHour unsafe cast with a validated HourSchema

### DIFF
--- a/src/facades/classic-base.ts
+++ b/src/facades/classic-base.ts
@@ -35,6 +35,7 @@ import {
   toClassicDeviceId,
 } from '../types/index.ts'
 import { getChartLineOptions, now } from '../utils.ts'
+import { HourSchema, parseOrThrow } from '../validation/index.ts'
 import type {
   ClassicFacade,
   ClassicFrostProtectionQuery,
@@ -338,10 +339,11 @@ export abstract class ClassicBaseFacade<
    * @returns The current hour as a valid {@link Hour}.
    */
   protected currentHour(): Hour {
-    // Temporal.PlainTime.hour is always in [0, 23] per spec, so the
-    // narrowing to `Hour` (the 0..23 literal union) is sound.
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    return Temporal.Now.plainTimeISO(this.api.timezone).hour as Hour
+    return parseOrThrow(
+      HourSchema,
+      Temporal.Now.plainTimeISO(this.api.timezone).hour,
+      'currentHour',
+    )
   }
 
   async #getBaseFrostProtection(

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -10,5 +10,6 @@ export {
   HomeParResponseSchema,
   HomeReportDataSchema,
   HomeTokenResponseSchema,
+  HourSchema,
   parseOrThrow,
 } from './schemas.ts'

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -13,6 +13,7 @@ import type {
   HomeErrorLogEntry,
   HomeReportData,
   HomeTokenResponse,
+  Hour,
 } from '../types/index.ts'
 import { ClassicDeviceType } from '../constants.ts'
 import { ValidationError } from '../errors/index.ts'
@@ -259,6 +260,17 @@ export const HomeErrorLogEntryListSchema: z.ZodType<HomeErrorLogEntry[]> =
       errorMessage: z.string(),
     }),
   )
+
+const MAX_HOUR = 23
+
+/** Integer hour of the day in 24-hour form (0 through 23). */
+export const HourSchema: z.ZodType<Hour> = z.custom<Hour>(
+  (value) =>
+    typeof value === 'number' &&
+    Number.isSafeInteger(value) &&
+    value >= 0 &&
+    value <= MAX_HOUR,
+)
 
 // Classic /User/ListDevices returns an array of building-with-structure
 // envelopes. The registry iterates structure.Devices and expects every

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -11,6 +11,7 @@ import {
   ClassicLoginDataSchema,
   HomeContextSchema,
   HomeTokenResponseSchema,
+  HourSchema,
   parseOrThrow,
 } from '../../src/validation/index.ts'
 import {
@@ -143,6 +144,21 @@ describe('validation/schemas', () => {
       expect(() =>
         parseOrThrow(z.object({ value: z.number() }), { value: 'x' }, 'ctx'),
       ).toThrow(/Invalid API response shape \(ctx\)/v)
+    })
+  })
+
+  describe('hourSchema', () => {
+    it.each([0, 12, 23])('accepts the in-range hour %d', (hour) => {
+      expect(HourSchema.parse(hour)).toBe(hour)
+    })
+
+    it.each([
+      { label: 'a negative hour', value: -1 },
+      { label: 'an out-of-range hour', value: 24 },
+      { label: 'a fractional hour', value: 12.5 },
+      { label: 'a string', value: '12' },
+    ])('rejects $label', ({ value }) => {
+      expect(() => HourSchema.parse(value)).toThrow(/invalid/iv)
     })
   })
 


### PR DESCRIPTION
## Quoi

Résout le dernier `eslint-disable` résolvable par le code : le cast `Temporal.Now.plainTimeISO(…).hour as Hour` de `currentHour()` (et son disable `@typescript-eslint/no-unsafe-type-assertion`) est remplacé par un vrai rétrécissement validé — `HourSchema` (`z.custom<Hour>`, zéro cast) via le `parseOrThrow` existant.

- Le chemin d'erreur vit dans zod : aucune branche morte dans notre couverture, alors que `Temporal` garantit `[0, 23]` par spec.
- Tests de branches du prédicat ajoutés (bornes 0/23, négatif, 24, fractionnaire, string) — 715 tests.

Indépendante de #1565 (hunks disjoints dans `schemas.ts`) : mergeable dans n'importe quel ordre.

## Vérification

`npm run lint` / `npm test` (715) / `npm run format` / `npm run typecheck` verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)