### PR TITLE
refactor(temporal): adopt the stabilized 1.x idioms

### DIFF
--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -48,26 +48,22 @@ const parseUser = (data: HomeUserContext): HomeUser => ({
   sub: data.id,
 })
 
-// Parse offset-bearing inputs (e.g. `'2026-03-01T10:00:00Z'`) as
-// absolute instants then re-project to UTC wall time; parse offset-less
-// inputs (e.g. `'2026-03-01'`, `'2026-03-01T00:00:00'`) as already-UTC
-// wall time. Anchoring on UTC prevents the host's local timezone from
-// shifting the formatted output by hours.
-const parseUTCPlainDateTime = (iso: string): Temporal.PlainDateTime => {
-  try {
-    return Temporal.Instant.from(iso)
-      .toZonedDateTimeISO('UTC')
-      .toPlainDateTime()
-  } catch {
-    return Temporal.PlainDateTime.from(iso)
-  }
-}
+// Anchor on UTC so the host's local timezone cannot shift the
+// formatted output: `offset: 'use'` keeps offset-bearing inputs
+// (e.g. `'2026-03-01T10:00:00Z'`) at their absolute instant while
+// offset-less inputs (e.g. `'2026-03-01'`) adopt UTC wall time.
+const parseUTCPlainDateTime = (iso: string): Temporal.PlainDateTime =>
+  Temporal.ZonedDateTime.from(`${iso}[UTC]`, {
+    offset: 'use',
+  }).toPlainDateTime()
 
 // `/report/v1/trendsummary` expects .NET-style ISO with 7 subsecond zeros
 // (e.g. `2026-04-19T00:00:00.0000000`). Anything shorter is silently
 // truncated to an empty window by the BFF.
 const toReportDate = (iso: string): string =>
-  `${parseUTCPlainDateTime(iso).toString({ smallestUnit: 'second' })}.0000000`
+  parseUTCPlainDateTime(iso)
+    .round({ roundingMode: 'trunc', smallestUnit: 'second' })
+    .toString({ fractionalSecondDigits: 7 })
 
 // `/telemetry/telemetry/{energy,actual}` expect `YYYY-MM-DD HH:MM` with a
 // space and no seconds. Seconds or an ISO `T` separator produce an empty

--- a/src/facades/classic-base-device.ts
+++ b/src/facades/classic-base-device.ts
@@ -49,13 +49,11 @@ const DEFAULT_YEAR = '1970-01-01'
 // Calendar-day delta between two ISO wall-clock strings. Computed on
 // `PlainDateTime` so the result reflects the literal Y-M-D-h-m-s span
 // the Classic server uses, independent of DST in any zone.
-const getDuration = ({ from, to }: Required<ReportQuery>): number => {
-  const diff = Temporal.PlainDateTime.from(to).since(
-    Temporal.PlainDateTime.from(from),
-    { largestUnit: 'day' },
-  )
-  return Math.ceil(diff.total({ unit: 'day' }))
-}
+const getDuration = ({ from, to }: Required<ReportQuery>): number =>
+  Temporal.PlainDateTime.from(to).since(Temporal.PlainDateTime.from(from), {
+    roundingMode: 'ceil',
+    smallestUnit: 'day',
+  }).days
 
 /**
  * Abstract base for device-specific facades. Handles device data access, report generation,

--- a/src/facades/classic-base.ts
+++ b/src/facades/classic-base.ts
@@ -34,7 +34,7 @@ import {
   mapResult,
   toClassicDeviceId,
 } from '../types/index.ts'
-import { getChartLineOptions, now } from '../utils.ts'
+import { getChartLineOptions } from '../utils.ts'
 import { HourSchema, parseOrThrow } from '../validation/index.ts'
 import type {
   ClassicFacade,
@@ -231,7 +231,9 @@ export abstract class ClassicBaseFacade<
     const isEnabled = to !== undefined
     const startDate =
       isEnabled ?
-        Temporal.PlainDateTime.from(from ?? now(this.api.timezone))
+        from === undefined ?
+          Temporal.Now.plainDateTimeISO(this.api.timezone)
+        : Temporal.PlainDateTime.from(from)
       : null
     const endDate = isEnabled ? Temporal.PlainDateTime.from(to) : null
     return this.api.updateHolidayMode({

--- a/src/facades/classic-base.ts
+++ b/src/facades/classic-base.ts
@@ -229,12 +229,11 @@ export abstract class ClassicBaseFacade<
     ClassicFailureData | ClassicSuccessData
   > {
     const isEnabled = to !== undefined
-    const startDate =
-      isEnabled ?
-        from === undefined ?
-          Temporal.Now.plainDateTimeISO(this.api.timezone)
-        : Temporal.PlainDateTime.from(from)
-      : null
+    const resolveStartDate = (): Temporal.PlainDateTime =>
+      from === undefined ?
+        Temporal.Now.plainDateTimeISO(this.api.timezone)
+      : Temporal.PlainDateTime.from(from)
+    const startDate = isEnabled ? resolveStartDate() : null
     const endDate = isEnabled ? Temporal.PlainDateTime.from(to) : null
     return this.api.updateHolidayMode({
       postData: {

--- a/src/resilience/rate-limit-gate.ts
+++ b/src/resilience/rate-limit-gate.ts
@@ -1,5 +1,4 @@
 import { Temporal } from '../temporal.ts'
-import { SECONDS_PER_MINUTE } from '../time-units.ts'
 
 /**
  * Subset of `Temporal.Duration` field values accepted by
@@ -73,12 +72,14 @@ const parseRetryAfter = (
  * @returns The formatted, English-diagnostic string.
  */
 export const formatDurationHuman = (duration: Temporal.Duration): string => {
-  const totalSeconds = Math.trunc(duration.total({ unit: 'seconds' }))
-  if (totalSeconds < SECONDS_PER_MINUTE) {
-    return `${String(totalSeconds)} ${pluralize(totalSeconds, 'second')}`
+  const { minutes, seconds } = duration.round({
+    largestUnit: 'minutes',
+    roundingMode: 'trunc',
+    smallestUnit: 'seconds',
+  })
+  if (minutes === 0) {
+    return `${String(seconds)} ${pluralize(seconds, 'second')}`
   }
-  const minutes = Math.trunc(totalSeconds / SECONDS_PER_MINUTE)
-  const seconds = totalSeconds % SECONDS_PER_MINUTE
   if (seconds === 0) {
     return `${String(minutes)} ${pluralize(minutes, 'minute')}`
   }

--- a/src/resilience/session-expiry.ts
+++ b/src/resilience/session-expiry.ts
@@ -1,27 +1,15 @@
 import { Temporal } from '../temporal.ts'
 
-// Detects an explicit UTC marker (`Z`) or numeric offset (`±HH:MM` /
-// `±HHMM`) after the date/time separator. Offset-less inputs need
-// zone-aware parsing; offset-bearing inputs are absolute instants.
-const OFFSET_REGEX = /[+\-]\d{2}:?\d{2}$/v
-
-const hasOffset = (iso: string): boolean => {
-  if (!iso.includes('T')) {
-    return false
-  }
-  const afterT = iso.slice(iso.indexOf('T') + 1)
-  return afterT.includes('Z') || OFFSET_REGEX.test(afterT)
-}
-
+// `offset: 'use'` keeps offset-bearing inputs (`Z`, `±HH:MM`, `±HHMM`)
+// at their absolute instant while offset-less inputs adopt `zone`.
 const toInstant = (
   expiry: string,
   zone: string | undefined,
 ): Temporal.Instant =>
-  hasOffset(expiry) ?
-    Temporal.Instant.from(expiry)
-  : Temporal.PlainDateTime.from(expiry)
-      .toZonedDateTime(zone ?? Temporal.Now.timeZoneId())
-      .toInstant()
+  Temporal.ZonedDateTime.from(
+    `${expiry}[${zone ?? Temporal.Now.timeZoneId()}]`,
+    { offset: 'use' },
+  ).toInstant()
 
 const parseToInstant = (
   expiry: string,

--- a/src/time-units.ts
+++ b/src/time-units.ts
@@ -4,8 +4,6 @@
  * `MILLISECONDS_IN_SECOND` vs `MILLISECONDS_PER_SECOND`).
  */
 
-/** Number of seconds in one minute. */
-export const SECONDS_PER_MINUTE = 60
 /** Number of milliseconds in one second. */
 export const MS_PER_SECOND = 1000
 /** Number of milliseconds in one minute. */


### PR DESCRIPTION
Companion of OlivierZal/com.melcloud#1374 — the Temporal 1.x review on the lib side. Six simplifications enabled by the final spec, **each verified byte-identical against the installed temporal-polyfill 1.0.1** (probe script in the working notes; whole-second, offset-bearing, offset-less, compact-offset and subsecond inputs).

## Quoi

- `parseUTCPlainDateTime` (home.ts) et le trio `OFFSET_REGEX`/`hasOffset`/`toInstant` (session-expiry.ts, ~19 lignes) s'effondrent chacun en **une expression** : `ZonedDateTime.from(`${iso}[zone]`, { offset: 'use' })` — l'option encode exactement la sémantique « instant absolu si offset présent, wall time sinon » que le try/catch et la regex maison réimplémentaient. Supprime aussi le hasard d'ordre des branches.
- `formatDurationHuman` : arithmétique entière manuelle → `Duration.round({ largestUnit: 'minutes', smallestUnit: 'seconds', roundingMode: 'trunc' })` ; `SECONDS_PER_MINUTE` n'a plus de consommateur et disparaît de time-units.
- `getDuration` : `Math.ceil(diff.total('day'))` → `since(from, { smallestUnit: 'day', roundingMode: 'ceil' }).days`.
- `toReportDate` : suffixe `.0000000` concaténé → `round('second', trunc) + toString({ fractionalSecondDigits: 7 })` — la troncature sous-seconde est désormais explicite et les octets wire restent identiques pour toute entrée.
- Holiday-mode : `PlainDateTime.from(now(tz))` (format-puis-reparse) → `Temporal.Now.plainDateTimeISO(tz)` direct.

## Non-applicables notables (vérifiés, documentés dans les notes)

Les formats wire MELCloud (`toTelemetryDate`, `getDateTimeComponents`) restent tels quels ; le spec final ne fournit **aucun parse non-throwing** (`parsePlainDate`/`safePlainDateYear` gardent leur try/catch) ; `Date.parse` reste pour les HTTP-dates `Retry-After` (IMF-fixdate non-Temporal) ; **`Intl.DurationFormat` est un piège** : lib.es2025 le déclare (ça typecheck) mais le polyfill le runtime-garde et dégrade en ISO `"PT2M30S"` — à ne pas adopter avant un bump d'engines au support vérifié.

## Vérification

Lint exit 0, Prettier, tsgo, 723 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)