### PR TITLE
ci(claude): drop the review triggers Copilot holds hostage

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -5,12 +5,6 @@ jobs:
         (github.event_name == 'issue_comment' &&
           contains(github.event.comment.body, '@claude') &&
           contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-        (github.event_name == 'pull_request_review_comment' &&
-          contains(github.event.comment.body, '@claude') &&
-          contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-        (github.event_name == 'pull_request_review' &&
-          contains(github.event.review.body || '', '@claude') &&
-          contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
         (github.event_name == 'issues' &&
           (contains(github.event.issue.body || '', '@claude') || contains(github.event.issue.title, '@claude')) &&
           contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
@@ -37,12 +31,10 @@ jobs:
     timeout-minutes: 15
 name: Claude
 on:
+  # No pull_request_review(_comment): Copilot auto-review fires them as a
+  # write-less bot, piling up held runs the if-guard would skip anyway.
   issue_comment:
     types: [created]
   issues:
     types: [opened]
-  pull_request_review:
-    types: [submitted]
-  pull_request_review_comment:
-    types: [created]
 permissions: {}


### PR DESCRIPTION
## Why

Since automatic Copilot code review was enabled via the `Protect main` ruleset (2026-07-04), every Copilot review submission and inline comment fires `claude.yml` through `pull_request_review` / `pull_request_review_comment`. Copilot is a Bot without write access and the repo's Actions approval policy is `all_external_contributors`, so each of those runs sits as `action_required` — the “workflows awaiting approval” banner on every PR.

Approving them is a no-op by construction: the job `if` requires `@claude` in the body **and** an OWNER/MEMBER/COLLABORATOR author, which Copilot never satisfies. No review-event run of this workflow has ever executed in the repo's history.

## What

- Remove the `pull_request_review` and `pull_request_review_comment` triggers and their now-dead `if` clauses.
- `@claude` stays reachable from PR conversation comments (`issue_comment`) and issues (`issues`).

zizmor and prettier pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)