### PR TITLE
chore(release): 40.0.0 — Home auth resilience

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "39.0.0",
+  "version": "40.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "39.0.0",
+      "version": "40.0.0",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "39.0.0",
+  "version": "40.0.0",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",


### PR DESCRIPTION
Version bump for the v40.0.0 major release.

## Breaking
- `HomeDeviceScheduleEntry` is now a structural placeholder (`Readonly<Record<string, unknown>>`) — the wire shape differs between ATA and ATW units and the SDK consumes no schedule fields (#1572).

## Fixed
- Home schema drift and boot-time network blips no longer read as "unauthenticated" (#1572): structural schedule validation, two-stage `/context` parse (identity slice → strict → per-unit salvage), non-destructive session-reuse probe, coherent `getUser()`.

## Refactored
- Session-reuse probe and pre-login wipe hoisted into `BaseAPI` (#1572): the probe can no longer clear persisted sessions, and clearing has exactly two owners (explicit login, reactive 401).

🤖 Generated with [Claude Code](https://claude.com/claude-code)