### PR TITLE
ci(review): claim the concurrency group at job level

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,8 +1,10 @@
-concurrency:
-  cancel-in-progress: true
-  group: claude-review-${{ github.event.pull_request.number }}
 jobs:
   review:
+    # Job-level so a fully-skipped bot-triggered run cannot claim the
+    # group and cancel an in-progress human review.
+    concurrency:
+      cancel-in-progress: true
+      group: claude-review-${{ github.event.pull_request.number }}
     if: |
       github.actor != 'claude[bot]' &&
       github.actor != 'dependabot[bot]' &&


### PR DESCRIPTION
Follow-up to the bot-skip fix, prompted by Copilot's review comment on OlivierZal/melcloud-api#1576: workflow-level `concurrency` with `cancel-in-progress: true` is claimed at run creation — before job `if:` evaluation — so a bot-triggered `synchronize` run (whose only job then skips) still cancelled an in-progress human review of the same PR. Moving the block to the job means a skipped job never claims the group: bot pushes now neither fail, run, nor cancel anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)