### PR TITLE
fix: accept null CoP entries in Classic ATW energy payloads (41.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,7 +227,9 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
-[Unreleased]: https://github.com/OlivierZal/melcloud-api/compare/41.1.0...HEAD
+[Unreleased]: https://github.com/OlivierZal/melcloud-api/compare/41.2.1...HEAD
+[41.2.1]: https://github.com/OlivierZal/melcloud-api/compare/41.2.0...41.2.1
+[41.2.0]: https://github.com/OlivierZal/melcloud-api/compare/41.1.0...41.2.0
 [41.1.0]: https://github.com/OlivierZal/melcloud-api/compare/41.0.0...41.1.0
 [41.0.0]: https://github.com/OlivierZal/melcloud-api/compare/39.0.0...41.0.0
 [39.0.0]: https://github.com/OlivierZal/melcloud-api/compare/38.0.2...39.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Claude automation workflows (mirrors [OlivierZal/com.melcloud#1409](https://github.com/OlivierZal/com.melcloud/pull/1409)): every newly opened issue is triaged automatically — existing labels applied, duplicates looked up, one diagnostic comment posted; collaborator issues that @-mention Claude keep their interactive `claude.yml` handling — and a red `CI`/`Zizmor` run on a dependabot branch triggers one auto-fix attempt that diagnoses from the failed logs, fixes on the branch, verifies the full suite, and pushes through the Claude GitHub App token so CI re-runs and the existing auto-merge completes. The `workflow_run` trigger is deliberate (dependabot-triggered runs get a read-only token and cannot reach `CLAUDE_CODE_OAUTH_TOKEN`; the dependabot actor gate doubles as the loop guard) and is ignored for `dangerous-triggers` in the zizmor config.
 
+## [41.2.1] - 2026-07-17
+
+### Fixed
+
+- Classic `/EnergyCost/Report` ATW payloads carry `null` CoP entries for idle periods (live payload, 2026-07-17): the schema now accepts them, so ATW energy reports validate again instead of failing since the 41.2.0 hardening. Consumers already coerce `null` to 0.
+
+## [41.2.0] - 2026-07-16
+
+### Added
+
+- `LifecycleEvents.onAuthenticationLost` — emitted once per authentication-loss episode when a sync cycle ends unauthenticated with recoverable persisted state; any authenticated cycle re-arms it.
+- `AuthenticationThrottledError`: Classic `ClientLogin3` `ErrorId 6` and Home HTTP 429 now classify as MELCloud-side login throttling.
+
+### Changed
+
+- Login backoff: after a failed credential login, `resumeSession` stops re-attempting doomed logins (15 minutes after a failure, 2 hours when throttled); refresh-token exchanges are never gated.
+
 ## [41.1.0] - 2026-07-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "41.2.0",
+  "version": "41.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "41.2.0",
+      "version": "41.2.1",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "41.2.0",
+  "version": "41.2.1",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/types/classic-atw.ts
+++ b/src/types/classic-atw.ts
@@ -18,7 +18,7 @@ import type { ClassicGetDeviceData } from './classic-generic.ts'
  * @category Types
  */
 export interface ClassicEnergyDataAtw {
-  readonly CoP: readonly number[]
+  readonly CoP: readonly (number | null)[]
   readonly TotalCoolingConsumed: number
   readonly TotalCoolingProduced: number
   readonly TotalHeatingConsumed: number

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -418,10 +418,14 @@ export const ClassicEnergyDataAtaSchema: z.ZodType<ClassicEnergyDataAta> =
     UsageDisclaimerPercentages: z.string(),
   })
 
-/** Classic `/EnergyCost/Report` response for an ATW (air-to-water) device. */
+/**
+ * Classic `/EnergyCost/Report` response for an ATW (air-to-water) device.
+ * Idle periods report `null` CoP entries (live payload, 2026-07-17) —
+ * consumers already coerce them to 0 through `Number(...)` tolerance.
+ */
 export const ClassicEnergyDataAtwSchema: z.ZodType<ClassicEnergyDataAtw> =
   z.looseObject({
-    CoP: z.array(z.number()),
+    CoP: z.array(z.number().nullable()),
     TotalCoolingConsumed: z.number(),
     TotalCoolingProduced: z.number(),
     TotalHeatingConsumed: z.number(),

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -409,6 +409,15 @@ describe('validation/schemas', () => {
       ).toThrow(/TotalHotWaterProduced/v)
     })
 
+    it('accepts an ATW payload with null CoP entries (idle periods)', () => {
+      expect(
+        ClassicEnergyDataAtwSchema.parse({
+          ...validClassicEnergyAtw,
+          CoP: [null, 2.5, null],
+        }),
+      ).toStrictEqual({ ...validClassicEnergyAtw, CoP: [null, 2.5, null] })
+    })
+
     it('rejects an ATW payload with a non-finite CoP entry', () => {
       expect(() =>
         ClassicEnergyDataAtwSchema.parse({


### PR DESCRIPTION
## Trouvé en live pendant la phase 3 de com.melcloud

Les logs de boot montraient `Hydrobox - Energy report fetch failed: MELCloud request failed: validation`. Sonde du payload réel (`scripts/probe-atw-energy-validation.ts`, GET read-only) :

```
CoP: [null, …]   →   Invalid input: expected number, received null (path: CoP.0)
```

**Les heures creuses remontent un CoP `null`** — le durcissement zod de 41.2.0 (#1554) rejette alors le rapport entier : les reports énergie Classic ATW échouent depuis, dès qu'une heure creuse est dans la fenêtre (c'est-à-dire presque toujours).

Fix minimal, fondé sur l'évidence : `CoP: z.array(z.number().nullable())` + type `readonly (number | null)[]` + fixture d'acceptation. Les consommateurs tolèrent déjà (`Number(null) === 0` dans les sumTags de com.melcloud). Les totaux restent stricts (numériques dans le payload observé).

Release 41.2.1 ; com.melcloud la récupère par son range `^41.2.0` (refresh du lockfile côté app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)