### PR TITLE
docs(claude): document the release and downstream-upgrade process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,11 +87,11 @@ is on: no runtime enums, no parameter properties, no runtime namespaces.
   so bump it before tagging.
 - Prerelease/alpha flow (keeps `main` on the target stable version, no
   `-alpha` suffix): branch from `main`, `npm version 41.0.0-alpha.0
-  --no-git-tag-version`, push, then `gh release create v41.0.0-alpha.0
-  --target <branch> --prerelease`. Consumers install it with
+--no-git-tag-version`, push, then `gh release create v41.0.0-alpha.0
+--target <branch> --prerelease`. Consumers install it with
   `@olivierzal/melcloud-api@next` (GitHub Packages needs `NODE_AUTH_TOKEN`).
 - Downstream `com.melcloud` (sibling repo, uses `/classic` + `/home`)
   upgrades by bumping the dep (`npm i @olivierzal/melcloud-api@<version>
-  --save-exact`) then running its `typecheck`/`lint`/`test`/`build`; open
+--save-exact`) then running its `typecheck`/`lint`/`test`/`build`; open
   the PR from that repo. A major bump's breaking surface is the CHANGELOG
   `[Unreleased]` section.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ is on: no runtime enums, no parameter properties, no runtime namespaces.
   `-alpha` suffix): branch from `main`, bump, push the branch, then cut a
   prerelease release off it — which publishes under `next`:
 
-  ```sh
+  ```sh title="alpha"
   npm version 41.0.0-alpha.0 --no-git-tag-version
   gh release create v41.0.0-alpha.0 --target <branch> --prerelease
   ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,13 +85,20 @@ is on: no runtime enums, no parameter properties, no runtime namespaces.
   **prerelease** publishes under the `next` dist-tag; a normal one under
   `latest`. The version comes from `package.json` at the released commit,
   so bump it before tagging.
-- Prerelease/alpha flow (keeps `main` on the target stable version, no
-  `-alpha` suffix): branch from `main`, `npm version 41.0.0-alpha.0
---no-git-tag-version`, push, then `gh release create v41.0.0-alpha.0
---target <branch> --prerelease`. Consumers install it with
-  `@olivierzal/melcloud-api@next` (GitHub Packages needs `NODE_AUTH_TOKEN`).
+- Prerelease/alpha flow keeps `main` on the target stable version (no
+  `-alpha` suffix): branch from `main`, bump, push the branch, then cut a
+  prerelease release off it — which publishes under `next`:
+
+  ```sh
+  npm version 41.0.0-alpha.0 --no-git-tag-version
+  gh release create v41.0.0-alpha.0 --target <branch> --prerelease
+  ```
+
+  Consumers install it with `@olivierzal/melcloud-api@next` (GitHub
+  Packages needs `NODE_AUTH_TOKEN`).
+
 - Downstream `com.melcloud` (sibling repo, uses `/classic` + `/home`)
-  upgrades by bumping the dep (`npm i @olivierzal/melcloud-api@<version>
---save-exact`) then running its `typecheck`/`lint`/`test`/`build`; open
-  the PR from that repo. A major bump's breaking surface is the CHANGELOG
-  `[Unreleased]` section.
+  upgrades by pinning the dep to the new version (exact for a prerelease)
+  then running its `typecheck`/`lint`/`test`/`build`; open the PR from that
+  repo. A major bump's breaking surface is the CHANGELOG `[Unreleased]`
+  section.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,17 +81,22 @@ is on: no runtime enums, no parameter properties, no runtime namespaces.
 ## Releasing
 
 - Publishing is release-triggered (`publish.yml`): a **published GitHub
-  Release** packs and `npm publish`es to GitHub Packages. A release marked
-  **prerelease** publishes under the `next` dist-tag; a normal one under
-  `latest`. The version comes from `package.json` at the released commit,
-  so bump it before tagging.
+  Release** packs the tarball and publishes it to GitHub Packages. A
+  release marked **prerelease** publishes under the `next` dist-tag; a
+  normal one under `latest`. The version comes from
+  `package.json` at the released commit, so bump it before tagging.
 - Prerelease/alpha flow keeps `main` on the target stable version (no
-  `-alpha` suffix): branch from `main`, bump, push the branch, then cut a
-  prerelease release off it — which publishes under `next`:
+  `-alpha` suffix): branch from `main`, bump, commit, push, then cut a
+  prerelease release off that branch — which publishes under `next`. The
+  release must target the pushed branch tip, so commit the version bump
+  first (otherwise the tag lands on the un-bumped commit):
 
   ```sh title="alpha"
+  git switch -c release/41.0.0-alpha.0
   npm version 41.0.0-alpha.0 --no-git-tag-version
-  gh release create v41.0.0-alpha.0 --target <branch> --prerelease
+  git commit -am 'chore(release): 41.0.0-alpha.0'
+  git push -u origin release/41.0.0-alpha.0
+  gh release create v41.0.0-alpha.0 --target release/41.0.0-alpha.0 --prerelease
   ```
 
   Consumers install it with `@olivierzal/melcloud-api@next` (GitHub

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,3 +77,21 @@ is on: no runtime enums, no parameter properties, no runtime namespaces.
 - The docs site deploys only on release or `gh workflow run docs.yml`.
 - CI: `Test (Node latest)` is `continue-on-error` by design — keep it out
   of required status checks. Sonar coverage runs on the `lts/*` leg only.
+
+## Releasing
+
+- Publishing is release-triggered (`publish.yml`): a **published GitHub
+  Release** packs and `npm publish`es to GitHub Packages. A release marked
+  **prerelease** publishes under the `next` dist-tag; a normal one under
+  `latest`. The version comes from `package.json` at the released commit,
+  so bump it before tagging.
+- Prerelease/alpha flow (keeps `main` on the target stable version, no
+  `-alpha` suffix): branch from `main`, `npm version 41.0.0-alpha.0
+  --no-git-tag-version`, push, then `gh release create v41.0.0-alpha.0
+  --target <branch> --prerelease`. Consumers install it with
+  `@olivierzal/melcloud-api@next` (GitHub Packages needs `NODE_AUTH_TOKEN`).
+- Downstream `com.melcloud` (sibling repo, uses `/classic` + `/home`)
+  upgrades by bumping the dep (`npm i @olivierzal/melcloud-api@<version>
+  --save-exact`) then running its `typecheck`/`lint`/`test`/`build`; open
+  the PR from that repo. A major bump's breaking surface is the CHANGELOG
+  `[Unreleased]` section.


### PR DESCRIPTION
Adds a **Releasing** section to `CLAUDE.md` capturing the process learned while cutting `41.0.0-alpha.0`:

- Publishing is release-triggered (`publish.yml`); a **prerelease** GitHub Release publishes under the `next` dist-tag, a normal one under `latest`. The published version is `package.json`'s at the released commit.
- The alpha/prerelease flow (branch, `npm version …-alpha.0 --no-git-tag-version`, `gh release create … --prerelease`) that keeps `main` on the target stable version.
- How the downstream `com.melcloud` app upgrades (dep bump + typecheck/lint/test/build), and that a major's breaking surface lives in the CHANGELOG `[Unreleased]` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)