### PR TITLE
Pin classic typescript to the typescript-eslint-supported line

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,14 @@ updates:
         patterns:
           - '@vitest/*'
           - vitest
+    # The classic `typescript` package intentionally trails on the
+    # newest line typescript-eslint supports (its peer range excludes
+    # TS 7); the real compiler is `@typescript/native`. Re-evaluate
+    # when typescript-eslint announces TypeScript 7 support.
+    ignore:
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
     package-ecosystem: npm
     schedule:
       interval: weekly

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,11 @@ is on: no runtime enums, no parameter properties, no runtime namespaces.
 - `npm run lint` / `npm run lint:fix` — ESLint (runs with an 8 GB heap).
 - `npm test` / `npm run test:coverage` — vitest; coverage must stay at 100%.
 - `npm run typecheck` — `tsc` from `@typescript/native` (TypeScript 7);
+  The classic `typescript` devDependency stays pinned to the newest line
+  typescript-eslint supports (`~6.0.x`; its peer range excludes TS 7):
+  it exists only for typescript-eslint's type-aware linting — the real
+  compiler is `@typescript/native`. Dependabot ignores its majors; move
+  the pin when typescript-eslint announces TypeScript 7 support.
   does not cover `*.config.ts` (the lint does). The tooling (typedoc,
   typescript-eslint) still resolves the separate `typescript` 6.x install.
 - `npm run format` / `npm run format:fix` — prettier.


### PR DESCRIPTION
typescript-eslint 8.64 peers `typescript >=4.8.4 <6.1.0` — 7.0.2 is out of range (extension's Dependabot #1194 proposed it; closed). The real compiler is already `@typescript/native` (TS 7). Adds a Dependabot ignore for classic-typescript majors + CLAUDE.md doctrine. Re-evaluate when typescript-eslint announces TypeScript 7 support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)