### PR TITLE
refactor(lint): honest ownership comments and leftover rule scars

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -527,7 +527,6 @@ const config = defineConfig([
         },
       ],
       'no-template-curly-in-string': 'error',
-      'no-unexpected-multiline': 'error',
       'no-unmodified-loop-condition': 'error',
       'no-unneeded-ternary': 'error',
       'no-unreachable-loop': 'error',
@@ -726,16 +725,19 @@ const config = defineConfig([
       ],
       'symbol-description': 'error',
       'unicode-bom': 'error',
-      // Owned by `@typescript-eslint/naming-convention`.
+      // Owned by `@typescript-eslint/naming-convention` for variables,
+      // parameters and class properties (identical prefix set).
       'unicorn/consistent-boolean-name': 'off',
       // Owned by `perfectionist/sort-classes`.
       'unicorn/consistent-class-member-order': 'off',
       'unicorn/custom-error-definition': 'error',
-      // Owned by `@typescript-eslint/naming-convention`.
+      // Vocabulary opt-out: the abbreviation renames it forces
+      // (`args` -> `arguments_`, ...) fight the domain naming.
       'unicorn/name-replacements': 'off',
       // Owned by `import-x/no-anonymous-default-export`.
       'unicorn/no-anonymous-default-export': 'off',
-      // Owned by `import-x/no-named-default`.
+      // Owned by `import-x/no-named-default` (imports; the export
+      // form it also covers is unused here).
       'unicorn/no-named-default': 'off',
       // Domain nouns: `Set-Cookie` header, `SetDeviceData` payload.
       'unicorn/no-non-function-verb-prefix': [

--- a/src/api/classic.ts
+++ b/src/api/classic.ts
@@ -134,7 +134,7 @@ const parseErrorLogQuery = (
 }
 
 // Collect all areas from both building-level and floor-level
-const collectAreas = function* collectAreas(
+const collectAreas = function* (
   buildings: ClassicBuildingWithStructure[],
 ): Generator<ClassicAreaDataAny> {
   for (const {
@@ -148,7 +148,7 @@ const collectAreas = function* collectAreas(
 }
 
 // Collect all devices from every level of the hierarchy
-const collectDevices = function* collectDevices(
+const collectDevices = function* (
   buildings: ClassicBuildingWithStructure[],
 ): Generator<ClassicListDeviceAny> {
   for (const {

--- a/src/entities/classic-registry.ts
+++ b/src/entities/classic-registry.ts
@@ -85,7 +85,7 @@ const level = {
   great_grandchild: 3,
 }
 
-const flattenAreas = function* flattenAreas(
+const flattenAreas = function* (
   areas: readonly ClassicAreaZone[],
 ): Generator<ClassicZone> {
   for (const area of areas) {
@@ -94,7 +94,7 @@ const flattenAreas = function* flattenAreas(
   }
 }
 
-const flattenBuildings = function* flattenBuildings(
+const flattenBuildings = function* (
   buildings: readonly ClassicBuildingZone[],
 ): Generator<ClassicZone> {
   for (const building of buildings) {

--- a/src/facades/classic-device-atw.ts
+++ b/src/facades/classic-device-atw.ts
@@ -19,8 +19,6 @@ import type { ReportChartLineOptions, ReportQuery } from './report-types.ts'
 import { BaseDeviceFacade } from './classic-base-device.ts'
 import { classicAtwFlags } from './classic-flags.ts'
 
-const DEFAULT_TEMPERATURE = 0
-
 const MIN_TANK_TEMPERATURE = 40
 
 const coolFlowTemperatureRange = { max: 25, min: 5 }
@@ -216,7 +214,7 @@ export class ClassicDeviceAtwFacade extends BaseDeviceFacade<
         .filter(([key]) => Object.hasOwn(data, key))
         .map(([key, range]) => [
           key,
-          clampToRange(data[key] ?? DEFAULT_TEMPERATURE, range),
+          clampToRange(data[key] ?? range.min, range),
         ]),
     )
   }


### PR DESCRIPTION
Sister PR of OlivierZal/com.melcloud#1373 — final bidirectional review of the two ESLint configs.

## Quoi

- **Commentaires d'ownership honnêtes** : `unicorn/name-replacements` était étiqueté « Owned by naming-convention » — factuellement faux (naming-convention n'impose que des formats, pas du vocabulaire ; la règle forcée rapporte ~82 renommages type `args`→`arguments_`). C'est un opt-out assumé, dit comme tel. `consistent-boolean-name` et `no-named-default` précisent désormais leur couverture réelle (scopes non couverts par le propriétaire).
- **`no-unexpected-multiline` retirée** : config-prettier la documente comme dangereuse à réactiver avec `semi: false` (le repo l'utilise) ; Prettier possède la séparation des statements.
- **Cicatrices résiduelles des règles `.all` abandonnées** (vérifiées lint-clean une à une) : 4 expressions de fonction nommées héritées de `func-names` (`const collectAreas = function* collectAreas(` → anonyme, le nom est inféré du const) ; `DEFAULT_TEMPERATURE = 0` trompeuse (0 est sous tous les minima de plage, donc le fallback clampait toujours à `range.min` — dit directement).

## Vérification

Lint exit 0, Prettier clean, tsgo clean, 723 tests. Chasse complète : zéro cicatrice `init-declarations` restante (les 14 `let` lisent leur initialiseur ou sont nus), zéro `+= 1`, les constantes 0/1/2 restantes sont des constantes de domaine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)