### PR TITLE
fix(home): stop schema drift and boot blips from reading as unauthenticated

### DIFF
--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -225,11 +225,32 @@ export abstract class BaseAPI implements Disposable {
     this.#rateLimitPolicy = new RateLimitPolicy(this.rateLimitGate, this.logger)
   }
 
+  /**
+   * Subclass hook: clear every persisted session credential (tokens,
+   * context keys, expiry — whatever the API persists). Ownership is
+   * deliberately narrow: the base {@link authenticate} template wipes
+   * before an explicit login, and the reactive-401 path
+   * ({@link reauthenticate}) wipes after the server rejected the
+   * credential. Nothing else may clear — in particular the
+   * {@link tryReuseSession} probe, where a transient failure is
+   * indistinguishable from a rejection and must leave the session
+   * untouched.
+   */
+  protected abstract clearPersistedSession(): void
+
   protected abstract doAuthenticate(
     credentials: LoginCredentials,
   ): Promise<void>
 
   protected abstract getAuthHeaders(): Record<string, string>
+
+  /**
+   * Subclass hook: whether any persisted session material exists that
+   * makes the {@link tryReuseSession} probe worth attempting (e.g. a
+   * non-expired token or a refresh token). A `false` skips the probe
+   * without issuing a doomed unauthenticated request.
+   */
+  protected abstract hasPersistedSession(): boolean
 
   public abstract isAuthenticated(): boolean
 
@@ -260,18 +281,18 @@ export abstract class BaseAPI implements Disposable {
    */
   protected abstract reauthenticate(): Promise<boolean>
 
-  protected abstract syncRegistry(): Promise<void>
-
   /**
-   * Subclass hook: try to reuse a persisted session without a full
-   * re-authentication. A `true` return carries two guarantees: the
-   * instance is authenticated, and the registry has been verified
-   * against the server (typically via a credentialed request that
-   * also populates it). Returning `false` falls through to a full
-   * {@link authenticate}.
-   * @returns `true` on reuse + registry populated; `false` otherwise.
+   * Subclass hook: whether the {@link tryReuseSession} probe ended in
+   * a reusable state. A `true` promises the {@link initialize}
+   * template that the instance is authenticated and the registry has
+   * been verified against the server; success semantics differ per
+   * API (Classic keys off the persisted credential, Home additionally
+   * requires a parsed context), which is why this stays a hook while
+   * the probe skeleton lives in {@link tryReuseSession}.
    */
-  protected abstract tryReuseSession(): Promise<boolean>
+  protected abstract reuseSucceeded(): boolean
+
+  protected abstract syncRegistry(): Promise<void>
 
   /**
    * Sign in with explicit credentials. Throws
@@ -288,6 +309,9 @@ export abstract class BaseAPI implements Disposable {
    */
   public async authenticate(credentials: LoginCredentials): Promise<void> {
     this.applyCredentials(credentials.username, credentials.password)
+    // Explicit login starts from a clean slate — enforced here so no
+    // subclass can forget it (mirrors the post-auth sync below).
+    this.clearPersistedSession()
     await this.doAuthenticate(credentials)
     await this.syncRegistry()
   }
@@ -556,6 +580,27 @@ export abstract class BaseAPI implements Disposable {
       )
       return err(classifyError(error))
     }
+  }
+
+  /**
+   * Try to reuse a persisted session without a full re-authentication:
+   * skip when nothing is persisted, otherwise run one registry sync
+   * and let {@link reuseSucceeded} judge the outcome. Returning
+   * `false` falls through to a full {@link authenticate}.
+   *
+   * The probe is strictly non-destructive: `syncRegistry()` swallows
+   * transient failures, which are indistinguishable here from a token
+   * rejection, so clearing persisted state from this path would
+   * destroy valid sessions on a boot-time network blip. Clearing is
+   * owned by {@link clearPersistedSession}'s two callers only.
+   * @returns `true` on reuse + registry populated; `false` otherwise.
+   */
+  protected async tryReuseSession(): Promise<boolean> {
+    if (!this.hasPersistedSession()) {
+      return false
+    }
+    await this.syncRegistry()
+    return this.reuseSucceeded()
   }
 
   /**

--- a/src/api/classic.ts
+++ b/src/api/classic.ts
@@ -626,11 +626,15 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
     })
   }
 
+  protected override clearPersistedSession(): void {
+    this.contextKey = ''
+    this.expiry = ''
+  }
+
   protected override async doAuthenticate({
     password,
     username,
   }: LoginCredentials): Promise<void> {
-    this.#clearPersistedSession()
     const { LoginData: loginData } = await this.login({
       postData: {
         AppVersion: APP_VERSION,
@@ -651,6 +655,13 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
 
   protected getAuthHeaders(): Record<string, string> {
     return this.contextKey === '' ? {} : { 'X-MitsContextKey': this.contextKey }
+  }
+
+  // Expiry is deliberately not checked here: the probe's own request
+  // pipeline refreshes an expired session from stored credentials
+  // (see `reuseSucceeded`), so any persisted key is worth probing.
+  protected override hasPersistedSession(): boolean {
+    return this.contextKey !== ''
   }
 
   /**
@@ -691,30 +702,23 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
     return this.resumeSession()
   }
 
-  protected override async syncRegistry(): Promise<void> {
-    await this.fetch()
-  }
-
   /**
-   * Classic's request pipeline is auth-self-healing: a call that
-   * arrives with a stale `contextKey` 401s, triggers retry-auth via
-   * stored credentials, and succeeds on the second try. A single
-   * `fetch()` therefore covers both "valid session" and "expired
-   * session, re-auth from stored creds" in one round-trip. We report
-   * `true` iff that produced an authenticated state; otherwise the
-   * template falls through to {@link authenticate}, preserving the
-   * explicit-credentials path and leaving a consistent empty state
-   * when neither a session nor credentials are available.
-   * @returns `true` when fetch yielded an authenticated session.
+   * Classic's request pipeline is auth-self-healing: the reuse probe's
+   * `fetch()` arriving with a stale `contextKey` 401s, triggers
+   * retry-auth via stored credentials, and succeeds on the second try —
+   * one round-trip covers both "valid session" and "expired session,
+   * re-auth from stored creds". Success is therefore judged by the
+   * credential alone: a transiently-failed probe with a valid
+   * `contextKey` stays authenticated and lets the auto-sync heal the
+   * registry, instead of paying a full re-login on a boot-time blip.
+   * @returns `true` when the probe left an authenticated session.
    */
-  protected override async tryReuseSession(): Promise<boolean> {
-    await this.fetch()
+  protected override reuseSucceeded(): boolean {
     return this.isAuthenticated()
   }
 
-  #clearPersistedSession(): void {
-    this.contextKey = ''
-    this.expiry = ''
+  protected override async syncRegistry(): Promise<void> {
+    await this.fetch()
   }
 
   async #fetch(): Promise<ClassicBuildingWithStructure[]> {

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -8,6 +8,7 @@ import type {
   HomeReportData,
   HomeTokenResponse,
   HomeUser,
+  HomeUserContext,
   LoginCredentials,
   Result,
 } from '../types/index.ts'
@@ -22,6 +23,9 @@ import {
   HomeEnergyDataSchema,
   HomeErrorLogEntryListSchema,
   HomeReportDataSchema,
+  HomeResilientContextSchema,
+  HomeUserContextSchema,
+  parseOrThrow,
 } from '../validation/index.ts'
 import type { HomeAPIAdapter, HomeAPIConfig } from './home-types.ts'
 import { BaseAPI, normalizeUnauthorized } from './base.ts'
@@ -37,7 +41,7 @@ const ATW_ENERGY_MEASURE = {
 const DEFAULT_RATE_LIMIT_FALLBACK_HOURS = 2
 const DEFAULT_SYNC_INTERVAL_MINUTES = 1
 
-const parseUser = (data: HomeContext): HomeUser => ({
+const parseUser = (data: HomeUserContext): HomeUser => ({
   email: data.email,
   firstName: data.firstname,
   lastName: data.lastname,
@@ -328,19 +332,22 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
   }
 
   /**
-   * Validate the current session by fetching the user context.
-   * Returns `null` if the request fails (401, network error, etc.)
-   * and clears the stored user state.
+   * Refresh the user by fetching the `/context` identity. On failure
+   * the last known user is returned unchanged: transient failures and
+   * device-payload drift must not read as "logged out" — the
+   * reactive-401 path ({@link reauthenticate}) is the single owner of
+   * clearing the authentication state, so a definitive rejection has
+   * already nulled the user by the time the failure surfaces here.
    * @returns The user or `null`.
    */
   public async getUser(): Promise<HomeUser | null> {
     try {
       await this.#fetchContext()
-      return this.#user
     } catch {
-      this.#user = null
-      return null
+      // Deliberately swallowed: the request pipeline logged the
+      // failure and a real 401 has cleared the user state already.
     }
+    return this.#user
   }
 
   /**
@@ -491,6 +498,12 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
    * A valid token returns populated context; an expired one triggers
    * the request pipeline's 401-retry + refresh-token flow; anything
    * else falls through to a full authenticate.
+   *
+   * Mirrors Classic: a failed probe must NOT clear the persisted
+   * session — `list()` swallows transient failures (network not ready
+   * at boot), which are indistinguishable here from a real token
+   * rejection. Clearing is owned by {@link reauthenticate}, which only
+   * runs on a definitive 401.
    * @returns `true` when persisted tokens verified against the BFF
    * (registry populated via the same round-trip); `false` otherwise.
    */
@@ -499,11 +512,11 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
       return false
     }
     await this.list()
-    if (this.context !== null) {
-      return true
-    }
-    this.#clearPersistedSession()
-    return false
+    // `context` gates the reuse: a `true` return promises a verified
+    // registry (see `BaseAPI.initialize`), so an identity-only success
+    // (the salvage parse failed) must fall through to the full-auth
+    // path instead of claiming the reuse completed.
+    return this.isAuthenticated() && this.context !== null
   }
 
   /**
@@ -556,13 +569,34 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
   /**
    * Fetch the user context from the BFF and update local state.
    * Shared by `getUser()` and `list()`.
+   *
+   * Two-stage parse: the identity slice is validated first, so any
+   * successful `/context` round-trip marks the session authenticated —
+   * device-payload drift must degrade the registry, never the
+   * authentication state (a strict-only parse used to read as
+   * "unauthenticated" and re-open the settings login form). The full
+   * payload is then parsed strictly; on drift the failure is logged
+   * with its field paths and the salvage schema recovers everything
+   * that still validates per unit.
    * @returns The fetched home context.
    */
   async #fetchContext(): Promise<HomeContext> {
-    const data = await this.requestData('get', '/context', {
-      schema: HomeContextSchema,
-    })
-    this.#syncContext(data)
+    const raw = await this.requestData('get', '/context')
+    this.#user = parseUser(
+      parseOrThrow(HomeUserContextSchema, raw, 'GET /context'),
+    )
+    const strict = HomeContextSchema.safeParse(raw)
+    if (!strict.success) {
+      this.logger.error(
+        'Home context drifted from the strict schema; salvaging device entries:',
+        strict.error,
+      )
+    }
+    const data =
+      strict.success ?
+        strict.data
+      : parseOrThrow(HomeResilientContextSchema, raw, 'GET /context (salvage)')
+    this.#context = data
     return data
   }
 
@@ -691,10 +725,5 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
       this.refreshToken = refreshToken
     }
     this.expiry = Temporal.Now.instant().add({ seconds: expiresIn }).toString()
-  }
-
-  #syncContext(data: HomeContext): void {
-    this.#context = data
-    this.#user = parseUser(data)
   }
 }

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -408,11 +408,17 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
     }
   }
 
+  protected override clearPersistedSession(): void {
+    this.#user = null
+    this.accessToken = ''
+    this.refreshToken = ''
+    this.expiry = ''
+  }
+
   protected override async doAuthenticate({
     password,
     username,
   }: LoginCredentials): Promise<void> {
-    this.#clearPersistedSession()
     const request = {
       credentials: { password, username },
       ...(this.abortSignal !== undefined && {
@@ -442,6 +448,15 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
     return this.accessToken === '' ?
         {}
       : { Authorization: `Bearer ${this.accessToken}` }
+  }
+
+  protected override hasPersistedSession(): boolean {
+    return (
+      (this.accessToken !== '' &&
+        this.expiry !== '' &&
+        !isSessionExpired(this.expiry)) ||
+      this.refreshToken !== ''
+    )
   }
 
   /**
@@ -483,40 +498,27 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
     if (this.refreshToken !== '' && (await this.#refreshAccessToken())) {
       return true
     }
-    this.#clearPersistedSession()
+    this.clearPersistedSession()
     return this.resumeSession()
+  }
+
+  /**
+   * The base probe's `syncRegistry()` runs `list()`, which hits
+   * `/context` once and hydrates `context`/`user` AND the device
+   * registry in a single request; an expired token triggers the
+   * pipeline's 401-retry + refresh-token flow along the way. Success
+   * requires a parsed context on top of the identity: a `true` reuse
+   * promises a verified registry, so an identity-only round-trip
+   * (the salvage parse failed) must fall through to the full-auth
+   * path instead of claiming the reuse completed.
+   * @returns `true` when persisted tokens verified against the BFF.
+   */
+  protected override reuseSucceeded(): boolean {
+    return this.isAuthenticated() && this.context !== null
   }
 
   protected override async syncRegistry(): Promise<void> {
     await this.list()
-  }
-
-  /**
-   * Reuse a persisted Home session by issuing the standard
-   * `list()` call, which hits `/context` once and hydrates both
-   * `context`/`user` AND the device registry in a single request.
-   * A valid token returns populated context; an expired one triggers
-   * the request pipeline's 401-retry + refresh-token flow; anything
-   * else falls through to a full authenticate.
-   *
-   * Mirrors Classic: a failed probe must NOT clear the persisted
-   * session — `list()` swallows transient failures (network not ready
-   * at boot), which are indistinguishable here from a real token
-   * rejection. Clearing is owned by {@link reauthenticate}, which only
-   * runs on a definitive 401.
-   * @returns `true` when persisted tokens verified against the BFF
-   * (registry populated via the same round-trip); `false` otherwise.
-   */
-  protected override async tryReuseSession(): Promise<boolean> {
-    if (!this.#hasPersistedSession()) {
-      return false
-    }
-    await this.list()
-    // `context` gates the reuse: a `true` return promises a verified
-    // registry (see `BaseAPI.initialize`), so an identity-only success
-    // (the salvage parse failed) must fall through to the full-auth
-    // path instead of claiming the reuse completed.
-    return this.isAuthenticated() && this.context !== null
   }
 
   /**
@@ -550,13 +552,6 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
     values: HomeAtwValues,
   ): Promise<void> {
     await this.#putDeviceValues(ATW_UNIT_PATH, id, values)
-  }
-
-  #clearPersistedSession(): void {
-    this.#user = null
-    this.accessToken = ''
-    this.refreshToken = ''
-    this.expiry = ''
   }
 
   async #exchangeAndStoreTokens(
@@ -672,15 +667,6 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
       },
       schema: HomeReportDataSchema.array(),
     })
-  }
-
-  #hasPersistedSession(): boolean {
-    return (
-      (this.accessToken !== '' &&
-        this.expiry !== '' &&
-        !isSessionExpired(this.expiry)) ||
-      this.refreshToken !== ''
-    )
   }
 
   /**

--- a/src/home.ts
+++ b/src/home.ts
@@ -38,6 +38,7 @@ export {
   type HomeReportDataset as ReportDataset,
   type HomeReportPoint as ReportPoint,
   type HomeUser as User,
+  type HomeUserContext as UserContext,
   type HomeVertical as Vertical,
   HomeAPI as API,
   HomeBaseDeviceFacade as BaseDeviceFacade,

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,7 @@ export type {
   HomeReportDataset,
   HomeReportPoint,
   HomeUser,
+  HomeUserContext,
   Hour,
   KeyOfClassicSetDeviceDataAtaNotInList,
   LoginCredentials,

--- a/src/types/home.ts
+++ b/src/types/home.ts
@@ -233,23 +233,14 @@ export type HomeDeviceData = HomeAtaDeviceData | HomeAtwDeviceData
 
 /**
  * Single weekly-schedule entry attached to a MELCloud Home device.
- * Field availability varies by device type; the SDK does not consume
- * specific entries today, so the type captures the canonical ATA shape
- * and leaves device-type extras off the canonical surface.
+ * The wire shape differs between ATA and ATW units (ATW entries carry
+ * zone/tank fields instead of setpoint/vane fields), and power-off
+ * entries hold `null` for every setting field; the SDK does not
+ * consume specific fields, so the type stays a structural placeholder
+ * until a use case appears — mirroring {@link HomeHolidayMode}.
  * @category Types
  */
-export interface HomeDeviceScheduleEntry {
-  readonly days: readonly string[]
-  readonly enabled: boolean
-  readonly id: string
-  readonly operationMode: string
-  readonly power: boolean
-  readonly setPoint: number
-  readonly time: string
-  readonly setFanSpeed?: string | undefined
-  readonly vaneHorizontalDirection?: string | undefined
-  readonly vaneVerticalDirection?: string | undefined
-}
+export type HomeDeviceScheduleEntry = Readonly<Record<string, unknown>>
 
 /**
  * Single name/value setting entry on a MELCloud Home device.
@@ -382,4 +373,20 @@ export interface HomeUser {
   readonly firstName: string
   readonly lastName: string
   readonly sub: string
+}
+
+/**
+ * Identity slice of the MELCloud Home `/context` response — the four
+ * fields that establish who is signed in. Kept separate from
+ * {@link HomeContext} so session validity can be derived from any
+ * successful `/context` round-trip even when the device payload
+ * fails full validation (device-schema drift must degrade the
+ * registry, never the authentication state).
+ * @category Types
+ */
+export interface HomeUserContext {
+  readonly email: string
+  readonly firstname: string
+  readonly id: string
+  readonly lastname: string
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -110,6 +110,7 @@ export type {
   HomeReportPoint,
   HomeTokenResponse,
   HomeUser,
+  HomeUserContext,
 } from './home.ts'
 export type { Hour } from './hour.ts'
 

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -9,7 +9,9 @@ export {
   HomeErrorLogEntryListSchema,
   HomeParResponseSchema,
   HomeReportDataSchema,
+  HomeResilientContextSchema,
   HomeTokenResponseSchema,
+  HomeUserContextSchema,
   HourSchema,
   parseOrThrow,
 } from './schemas.ts'

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -8,11 +8,13 @@ import type {
   HomeAtaDeviceData,
   HomeAtwDeviceCapabilities,
   HomeAtwDeviceData,
+  HomeBuilding,
   HomeContext,
   HomeEnergyData,
   HomeErrorLogEntry,
   HomeReportData,
   HomeTokenResponse,
+  HomeUserContext,
   Hour,
 } from '../types/index.ts'
 import { ClassicDeviceType } from '../constants.ts'
@@ -131,19 +133,6 @@ const HomeProtectionSchema = z.looseObject({
   min: z.number(),
 })
 
-const HomeDeviceScheduleEntrySchema = z.looseObject({
-  days: z.array(z.string()),
-  enabled: z.boolean(),
-  id: z.string(),
-  operationMode: z.string(),
-  power: z.boolean(),
-  setFanSpeed: z.string().optional(),
-  setPoint: z.number(),
-  time: z.string(),
-  vaneHorizontalDirection: z.string().optional(),
-  vaneVerticalDirection: z.string().optional(),
-})
-
 const HomeDeviceCommonFields = {
   displayIcon: z.string(),
   frostProtection: HomeProtectionSchema.nullable(),
@@ -154,7 +143,12 @@ const HomeDeviceCommonFields = {
   isInError: z.boolean(),
   overheatProtection: HomeProtectionSchema.nullable(),
   rssi: z.number(),
-  schedule: z.array(HomeDeviceScheduleEntrySchema),
+  // Structural like `holidayMode`: the wire shape differs between ATA
+  // and ATW units, power-off entries carry `null` for every setting
+  // field, and the SDK does not consume schedule fields. Validating
+  // the entries strictly took the whole /context down on legitimate
+  // payloads (off-schedules), which read as "unauthenticated".
+  schedule: z.array(z.looseObject({})),
   scheduleEnabled: z.boolean(),
   settings: z.array(HomeDeviceSettingSchema),
   timeZone: z.string(),
@@ -203,6 +197,72 @@ export const HomeContextSchema: z.ZodType<HomeContext> = z.looseObject({
   numberOfGuestUsersAllowedPerUnit: z.number(),
   scenes: z.array(z.looseObject({})),
 })
+
+/**
+ * Identity slice of the /context response — parsed before the full
+ * {@link HomeContextSchema} so a valid session is recognized even when
+ * the device payload drifts. Device-schema failures must degrade the
+ * registry, never the authentication state.
+ */
+export const HomeUserContextSchema: z.ZodType<HomeUserContext> = z.looseObject({
+  email: z.string(),
+  firstname: z.string(),
+  id: z.string(),
+  lastname: z.string(),
+})
+
+/**
+ * Parse an array while dropping entries that fail `schema` instead of
+ * failing the whole payload. Used by the salvage pass on `/context`:
+ * one drifted device must degrade the registry by one unit, not hide
+ * every building.
+ * @param schema - Element schema applied to each entry.
+ * @returns Schema producing only the entries that validated.
+ */
+const lenientArray = <T>(schema: z.ZodType<T>): z.ZodType<T[]> =>
+  z.array(z.unknown()).transform((entries) =>
+    entries.flatMap((entry) => {
+      const result = schema.safeParse(entry)
+      return result.success ? [result.data] : []
+    }),
+  )
+
+// Building envelopes stay strict on purpose: a malformed building
+// signals payload-level breakage where silently dropping the building
+// would unregister all of its devices — better to fail the salvage and
+// keep the registry on its last known state.
+const HomeResilientBuildingSchema: z.ZodType<HomeBuilding> = z.looseObject({
+  airToAirUnits: lenientArray(HomeAtaDeviceDataSchema),
+  airToWaterUnits: lenientArray(HomeAtwDeviceDataSchema),
+  id: z.string(),
+  name: z.string(),
+  timezone: z.string(),
+})
+
+/**
+ * Salvage variant of {@link HomeContextSchema}, applied only after the
+ * strict parse fails (the strict failure is logged with full paths).
+ * Device entries are validated one by one so a single drifted unit
+ * degrades the registry by exactly that unit, and unconsumed metadata
+ * falls back to neutral defaults instead of failing the payload.
+ */
+export const HomeResilientContextSchema: z.ZodType<HomeContext> = z.looseObject(
+  {
+    buildings: z.array(HomeResilientBuildingSchema),
+    country: z.string().catch(''),
+    email: z.string(),
+    firstname: z.string(),
+    guestBuildings: z.array(HomeResilientBuildingSchema),
+    id: z.string(),
+    language: z.string().catch(''),
+    lastname: z.string(),
+    numberOfBuildingsAllowed: z.number().catch(0),
+    numberOfDevicesAllowed: z.number().catch(0),
+    numberOfGuestDevicesAllowed: z.number().catch(0),
+    numberOfGuestUsersAllowedPerUnit: z.number().catch(0),
+    scenes: z.array(z.looseObject({})).catch([]),
+  },
+)
 
 // Home telemetry / report endpoints. Responses are consumed as arrays
 // the SDK iterates downstream, so a malformed shape would surface as

--- a/tests/integration/api-lifecycle.test.ts
+++ b/tests/integration/api-lifecycle.test.ts
@@ -83,6 +83,18 @@ const buildingResponse: ClassicBuildingWithStructure[] = [
 const { client: mockHttpClient, requestSpy: mockRequest } =
   createMockHttpClient('https://app.melcloud.com/Mitsubishi.Wifi.Client')
 
+// Lifecycle tests start from a persisted Classic session: the reuse
+// probe (and with it the create-time initial sync these tests rely
+// on) only runs when a contextKey is persisted — an unauthenticated
+// fetch would 401 against the real API anyway.
+const persistedClassicSession = (): ReturnType<
+  typeof createSettingStore
+>['settingManager'] =>
+  createSettingStore({
+    contextKey: 'test-context-key',
+    expiry: '2099-12-31T00:00:00',
+  }).settingManager
+
 describe('api lifecycle', () => {
   let melCloudApi: typeof ClassicAPI
 
@@ -102,6 +114,7 @@ describe('api lifecycle', () => {
 
   it('creates ClassicAPI, syncs buildings, and populates the registry', async () => {
     const api = await melCloudApi.create({
+      settingManager: persistedClassicSession(),
       syncIntervalMinutes: false,
       transport: mockHttpClient,
     })
@@ -162,6 +175,7 @@ describe('api lifecycle', () => {
 
   it('facadeManager works with registry populated by ClassicAPI', async () => {
     const api = await melCloudApi.create({
+      settingManager: persistedClassicSession(),
       syncIntervalMinutes: false,
       transport: mockHttpClient,
     })
@@ -246,6 +260,7 @@ describe('api lifecycle', () => {
 
   it('re-sync replaces registry data', async () => {
     const api = await melCloudApi.create({
+      settingManager: persistedClassicSession(),
       syncIntervalMinutes: false,
       transport: mockHttpClient,
     })
@@ -266,6 +281,7 @@ describe('api lifecycle', () => {
     const onSyncComplete = vi.fn<SyncCallback>()
     await melCloudApi.create({
       events: { onSyncComplete },
+      settingManager: persistedClassicSession(),
       syncIntervalMinutes: false,
       transport: mockHttpClient,
     })
@@ -284,6 +300,7 @@ describe('api lifecycle', () => {
     const onSyncComplete = vi.fn<SyncCallback>()
     const api = await melCloudApi.create({
       events: { onSyncComplete },
+      settingManager: persistedClassicSession(),
       syncIntervalMinutes: false,
       transport: mockHttpClient,
     })
@@ -371,6 +388,7 @@ describe('api lifecycle', () => {
       })
       mockRequest.mockRejectedValue(rateLimitError)
       const api = await melCloudApi.create({
+        settingManager: persistedClassicSession(),
         syncIntervalMinutes: false,
         transport: mockHttpClient,
       })
@@ -410,6 +428,7 @@ describe('api lifecycle', () => {
       })
       const api = await melCloudApi.create({
         abortSignal: controller.signal,
+        settingManager: persistedClassicSession(),
         syncIntervalMinutes: false,
         transport: mockHttpClient,
       })

--- a/tests/unit/base-api.test.ts
+++ b/tests/unit/base-api.test.ts
@@ -32,9 +32,13 @@ const { client: mockHttpClient, requestSpy: mockRequest } =
  * request pipeline without any Classic/Home-specific logic.
  */
 class TestAPI extends BaseAPI {
+  public readonly clearPersistedSessionMock = vi.fn<() => void>()
+
   public readonly doAuthenticateMock = vi.fn<() => Promise<void>>()
 
   public readonly getAuthHeadersMock = vi.fn<() => Record<string, string>>()
+
+  public readonly hasPersistedSessionMock = vi.fn<() => boolean>()
 
   public readonly isAuthenticatedMock = vi.fn<() => boolean>()
 
@@ -43,6 +47,8 @@ class TestAPI extends BaseAPI {
   public readonly performSessionRefreshMock = vi.fn<() => Promise<void>>()
 
   public readonly reauthenticateMock = vi.fn<() => Promise<boolean>>()
+
+  public readonly reuseSucceededMock = vi.fn<() => boolean>()
 
   public readonly syncRegistryMock = vi.fn<() => Promise<void>>()
 
@@ -68,10 +74,12 @@ class TestAPI extends BaseAPI {
       },
     )
     this.getAuthHeadersMock.mockReturnValue({})
+    this.hasPersistedSessionMock.mockReturnValue(false)
     this.isAuthenticatedMock.mockReturnValue(true)
     this.needsSessionRefreshMock.mockReturnValue(false)
     this.performSessionRefreshMock.mockResolvedValue()
     this.reauthenticateMock.mockResolvedValue(false)
+    this.reuseSucceededMock.mockReturnValue(false)
     this.doAuthenticateMock.mockResolvedValue()
     this.syncRegistryMock.mockResolvedValue()
     this.tryReuseSessionMock.mockResolvedValue(false)
@@ -104,12 +112,20 @@ class TestAPI extends BaseAPI {
     return this.isAuthenticatedMock()
   }
 
+  protected override clearPersistedSession(): void {
+    this.clearPersistedSessionMock()
+  }
+
   protected override async doAuthenticate(): Promise<void> {
     return this.doAuthenticateMock()
   }
 
   protected override getAuthHeaders(): Record<string, string> {
     return this.getAuthHeadersMock()
+  }
+
+  protected override hasPersistedSession(): boolean {
+    return this.hasPersistedSessionMock()
   }
 
   protected override needsSessionRefresh(): boolean {
@@ -122,6 +138,10 @@ class TestAPI extends BaseAPI {
 
   protected override async reauthenticate(): Promise<boolean> {
     return this.reauthenticateMock()
+  }
+
+  protected override reuseSucceeded(): boolean {
+    return this.reuseSucceededMock()
   }
 
   protected override async syncRegistry(): Promise<void> {

--- a/tests/unit/classic-api.test.ts
+++ b/tests/unit/classic-api.test.ts
@@ -213,9 +213,16 @@ describe('mELCloud Classic API', () => {
       .mockImplementationOnce(async () => {
         // First call (initial create) succeeds, subsequent calls can throw
       })
+    // Persisted session so the create-time reuse probe runs the first
+    // sync and arms the auto-sync timer the test advances into.
+    const { settingManager } = createSettingStore({
+      contextKey: 'test-context-key',
+      expiry: '2099-12-31T00:00:00',
+    })
     await melCloudApi.create({
       events: { onSyncComplete },
       logger,
+      settingManager,
       syncIntervalMinutes: 1,
       transport: mockHttpClient,
     })

--- a/tests/unit/home-api.test.ts
+++ b/tests/unit/home-api.test.ts
@@ -522,10 +522,25 @@ describe('melcloud home API', () => {
       })
     })
 
-    it('should return null on failure', async () => {
+    // A transient refresh failure must not read as "logged out": the
+    // reactive-401 path is the single owner of clearing the user, so
+    // getUser returns the last known identity unchanged.
+    it('should keep the last known user on a transient failure', async () => {
       setupSuccessfulLogin()
       const api = await createApi()
-      mockRequest.mockRejectedValueOnce(new Error('unauthorized'))
+      mockRequest.mockRejectedValueOnce(new Error('network down'))
+      const user = await api.getUser()
+
+      expect(user).not.toBeNull()
+      expect(api.isAuthenticated()).toBe(true)
+    })
+
+    it('should return null when a definitive 401 clears the session', async () => {
+      setupSuccessfulLogin()
+      const api = await createApi()
+      // 401 → refresh-token exchange and OIDC resume both fail (fetch
+      // queue exhausted) → reauthenticate clears the user state.
+      mockRequest.mockRejectedValueOnce(httpUnauthorized())
       const user = await api.getUser()
 
       expect(user).toBeNull()
@@ -1651,14 +1666,14 @@ describe('melcloud home API', () => {
       expect(api.isAuthenticated()).toBe(true)
     })
 
-    it('should wipe persisted state when rejected session has no credentials', async () => {
+    it('should wipe persisted state on a definitive 401 with no credentials', async () => {
       const futureExpiry = Temporal.Now.instant().add({ hours: 1 }).toString()
       const { setSpy, settingManager } = createSettingStore({
         accessToken: 'dead-token',
         expiry: futureExpiry,
         refreshToken: 'dead-refresh',
       })
-      mockRequest.mockRejectedValueOnce(new Error('401 Unauthorized'))
+      mockRequest.mockRejectedValueOnce(httpUnauthorized())
 
       const api = await createFromPersistedStore(settingManager)
 
@@ -1666,6 +1681,53 @@ describe('melcloud home API', () => {
       expect(setSpy).toHaveBeenCalledWith('accessToken', '')
       expect(setSpy).toHaveBeenCalledWith('refreshToken', '')
       expect(setSpy).toHaveBeenCalledWith('expiry', '')
+    })
+
+    // Regression guard for the boot-outage class of bug: inside
+    // `list()` a transient failure (network not ready right after an
+    // app restart) is indistinguishable from a token rejection, so the
+    // reuse probe must never wipe the persisted session — clearing is
+    // owned by the reactive-401 path. Before this fix the probe wiped
+    // on any empty context, so a network blip at boot destroyed valid
+    // tokens and the settings page demanded credentials again.
+    it('keeps the persisted session when the reuse probe fails transiently', async () => {
+      const futureExpiry = Temporal.Now.instant().add({ hours: 1 }).toString()
+      const { setSpy, settingManager } = createSettingStore({
+        accessToken: 'persisted-token',
+        expiry: futureExpiry,
+        refreshToken: 'persisted-refresh',
+      })
+      mockRequest.mockRejectedValueOnce(new Error('network down'))
+
+      const api = await createFromPersistedStore(settingManager)
+
+      expect(api.isAuthenticated()).toBe(false)
+      expect(setSpy).not.toHaveBeenCalledWith('accessToken', '')
+      expect(setSpy).not.toHaveBeenCalledWith('refreshToken', '')
+      expect(setSpy).not.toHaveBeenCalledWith('expiry', '')
+      expect(settingManager.get('accessToken')).toBe('persisted-token')
+      expect(settingManager.get('refreshToken')).toBe('persisted-refresh')
+    })
+
+    it('recovers on the next sync after a transient boot failure', async () => {
+      const futureExpiry = Temporal.Now.instant().add({ hours: 1 }).toString()
+      const { settingManager } = createSettingStore({
+        accessToken: 'persisted-token',
+        expiry: futureExpiry,
+        refreshToken: 'persisted-refresh',
+      })
+      mockRequest.mockRejectedValueOnce(new Error('network down'))
+      const api = await createFromPersistedStore(settingManager)
+
+      expect(api.isAuthenticated()).toBe(false)
+
+      mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
+      await api.list()
+
+      expect(api.isAuthenticated()).toBe(true)
+      // Recovery reused the preserved token — nothing was re-minted,
+      // which pins that the boot failure left the session untouched.
+      expect(settingManager.get('accessToken')).toBe('persisted-token')
     })
 
     it('should skip getUser when expiry is empty and no tokens', async () => {
@@ -1777,6 +1839,206 @@ describe('melcloud home API', () => {
       // First call sets '' (clear), subsequent call sets the new token
       expect(tokenCalls[0]?.[1]).toBe('')
       expect(tokenCalls.at(-1)?.[1]).toBe('test-access-token')
+    })
+  })
+
+  describe('context drift resilience', () => {
+    const validAtaUnit = {
+      ...commonDeviceFields,
+      capabilities: mockAtaCapabilities,
+      connectedInterfaceIdentifier: 'FE0000060403388D3DFFFE000000000000',
+      connectedInterfaceType: 'fourthGenWifi',
+      givenDisplayName: 'Valid ATA unit',
+      id: 'device-1',
+      rssi: -50,
+      settings: [],
+      systemId: null,
+      unitSettings: null,
+    }
+
+    // The captured production regression: power-off schedule entries
+    // carry `null` for every setting field and ATW schedules use a
+    // zone/tank shape — both used to fail the strict /context schema,
+    // which read as "unauthenticated" and re-opened the settings login
+    // form despite valid credentials.
+    it('accepts schedule entries in either device-type shape', async () => {
+      const logger = createLogger()
+      const { settingManager } = persistedSessionStore()
+      mockRequest.mockResolvedValueOnce(
+        mockResponse(
+          {
+            ...mockContext,
+            guestBuildings: [
+              {
+                ...mockBuilding,
+                airToAirUnits: [
+                  {
+                    ...validAtaUnit,
+                    schedule: [
+                      {
+                        days: ['saturday', 'sunday'],
+                        enabled: true,
+                        id: 'schedule-1',
+                        operationMode: null,
+                        power: false,
+                        setFanSpeed: null,
+                        setPoint: null,
+                        time: '05:00:00',
+                        vaneHorizontalDirection: null,
+                        vaneVerticalDirection: null,
+                      },
+                    ],
+                  },
+                ],
+                airToWaterUnits: [
+                  {
+                    ...mockBuilding.airToWaterUnits[0],
+                    schedule: [
+                      {
+                        days: ['saturday'],
+                        forcedHotWaterMode: null,
+                        hotWaterActive: false,
+                        id: 'schedule-2',
+                        operationModeZone1: null,
+                        operationModeZone2: null,
+                        power: false,
+                        setTankWaterTemperature: null,
+                        setTemperatureZone1: null,
+                        setTemperatureZone2: null,
+                        time: '17:00:00',
+                        zone1Active: false,
+                        zone2Active: false,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {},
+          200,
+        ),
+      )
+
+      const api = await melCloudHomeApi.create({
+        baseURL: BASE_URL,
+        logger,
+        settingManager,
+        transport: mockHttpClient,
+      })
+
+      expect(api.isAuthenticated()).toBe(true)
+      expect(api.registry.getAll()).toHaveLength(2)
+      expect(logger.error).not.toHaveBeenCalled()
+    })
+
+    it('keeps authentication and the valid units when one unit drifts', async () => {
+      const logger = createLogger()
+      const { settingManager } = persistedSessionStore()
+      mockRequest.mockResolvedValueOnce(
+        mockResponse(
+          {
+            ...mockContext,
+            guestBuildings: [
+              {
+                ...mockBuilding,
+                airToAirUnits: [
+                  validAtaUnit,
+                  { ...validAtaUnit, id: 'device-3', rssi: 'weak' },
+                ],
+              },
+            ],
+          },
+          {},
+          200,
+        ),
+      )
+
+      const api = await melCloudHomeApi.create({
+        baseURL: BASE_URL,
+        logger,
+        settingManager,
+        transport: mockHttpClient,
+      })
+
+      expect(api.isAuthenticated()).toBe(true)
+      expect(logger.error).toHaveBeenCalledWith(
+        'Home context drifted from the strict schema; salvaging device entries:',
+        expect.anything(),
+      )
+      expect(api.registry.getById('device-3')).toBeUndefined()
+      expect(api.registry.getAll()).toHaveLength(2)
+    })
+
+    it('keeps the full registry when only metadata drifts', async () => {
+      const { settingManager } = persistedSessionStore()
+      mockRequest.mockResolvedValueOnce(
+        mockResponse({ ...mockContext, language: 123 }, {}, 200),
+      )
+
+      const api = await createFromPersistedStore(settingManager)
+
+      expect(api.isAuthenticated()).toBe(true)
+      expect(api.registry.getAll()).toHaveLength(2)
+      expect(api.context?.language).toBe('')
+    })
+
+    // Identity-only success: the user parses but even the salvage
+    // schema fails (building envelope drift). Authentication holds —
+    // that is the core invariant — while the reuse probe reports
+    // `false` (its `true` promises a verified registry) and the
+    // session material stays untouched for the next sync to retry.
+    it('stays authenticated without completing reuse when salvage fails', async () => {
+      const futureExpiry = Temporal.Now.instant().add({ hours: 1 }).toString()
+      const { setSpy, settingManager } = createSettingStore({
+        accessToken: 'persisted-token',
+        expiry: futureExpiry,
+        refreshToken: 'persisted-refresh',
+      })
+      mockRequest.mockResolvedValue(
+        mockResponse(
+          {
+            ...mockContext,
+            guestBuildings: [
+              {
+                airToAirUnits: [],
+                airToWaterUnits: [],
+                id: 'building-1',
+                name: 'Home',
+                // timezone missing — the building envelope stays
+                // strict on purpose, so the salvage parse fails too.
+              },
+            ],
+          },
+          {},
+          200,
+        ),
+      )
+
+      const api = await createFromPersistedStore(settingManager)
+
+      expect(api.isAuthenticated()).toBe(true)
+      expect(api.context).toBeNull()
+      expect(api.registry.getAll()).toHaveLength(0)
+      expect(setSpy).not.toHaveBeenCalledWith('accessToken', '')
+    })
+
+    it('does not authenticate when the identity slice is missing', async () => {
+      const futureExpiry = Temporal.Now.instant().add({ hours: 1 }).toString()
+      const { setSpy, settingManager } = createSettingStore({
+        accessToken: 'persisted-token',
+        expiry: futureExpiry,
+        refreshToken: 'persisted-refresh',
+      })
+      mockRequest.mockResolvedValueOnce(
+        mockResponse({ ...mockContext, id: undefined }, {}, 200),
+      )
+
+      const api = await createFromPersistedStore(settingManager)
+
+      expect(api.isAuthenticated()).toBe(false)
+      // Not a 401 — the persisted session must survive for later syncs.
+      expect(setSpy).not.toHaveBeenCalledWith('accessToken', '')
     })
   })
 


### PR DESCRIPTION
## Problem

Opening the app's settings page showed the MELCloud Home credentials form despite valid credentials (com.melcloud bug). Captured production evidence (`/context` HTTP 200 on a valid session) fails the current `HomeContextSchema` with 16 issues:

- ATA power-off schedule entries carry `null` for `operationMode`, `setPoint`, `setFanSpeed`, `vane*Direction` — the schema requires `string`/`number`.
- ATW schedule entries use a completely different zone/tank shape (`setTankWaterTemperature`, `operationModeZone1/2`, …) — the schema models only the ATA shape.

One power-off schedule anywhere → the whole `/context` parse throws → `runSyncCycle` swallows it → `#user` never set → `isAuthenticated()` reads `false` on every sync, deterministically, with a perfectly valid session.

Two more defects compounded it:
- `tryReuseSession()` wiped the persisted tokens whenever `list()` left the context empty — but `list()` swallows transient failures too, so a boot-time network blip destroyed valid sessions (Classic never had this pattern).
- Auth state was coupled to full-payload validity: any future device-field drift reads as "logged out".

## Fix

- **Schedule entries become structural** (`z.array(z.looseObject({}))`, type `Readonly<Record<string, unknown>>`) — the SDK consumes no schedule fields, mirroring the existing `holidayMode` precedent and the file's own "validate only what we consume" principle.
- **Two-stage `/context` parse** in `#fetchContext`: the identity slice (`HomeUserContextSchema`) establishes the user on any successful round-trip; the strict schema feeds the registry, falling back to a per-unit salvage (`HomeResilientContextSchema` + `lenientArray`) that drops only drifted units and logs the strict failure with full paths. Building envelopes stay strict on purpose (a drifted building fails the salvage instead of silently unregistering its devices).
- **`tryReuseSession()` never clears the session** — clearing is owned by the reactive-401 path (`reauthenticate`). Its `true` return stays gated on a verified registry (`context !== null`), preserving the #1281 invariant.
- **`getUser()` made coherent**: failures return the last known user instead of nulling it — a definitive 401 has already cleared the state via `reauthenticate` by the time the failure surfaces.

## Verification

- Full suite: 723 tests, 100 % statements/branches/functions/lines.
- New regression tests: definitive-401 wipe (now via a real `HttpError`), transient-preserve, next-sync recovery pinned to the preserved token, both captured schedule shapes, per-unit salvage, metadata-only drift, identity-slice-missing, identity-only success.
- Captured production payload replayed: identity ✅, strict ✅ (5/5 units), salvage ✅ — same payload fails on `main` with 16 issues.
- On-device E2E (com.melcloud + this branch packed locally on a real Homey): 8+ consecutive clean `/context` sync cycles, zero `Failed to fetch devices`, zero drift logs.

## Breaking

`HomeDeviceScheduleEntry` collapses from a 10-field interface to a structural placeholder (`Readonly<Record<string, unknown>>`). No consumer reads schedule fields (verified repo-wide and in com.melcloud), but this is a published type → semver-major release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)