### PR TITLE
chore(release): 41.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,7 +194,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
-[Unreleased]: https://github.com/OlivierZal/melcloud-api/compare/39.0.0...HEAD
+[Unreleased]: https://github.com/OlivierZal/melcloud-api/compare/41.0.0...HEAD
+[41.0.0]: https://github.com/OlivierZal/melcloud-api/compare/39.0.0...41.0.0
 [39.0.0]: https://github.com/OlivierZal/melcloud-api/compare/38.0.2...39.0.0
 [38.0.2]: https://github.com/OlivierZal/melcloud-api/compare/38.0.1...38.0.2
 [38.0.1]: https://github.com/OlivierZal/melcloud-api/compare/38.0.0...38.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [41.0.0] - 2026-07-13
+
 ### Breaking
 
 - **`HomeDeviceAtwFacade.operationModeZone1`/`operationModeZone2` return the normalized `HomeAtwZoneMode` union** (`'room' | 'flow' | 'curve' | 'room_cool' | 'flow_cool'`) instead of raw FTC strings, and **`HomeAtwValues.operationModeZone1/2` accept that union** — the wire dialect (PascalCase reads, camelCase writes) is now fully encapsulated. The external `*Thermostat` variants and unknown firmware strings degrade to the room modes so new FTC vocabulary can never break a consumer's sync.


### PR DESCRIPTION
Stamps the Unreleased section as 41.0.0 (2026-07-13) ahead of the stable release; the package.json version on main is already 41.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)