### PR TITLE
ci(review): skip runs triggered by the claude bot's own pushes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,6 +4,7 @@ concurrency:
 jobs:
   review:
     if: |
+      github.actor != 'claude[bot]' &&
       github.actor != 'dependabot[bot]' &&
       !github.event.pull_request.draft &&
       github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
Root cause of the red Review check on #1575: an `@claude` mention made the bot push `be6b3849` to the PR branch; the `synchronize` event re-fired this workflow with `actor: claude[bot]`, which `claude-code-action` rejects by default (`Workflow initiated by non-human actor` — its anti-loop guard).

Extend the existing dependabot exclusion to `claude[bot]`: bot pushes now **skip** the review (neutral) instead of failing it. Rationale over `allowed_bots`: the bot's push was human-requested and reviewed by that human; the next human push reviews the branch cumulatively; and it forecloses review↔bot ping-pong.

Sister PR on com.melcloud follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)