### PR TITLE
docs: pin the live-probed Home telemetry semantics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,35 @@ is on: no runtime enums, no parameter properties, no runtime namespaces.
   silently ignores unknown fields (a garbage key is accepted). Only a
   `/context` readback showing the change proves a write path exists —
   never add a `HomeAtwValues` field on acceptance alone.
+- Home telemetry, live-probed 2026-07-17 (guest account — guests DO get
+  telemetry): `/telemetry/telemetry/actual/{id}` validates `measure`
+  (unknown → 400, so the vocabulary is enumerable; only `rssi` and
+  `power` — the on/off boolean history — exist), but
+  `/telemetry/telemetry/energy/{id}` does NOT: an unknown measure gets a
+  200 with empty `measureData`, indistinguishable from a real idle
+  window. Never conclude "no data" from an empty payload without
+  re-checking the measure name against a known-good one.
+- Telemetry `interval` grammar is a case-insensitive .NET enum:
+  `Minute`, `Hour`, `Day`, `Week`, `Month`; anything else → 500,
+  missing → 400 (the `PT1H` ISO style never worked). Buckets are sparse
+  (only active periods return points) and near-live at `Minute` grain
+  (~1-2 min lag observed once — reconfirm under sustained activity).
+- Telemetry units differ per measure: ATW
+  `interval_energy_consumed/produced` are kWh per bucket; the ATA
+  `cumulative_energy_consumed_since_last_upload` is Wh, delivered as
+  100 Wh quantum pulses (a `100.0` point, then a `0.0` reset marker the
+  next minute). Hour/Day server aggregation sums those pulses correctly
+  on recent windows.
+- No instantaneous power exists anywhere on the Home API: not in
+  `/context` settings (raw enumeration 2026-07-17: 11 ATA / 15 ATW
+  names, none energy-bearing — no `CurrentEnergyConsumed/Produced`
+  analog to Classic ATW's list fields), not as an `actual` measure.
+  Any Home power figure must be derived from energy buckets ÷ duration.
+- Historical telemetry windows mix semantics: May–June 2026 ATA daily
+  values are counter samples (~10^5 Wh), not consumption — bound any
+  backfill by plausibility or restrict it to recent windows. Observed
+  retention ≥ 75/91 days (ATA/ATW), possibly just device onboarding
+  age.
 
 ## Lint doctrine
 

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -310,11 +310,11 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
    * Fetch interval-energy telemetry for an ATW unit. Unlike ATA's
    * `cumulative_energy_consumed_since_last_upload`, ATW exposes
    * separate `interval_energy_consumed` and `interval_energy_produced`
-   * measures (Wh per interval, not cumulative).
+   * measures (kWh per bucket, not cumulative — live-probed 2026-07-17).
    * @param id - Device id.
    * @param params - Query window.
    * @param params.from - ISO start timestamp (inclusive).
-   * @param params.interval - Aggregation interval (e.g. `Hour`, `Day`).
+   * @param params.interval - Aggregation interval (`Minute`, `Hour`, `Day`, `Week` or `Month`).
    * @param params.measure - Energy direction (`'consumed'` or `'produced'`).
    * @param params.to - ISO end timestamp (exclusive).
    * @returns Success with the telemetry bundle, or a typed failure.

--- a/src/facades/home-device-ata.ts
+++ b/src/facades/home-device-ata.ts
@@ -164,7 +164,7 @@ export class HomeDeviceAtaFacade extends HomeBaseDeviceFacade<HomeAtaDeviceData>
    * Fetches cumulative-energy telemetry for this device over the given time window.
    * @param params - Query window.
    * @param params.from - ISO start timestamp (inclusive).
-   * @param params.interval - Aggregation interval (e.g. `PT1H`).
+   * @param params.interval - Aggregation interval (`Minute`, `Hour`, `Day`, `Week` or `Month`).
    * @param params.to - ISO end timestamp (exclusive).
    * @returns The telemetry bundle, or a typed failure.
    */


### PR DESCRIPTION
## Phase 0 of the Home energy/power work — findings, committed this time

The audit showed the 2026-04 probe knowledge was never committed (`scripts/` is gitignored) and partly wrong in docstrings. This PR pins what a fresh live probe (2026-07-17, read-only GETs, guest account) established:

| Fact | Detail |
|---|---|
| **No live power on Home** | Raw `/context` enumeration (11 ATA / 15 ATW setting names): nothing energy-bearing — no analog to Classic ATW's `CurrentEnergyConsumed/Produced` list fields. `/actual/` serves only `rssi` + `power` (on/off history). |
| **`/actual/` validates measures** | Unknown → **400** ⇒ vocabulary enumerable (17 power-ish candidates all rejected). |
| **`/energy/` does NOT validate** | Unknown measure → **200 + empty `measureData`**, indistinguishable from an idle window — documented trap. |
| **Interval grammar** | Case-insensitive .NET enum `Minute/Hour/Day/Week/Month`; else 500; missing 400. `PT1H` never worked (docstring fixed). |
| **Units** | ATW `interval_energy_*` = **kWh per bucket** (docstring said Wh — fixed); ATA cumulative = **Wh**, delivered as **100 Wh quantum pulses** (`100.0` then `0.0` reset marker next minute). |
| **Bucket behavior** | Sparse (active periods only), near-live at Minute grain (~1-2 min lag, single observation). Hour/Day server aggregation sums pulses correctly on recent windows. |
| **Backfill hazard** | May–June 2026 ATA daily values are counter samples (~10⁵ Wh), not consumption — bound backfill by plausibility. Retention observed ≥ 75/91 days (ATA/ATW). |
| **Guests get telemetry** | All probed units are guest buildings. |

Code changes: two wrong docstrings only (`home.ts` kWh + interval enum, `home-device-ata.ts` PT1H → enum). No behavior change, no release needed.

Open items (phase 0 tail): Minute-lag under sustained activity, owner-account `/actual/` vocabulary, universality of the 100 Wh quantum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)