### PR TITLE
Auth resilience: onAuthenticationLost + sync disarm + login backoff + throttle classification (41.2.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "41.1.0",
+  "version": "41.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "41.1.0",
+      "version": "41.2.0",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "41.1.0",
+  "version": "41.2.0",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -3,7 +3,11 @@ import { randomUUID } from 'node:crypto'
 import type { z } from 'zod'
 
 import { setting } from '../decorators/index.ts'
-import { AuthenticationError, RateLimitError } from '../errors/index.ts'
+import {
+  AuthenticationError,
+  AuthenticationThrottledError,
+  RateLimitError,
+} from '../errors/index.ts'
 import {
   type HttpClientConfig,
   type HttpResponse,
@@ -26,6 +30,8 @@ import {
   RetryGuard,
   TransientRetryPolicy,
 } from '../resilience/index.ts'
+import { Temporal } from '../temporal.ts'
+import { MS_PER_MINUTE } from '../time-units.ts'
 import {
   type ApiRequestError,
   type LoginCredentials,
@@ -106,6 +112,16 @@ const DEFAULT_TIMEOUT_MS = 30_000
 // it is more likely to mask bugs than reflect a real product need.
 const DEFAULT_AUTH_RETRY_COOLDOWN_MS = 1000
 
+// Automatic re-login backoff after a REJECTED sign-in: MELCloud
+// throttles logins aggressively (Classic `ErrorId 6`) while staying
+// generous with requests on an existing session, so hammering the login
+// endpoint keeps a lockout alive. Transport failures do not arm it (the
+// normal retry paths handle those); an explicit `authenticate()` — the
+// user re-submitting credentials — bypasses the gate and resets it on
+// success.
+const LOGIN_BACKOFF_FAILURE_MS = 900_000
+const LOGIN_BACKOFF_THROTTLE_MS = 7_200_000
+
 /**
  * Subclass-internal options injected into the {@link BaseAPI}
  * constructor. Distinct from {@link BaseAPIConfig} (the user-facing
@@ -177,6 +193,9 @@ export abstract class BaseAPI implements Disposable {
   // One event per loss episode: rearmed by any cycle observed
   // authenticated again (including the post-auth sync of a re-login).
   #hasEmittedAuthenticationLost = false
+
+  // Epoch-ms deadline before which automatic re-logins are refused.
+  #loginBackoffUntil: number | null = null
 
   readonly #rateLimitPolicy: RateLimitPolicy
 
@@ -316,7 +335,13 @@ export abstract class BaseAPI implements Disposable {
     // Explicit login starts from a clean slate — enforced here so no
     // subclass can forget it (mirrors the post-auth sync below).
     this.clearPersistedSession()
-    await this.doAuthenticate(credentials)
+    try {
+      await this.doAuthenticate(credentials)
+    } catch (error) {
+      this.#armLoginBackoff(error)
+      throw error
+    }
+    this.#loginBackoffUntil = null
     await this.syncRegistry()
   }
 
@@ -382,6 +407,9 @@ export abstract class BaseAPI implements Disposable {
    * if the distinction matters).
    */
   public async resumeSession(): Promise<boolean> {
+    if (this.#isLoginBackedOff()) {
+      return false
+    }
     const credentials = this.resolvePersistedCredentials()
     if (credentials === null) {
       return false
@@ -621,6 +649,23 @@ export abstract class BaseAPI implements Disposable {
     return this.reuseSucceeded()
   }
 
+  #armLoginBackoff(error: unknown): void {
+    if (!(error instanceof AuthenticationError)) {
+      // A transport failure is not a rejected login: the normal retry
+      // paths own those, and pausing sign-ins would mask a mere blip.
+      return
+    }
+    const backoffMs =
+      error instanceof AuthenticationThrottledError ?
+        LOGIN_BACKOFF_THROTTLE_MS
+      : LOGIN_BACKOFF_FAILURE_MS
+    this.#loginBackoffUntil =
+      Temporal.Now.instant().epochMilliseconds + backoffMs
+    this.logger.error(
+      `Automatic sign-ins paused for ${String(Math.round(backoffMs / MS_PER_MINUTE))} minutes after a rejected login`,
+    )
+  }
+
   /**
    * Build the per-request resilience pipeline. Order matters — outer
    * policies see the attempt first: rate-limit guards the entry
@@ -685,6 +730,13 @@ export abstract class BaseAPI implements Disposable {
   #hasRecoverableState(): boolean {
     return (
       this.hasPersistedSession() || this.resolvePersistedCredentials() !== null
+    )
+  }
+
+  #isLoginBackedOff(): boolean {
+    return (
+      this.#loginBackoffUntil !== null &&
+      Temporal.Now.instant().epochMilliseconds < this.#loginBackoffUntil
     )
   }
 

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -174,6 +174,10 @@ export abstract class BaseAPI implements Disposable {
   // injected dependencies, not in the policy itself.
   readonly #authRetryPolicy: AuthRetryPolicy
 
+  // One event per loss episode: rearmed by any cycle observed
+  // authenticated again (including the post-auth sync of a re-login).
+  #hasEmittedAuthenticationLost = false
+
   readonly #rateLimitPolicy: RateLimitPolicy
 
   // Single in-flight refresh handle. Set when the first `ensureSession`
@@ -344,7 +348,9 @@ export abstract class BaseAPI implements Disposable {
     if (await this.tryReuseSession()) {
       return
     }
-    await this.resumeSession()
+    if (!(await this.resumeSession()) && this.#hasRecoverableState()) {
+      this.#emitAuthenticationLostOnce()
+    }
   }
 
   /**
@@ -548,7 +554,19 @@ export abstract class BaseAPI implements Disposable {
       this.logger.error('Failed to fetch devices:', error)
       return []
     } finally {
-      this.syncManager.planNext()
+      if (this.isAuthenticated()) {
+        // A live session marks any earlier loss episode as recovered.
+        this.#hasEmittedAuthenticationLost = false
+        this.syncManager.planNext()
+      } else if (this.#hasRecoverableState()) {
+        // Rescheduling would hammer the account with a doomed sign-in
+        // every cycle: stay disarmed and surface the loss instead — a
+        // successful authenticate() re-arms the sync through its
+        // enforced post-auth registry sync.
+        this.#emitAuthenticationLostOnce()
+      }
+      // Unauthenticated with nothing to recover from (e.g. the settings
+      // page probing a never-configured API) stays silent AND disarmed.
     }
   }
 
@@ -650,6 +668,24 @@ export abstract class BaseAPI implements Disposable {
       )
     }
     return new CompositePolicy(policies)
+  }
+
+  #emitAuthenticationLostOnce(): void {
+    if (this.#hasEmittedAuthenticationLost) {
+      return
+    }
+
+    this.#hasEmittedAuthenticationLost = true
+    this.events.emitAuthenticationLost()
+  }
+
+  // A loss is only a loss when there was something to restore — a
+  // persisted session or persisted credentials. Probing an API that was
+  // never configured must neither notify nor look like an expiry.
+  #hasRecoverableState(): boolean {
+    return (
+      this.hasPersistedSession() || this.resolvePersistedCredentials() !== null
+    )
   }
 
   async #runWithEvents<T>(

--- a/src/api/classic.ts
+++ b/src/api/classic.ts
@@ -3,7 +3,10 @@ import { Agent } from 'undici'
 import { ClassicDeviceType, ClassicLanguage } from '../constants.ts'
 import { setting, syncDevices } from '../decorators/index.ts'
 import { ClassicRegistry } from '../entities/index.ts'
-import { AuthenticationError } from '../errors/index.ts'
+import {
+  AuthenticationError,
+  AuthenticationThrottledError,
+} from '../errors/index.ts'
 import { isSessionExpired, toClassicDeviceId } from '../resilience/index.ts'
 import { Temporal } from '../temporal.ts'
 import { SESSION_REFRESH_AHEAD_MS } from '../time-units.ts'
@@ -71,6 +74,8 @@ const APP_VERSION = '1.38.4.0'
 
 const DEFAULT_RETRY_HOURS = 2
 const DEFAULT_SYNC_INTERVAL_MINUTES = 5
+
+const LOGIN_THROTTLE_ERROR_ID = 6
 
 // MELCloud uses year 1 for uninitialized error dates; filter these out as invalid
 const INVALID_YEAR = 1
@@ -635,7 +640,7 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
     password,
     username,
   }: LoginCredentials): Promise<void> {
-    const { LoginData: loginData } = await this.login({
+    const { ErrorId: errorId, LoginData: loginData } = await this.login({
       postData: {
         AppVersion: APP_VERSION,
         Email: username,
@@ -645,7 +650,14 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
       },
     })
     if (loginData === null) {
-      throw new AuthenticationError('MELCloud Classic rejected the credentials')
+      // ErrorId 6 is MELCloud's login throttle (LoginStatus 6, high
+      // LoginAttempts): the credentials may be perfectly valid — asking
+      // the user to re-log would keep the lockout alive.
+      throw errorId === LOGIN_THROTTLE_ERROR_ID ?
+          new AuthenticationThrottledError(
+            'MELCloud is temporarily blocking sign-ins (too many attempts)',
+          )
+        : new AuthenticationError('MELCloud Classic rejected the credentials')
     }
     this.username = username
     this.password = password

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -18,6 +18,8 @@ import {
   type TypedHomeDeviceData,
   HomeRegistry,
 } from '../entities/home-registry.ts'
+import { AuthenticationThrottledError } from '../errors/index.ts'
+import { isHttpError } from '../http/index.ts'
 import { isSessionExpired } from '../resilience/index.ts'
 import { Temporal } from '../temporal.ts'
 import { SESSION_REFRESH_AHEAD_MS } from '../time-units.ts'
@@ -36,6 +38,7 @@ import { performTokenAuth, refreshAccessToken } from './token-auth.ts'
 
 const API_BASE_URL = 'https://mobile.bff.melcloudhome.com'
 const ATA_UNIT_PATH = '/monitor/ataunit'
+const HTTP_TOO_MANY_REQUESTS = 429
 const ATW_UNIT_PATH = '/monitor/atwunit'
 
 /**
@@ -486,14 +489,23 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
       // of the Classic `LoginData: null → AuthenticationError` path).
       // Non-401 errors (PAR failures, Cognito redirect chain issues,
       // network timeouts) propagate unchanged.
+      if (
+        isHttpError(error) &&
+        error.response.status === HTTP_TOO_MANY_REQUESTS
+      ) {
+        // The BFF/Cognito login throttle — the Home mirror of Classic's
+        // ErrorId 6. Valid credentials, blocked endpoint: back off.
+        throw new AuthenticationThrottledError(
+          'MELCloud Home is temporarily blocking sign-ins (too many attempts)',
+        )
+      }
       const authError = normalizeUnauthorized(error)
       if (authError !== null) {
         throw authError
       }
       throw error
     }
-    this.password = password
-    this.username = username
+    this.applyCredentials(username, password)
   }
 
   protected getAuthHeaders(): Record<string, string> {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -55,6 +55,21 @@ export interface BaseAPIConfig extends UndefinedTolerant<LoginCredentials> {
  * @category Configuration
  */
 export interface LifecycleEvents {
+  /**
+   * Invoked after each sync trigger (auto-timer or
+   * `@syncDevices`-decorated mutation). Receives the device-type
+   * filter and any IDs the cascade was scoped to.
+   */
+  /**
+   * Fires when a previously-available session is definitively lost:
+   * the boot-time restore found persisted state but could not sign
+   * in, or a sync cycle ended unauthenticated after the 401-recovery
+   * chain gave up. The auto-sync disarms at the same moment
+   * (rescheduling would hammer the account with a doomed sign-in
+   * every cycle); a successful `authenticate()` — e.g. the user
+   * logging back in — re-arms it. Fires once per loss episode.
+   */
+  readonly onAuthenticationLost?: (() => void) | undefined
   /** Invoked after a successful HTTP response is received. */
   readonly onRequestComplete?:
     ((event: RequestCompleteEvent) => void) | undefined
@@ -64,11 +79,6 @@ export interface LifecycleEvents {
   readonly onRequestRetry?: ((event: RequestRetryEvent) => void) | undefined
   /** Invoked when a request is dispatched for the first time. */
   readonly onRequestStart?: ((event: RequestStartEvent) => void) | undefined
-  /**
-   * Invoked after each sync trigger (auto-timer or
-   * `@syncDevices`-decorated mutation). Receives the device-type
-   * filter and any IDs the cascade was scoped to.
-   */
   readonly onSyncComplete?: SyncCallback | undefined
 }
 

--- a/src/errors/authentication-throttled.ts
+++ b/src/errors/authentication-throttled.ts
@@ -1,0 +1,13 @@
+import { AuthenticationError } from './authentication.ts'
+
+/**
+ * MELCloud is temporarily refusing sign-ins (login throttle): Classic
+ * reports it as `ErrorId 6` on `ClientLogin3`, Home as HTTP 429 from
+ * the token endpoints. Retrying a login keeps the lockout alive, so the
+ * automatic re-login backoff widens when this error arms it; sessions
+ * established BEFORE the throttle keep working (MELCloud stays generous
+ * with existing keys).
+ */
+export class AuthenticationThrottledError extends AuthenticationError {
+  public override readonly name = 'AuthenticationThrottledError'
+}

--- a/src/errors/authentication.ts
+++ b/src/errors/authentication.ts
@@ -6,5 +6,5 @@ import { APIError } from './base.ts'
  * @category Errors
  */
 export class AuthenticationError extends APIError {
-  public override readonly name = 'AuthenticationError'
+  public override readonly name: string = 'AuthenticationError'
 }

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,3 +1,4 @@
+export { AuthenticationThrottledError } from './authentication-throttled.ts'
 export { AuthenticationError } from './authentication.ts'
 export { APIError, isAPIError } from './base.ts'
 export { EntityNotFoundError } from './entity-not-found.ts'

--- a/src/observability/events-emitter.ts
+++ b/src/observability/events-emitter.ts
@@ -25,6 +25,12 @@ export class LifecycleEmitter {
     this.#logger = logger
   }
 
+  public emitAuthenticationLost(): void {
+    this.#safeInvoke('onAuthenticationLost', () =>
+      this.#events?.onAuthenticationLost?.(),
+    )
+  }
+
   public emitComplete(event: RequestCompleteEvent): void {
     this.#safeInvoke('onRequestComplete', () =>
       this.#events?.onRequestComplete?.(event),

--- a/src/types/classic-generic.ts
+++ b/src/types/classic-generic.ts
@@ -406,6 +406,7 @@ export interface ClassicLoginData {
     readonly ContextKey: string
     readonly Expiry: string
   } | null
+  readonly ErrorId?: number | null | undefined
 }
 
 /**

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -28,6 +28,7 @@ import { ValidationError } from '../errors/index.ts'
 /** Classic /Login/ClientLogin3 response. */
 export const ClassicLoginDataSchema: z.ZodType<ClassicLoginData> =
   z.looseObject({
+    ErrorId: z.number().nullable().optional(),
     LoginData: z
       .looseObject({
         ContextKey: z.string(),

--- a/tests/unit/base-api.test.ts
+++ b/tests/unit/base-api.test.ts
@@ -9,7 +9,11 @@ import type {
   RequestStartEvent,
 } from '../../src/api/types.ts'
 import { BaseAPI, normalizeUnauthorized } from '../../src/api/base.ts'
-import { AuthenticationError, RateLimitError } from '../../src/errors/index.ts'
+import {
+  AuthenticationError,
+  AuthenticationThrottledError,
+  RateLimitError,
+} from '../../src/errors/index.ts'
 import { type HttpResponse, HttpError } from '../../src/http/index.ts'
 import { Temporal } from '../../src/temporal.ts'
 import {
@@ -899,5 +903,105 @@ describe('authentication-lost lifecycle', () => {
     await api.initialize()
 
     expect(onAuthenticationLost).not.toHaveBeenCalled()
+  })
+})
+
+describe('automatic login backoff', () => {
+  it('pauses automatic re-logins after a rejected sign-in and retries past the window', async () => {
+    vi.useFakeTimers()
+    mockTemporalNowInstant()
+    try {
+      const api = new TestAPI({
+        settingManager: createSettingStore({ password: 'p', username: 'u' })
+          .settingManager,
+      })
+      api.doAuthenticateMock.mockRejectedValue(new AuthenticationError('bad'))
+
+      await expect(
+        api.authenticate({ password: 'p', username: 'u' }),
+      ).rejects.toThrow('bad')
+      await expect(api.resumeSession()).resolves.toBe(false)
+      expect(api.doAuthenticateMock).toHaveBeenCalledTimes(1)
+
+      vi.advanceTimersByTime(900_001)
+
+      await expect(api.resumeSession()).resolves.toBe(false)
+      expect(api.doAuthenticateMock).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('widens the pause to two hours on a throttled sign-in', async () => {
+    vi.useFakeTimers()
+    mockTemporalNowInstant()
+    try {
+      const api = new TestAPI({
+        settingManager: createSettingStore({ password: 'p', username: 'u' })
+          .settingManager,
+      })
+      api.doAuthenticateMock.mockRejectedValue(
+        new AuthenticationThrottledError('locked'),
+      )
+
+      await expect(
+        api.authenticate({ password: 'p', username: 'u' }),
+      ).rejects.toThrow('locked')
+
+      vi.advanceTimersByTime(900_001)
+
+      await expect(api.resumeSession()).resolves.toBe(false)
+      expect(api.doAuthenticateMock).toHaveBeenCalledTimes(1)
+
+      vi.advanceTimersByTime(6_300_000)
+
+      await expect(api.resumeSession()).resolves.toBe(false)
+      expect(api.doAuthenticateMock).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not arm on transport failures', async () => {
+    const api = new TestAPI({
+      settingManager: createSettingStore({ password: 'p', username: 'u' })
+        .settingManager,
+    })
+    api.doAuthenticateMock.mockRejectedValue(new Error('socket hang up'))
+
+    await expect(
+      api.authenticate({ password: 'p', username: 'u' }),
+    ).rejects.toThrow('socket hang up')
+    await expect(api.resumeSession()).resolves.toBe(false)
+
+    expect(api.doAuthenticateMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('lets an explicit sign-in through and clears the gate on success', async () => {
+    vi.useFakeTimers()
+    mockTemporalNowInstant()
+    try {
+      const api = new TestAPI({
+        settingManager: createSettingStore({ password: 'p', username: 'u' })
+          .settingManager,
+      })
+      api.doAuthenticateMock.mockRejectedValueOnce(
+        new AuthenticationError('bad'),
+      )
+
+      await expect(
+        api.authenticate({ password: 'p', username: 'u' }),
+      ).rejects.toThrow('bad')
+
+      await api.authenticate({ password: 'right', username: 'u' })
+
+      expect(api.doAuthenticateMock).toHaveBeenCalledTimes(2)
+
+      await api.resumeSession()
+
+      expect(api.doAuthenticateMock).toHaveBeenCalledTimes(3)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/tests/unit/base-api.test.ts
+++ b/tests/unit/base-api.test.ts
@@ -24,6 +24,23 @@ import {
   mockTemporalNowInstant,
 } from '../helpers.ts'
 
+// Observes the auto-sync timer firing (planNext armed) — module-scoped
+// because an arrow referencing `this` inside super() arguments is
+// rejected before super binds it.
+const syncCallbackMock = vi
+  .fn<() => Promise<void>>()
+  .mockResolvedValue(undefined)
+
+// Shared work stubs for the runSyncCycle tests (outer scope per
+// unicorn/consistent-function-scoping).
+const failingWork = vi
+  .fn<() => Promise<never[]>>()
+  .mockRejectedValue(new Error('boom'))
+const successfulWork = vi.fn<() => Promise<never[]>>().mockResolvedValue([])
+const createLostSpy = (): ReturnType<
+  typeof vi.fn<NonNullable<LifecycleEvents['onAuthenticationLost']>>
+> => vi.fn<NonNullable<LifecycleEvents['onAuthenticationLost']>>()
+
 const { client: mockHttpClient, requestSpy: mockRequest } =
   createMockHttpClient('https://test.api')
 
@@ -68,9 +85,7 @@ class TestAPI extends BaseAPI {
         defaultSyncIntervalMinutes: false,
         httpConfig: { baseURL: 'https://test.api' },
         rateLimitHours: 2,
-        syncCallback: async () => {
-          // stub: sync is exercised by tests that drive it explicitly
-        },
+        syncCallback: syncCallbackMock,
       },
     )
     this.getAuthHeadersMock.mockReturnValue({})
@@ -106,6 +121,11 @@ class TestAPI extends BaseAPI {
     config: Record<string, unknown> = {},
   ): Promise<HttpResponse<T>> {
     return this.request<T>(method, url, config)
+  }
+
+  /** Expose the protected runSyncCycle for direct testing. */
+  public async callRunSyncCycle<T>(work: () => Promise<T[]>): Promise<T[]> {
+    return this.runSyncCycle(work)
   }
 
   public override isAuthenticated(): boolean {
@@ -766,5 +786,118 @@ describe(normalizeUnauthorized, () => {
     const native = new Error('network')
 
     expect(normalizeUnauthorized(native)).toBeNull()
+  })
+})
+
+describe('authentication-lost lifecycle', () => {
+  it('disarms the auto-sync and fires once when a cycle ends unauthenticated with recoverable state', async () => {
+    vi.useFakeTimers()
+    try {
+      const onAuthenticationLost = createLostSpy()
+      const api = new TestAPI({
+        events: { onAuthenticationLost },
+        settingManager: createSettingStore({ password: 'p', username: 'u' })
+          .settingManager,
+        syncIntervalMinutes: 1,
+      })
+      api.isAuthenticatedMock.mockReturnValue(false)
+
+      await api.callRunSyncCycle(failingWork)
+      await api.callRunSyncCycle(failingWork)
+      await vi.advanceTimersByTimeAsync(120_000)
+
+      expect(onAuthenticationLost).toHaveBeenCalledTimes(1)
+      expect(syncCallbackMock).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('stays silent and disarmed when nothing was ever persisted (probing an unconfigured API)', async () => {
+    vi.useFakeTimers()
+    try {
+      const onAuthenticationLost = createLostSpy()
+      const api = new TestAPI({
+        events: { onAuthenticationLost },
+        syncIntervalMinutes: 1,
+      })
+      api.isAuthenticatedMock.mockReturnValue(false)
+
+      await api.callRunSyncCycle(failingWork)
+      await vi.advanceTimersByTimeAsync(120_000)
+
+      expect(onAuthenticationLost).not.toHaveBeenCalled()
+      expect(syncCallbackMock).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps rescheduling on a transient failure while still authenticated', async () => {
+    vi.useFakeTimers()
+    try {
+      const onAuthenticationLost = createLostSpy()
+      const api = new TestAPI({
+        events: { onAuthenticationLost },
+        syncIntervalMinutes: 1,
+      })
+
+      await api.callRunSyncCycle(failingWork)
+      await vi.advanceTimersByTimeAsync(60_000)
+
+      expect(onAuthenticationLost).not.toHaveBeenCalled()
+      expect(syncCallbackMock).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('fires again for a new loss episode after a recovery', async () => {
+    vi.useFakeTimers()
+    try {
+      const onAuthenticationLost = createLostSpy()
+      const api = new TestAPI({
+        events: { onAuthenticationLost },
+        settingManager: createSettingStore({ password: 'p', username: 'u' })
+          .settingManager,
+        syncIntervalMinutes: 1,
+      })
+
+      api.isAuthenticatedMock.mockReturnValue(false)
+      await api.callRunSyncCycle(failingWork)
+      api.isAuthenticatedMock.mockReturnValue(true)
+      await api.callRunSyncCycle(successfulWork)
+      api.isAuthenticatedMock.mockReturnValue(false)
+      await api.callRunSyncCycle(failingWork)
+
+      expect(onAuthenticationLost).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('fires at boot when persisted credentials cannot restore the session', async () => {
+    const onAuthenticationLost = createLostSpy()
+    const api = new TestAPI({
+      events: { onAuthenticationLost },
+      settingManager: createSettingStore({ password: 'p', username: 'u' })
+        .settingManager,
+    })
+    api.isAuthenticatedMock.mockReturnValue(false)
+    api.doAuthenticateMock.mockRejectedValue(new Error('nope'))
+
+    await api.initialize()
+
+    expect(onAuthenticationLost).toHaveBeenCalledTimes(1)
+  })
+
+  it('stays silent at boot when nothing was persisted', async () => {
+    const onAuthenticationLost = createLostSpy()
+    const api = new TestAPI({ events: { onAuthenticationLost } })
+    api.isAuthenticatedMock.mockReturnValue(false)
+
+    await api.initialize()
+
+    expect(onAuthenticationLost).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/classic-api.test.ts
+++ b/tests/unit/classic-api.test.ts
@@ -1092,4 +1092,15 @@ describe('mELCloud Classic API', () => {
       )
     })
   })
+
+  it('classifies ErrorId 6 as a login throttle, not bad credentials', async () => {
+    const { AuthenticationThrottledError } =
+      await import('../../src/errors/index.ts')
+    mockRequest.mockResolvedValue(wrap({ ErrorId: 6, LoginData: null }))
+    const api = await createApi()
+
+    await expect(
+      api.authenticate({ password: 'p', username: 'u@test.com' }),
+    ).rejects.toThrow(AuthenticationThrottledError)
+  })
 })

--- a/tests/unit/errors.test.ts
+++ b/tests/unit/errors.test.ts
@@ -92,7 +92,7 @@ describe.concurrent(isAPIError, () => {
       new RateLimitError('x', { retryAfter: null, unblockAt: null }),
     ],
     ['NetworkError', new NetworkError('x')],
-  ])('returns true for %s', (_name, error) => {
+  ])('returns true for %s', (_name, error: unknown) => {
     expect(isAPIError(error)).toBe(true)
   })
 

--- a/tests/unit/events-emitter.test.ts
+++ b/tests/unit/events-emitter.test.ts
@@ -107,4 +107,38 @@ describe(LifecycleEmitter, () => {
       expect.any(Error),
     )
   })
+
+  it('forwards onAuthenticationLost and tolerates its absence', () => {
+    const logger = createLogger()
+    const onAuthenticationLost =
+      vi.fn<NonNullable<LifecycleEvents['onAuthenticationLost']>>()
+
+    const emitter = new LifecycleEmitter({ onAuthenticationLost }, logger)
+    const emptyEmitter = new LifecycleEmitter({}, logger)
+
+    emitter.emitAuthenticationLost()
+
+    expect(onAuthenticationLost).toHaveBeenCalledTimes(1)
+    expect(() => {
+      emptyEmitter.emitAuthenticationLost()
+    }).not.toThrow()
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it('logs and swallows a throwing onAuthenticationLost callback', () => {
+    const logger = createLogger()
+    const emitter = new LifecycleEmitter(
+      {
+        onAuthenticationLost: (): void => {
+          throw new Error('observer boom')
+        },
+      },
+      logger,
+    )
+
+    expect(() => {
+      emitter.emitAuthenticationLost()
+    }).not.toThrow()
+    expect(logger.error).toHaveBeenCalledTimes(1)
+  })
 })

--- a/tests/unit/home-api.test.ts
+++ b/tests/unit/home-api.test.ts
@@ -2492,4 +2492,77 @@ describe('melcloud home API', () => {
       )
     })
   })
+
+  it('classifies HTTP 429 from the token exchange as a login throttle', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        mockFetchResponse(
+          { request_uri: 'urn:ietf:params:oauth:request_uri:test' },
+          {},
+          200,
+        ),
+      )
+      .mockResolvedValueOnce(
+        mockFetchResponse(
+          '',
+          { location: `${AUTH_BASE}/connect/redirect` },
+          302,
+        ),
+      )
+      .mockResolvedValueOnce(
+        mockFetchResponse(
+          '',
+          { location: `${COGNITO}/oauth2/authorize?client_id=test` },
+          302,
+        ),
+      )
+      .mockResolvedValueOnce(
+        mockFetchResponse(
+          '',
+          { location: `${COGNITO}/login?client_id=test` },
+          302,
+        ),
+      )
+      .mockResolvedValueOnce(mockFetchResponse(cognitoLoginPage(), {}, 200))
+      .mockResolvedValueOnce(
+        mockFetchResponse(
+          '',
+          {
+            location:
+              'https://auth.melcloudhome.com/signin-oidc-meu?code=abc&state=xyz',
+          },
+          302,
+        ),
+      )
+      .mockResolvedValueOnce(
+        mockFetchResponse(
+          '',
+          { location: 'https://auth.melcloudhome.com/ExternalLogin/Callback' },
+          302,
+        ),
+      )
+      .mockResolvedValueOnce(
+        mockFetchResponse(
+          "<script>window.location='melcloudhome://?code=auth-code&amp;state=xyz'</script>",
+          {},
+          200,
+        ),
+      )
+      .mockRejectedValueOnce(
+        new HttpError('Too Many Requests', {
+          config: { url: '/connect/token' },
+          response: { data: undefined, headers: {}, status: 429 },
+        }),
+      )
+    const api = await melCloudHomeApi.create({
+      baseURL: BASE_URL,
+      transport: mockHttpClient,
+    })
+    const { AuthenticationThrottledError } =
+      await import('../../src/errors/index.ts')
+
+    await expect(
+      api.authenticate({ password: 'locked', username: 'u@test.com' }),
+    ).rejects.toThrow(AuthenticationThrottledError)
+  })
 })


### PR DESCRIPTION
## The full auth-resilience story (41.2.0) — problème B lib-half + user lockout report

### 1. Auto-sync disarm + `onAuthenticationLost` (first commit)

- `runSyncCycle` only reschedules while authenticated: a session loss no longer drives doomed sign-ins every cycle (Home's 1-min cadence = 1,440/day). A later `authenticate()` re-arms naturally via its enforced post-auth sync.
- `LifecycleEvents.onAuthenticationLost` fires **once per loss episode** (boot restore failed with persisted state, or the 401-recovery chain gave up) — never for a never-configured API (the settings page's lazy probe stays silent AND disarmed, which also stops that probe re-arming the loop).

### 2. Login backoff + throttle classification (second commit — user report: ErrorId 6 lockouts)

Audit findings (both dialects): sessions ARE persisted and reused exemplarily (`@setting` contextKey / access+refresh tokens, probe-not-login at boot, headers reuse) — but the **failure paths** could hammer `ClientLogin`: `ensureSession` retried a login per request on an empty key, nothing backed off after a rejected login (the 1 s RetryGuard only de-bounces the 401 path), and a throttle was indistinguishable from bad credentials.

- **Backoff on the automatic full-login path** (`resumeSession`): 15 min after rejected credentials, **2 h after a throttle**. Transport failures don't arm it; Home's refresh-token exchange is never gated; an explicit `authenticate()` (settings form) bypasses and resets on success.
- **`AuthenticationThrottledError`**: Classic `ErrorId 6` (envelope now parsed) and Home HTTP 429 → consumers can say "MELCloud is temporarily blocking sign-ins, try later" instead of the counter-productive "please re-log".

Coverage 100% (backoff windows exercised via time travel; both dialect classifications). Release **41.2.0**; com.melcloud 45.3.0 follow-up wires the event + error into differentiated Homey notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
