### PR TITLE
fix: recognize the instant-dialect year-1 sentinel in error logs (41.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Claude automation workflows (mirrors [OlivierZal/com.melcloud#1409](https://github.com/OlivierZal/com.melcloud/pull/1409)): every newly opened issue is triaged automatically — existing labels applied, duplicates looked up, one diagnostic comment posted; collaborator issues that @-mention Claude keep their interactive `claude.yml` handling — and a red `CI`/`Zizmor` run on a dependabot branch triggers one auto-fix attempt that diagnoses from the failed logs, fixes on the branch, verifies the full suite, and pushes through the Claude GitHub App token so CI re-runs and the existing auto-merge completes. The `workflow_run` trigger is deliberate (dependabot-triggered runs get a read-only token and cannot reach `CLAUDE_CODE_OAUTH_TOKEN`; the dependabot actor gate doubles as the loop guard) and is ignored for `dangerous-triggers` in the zizmor config.
 
+## [41.2.2] - 2026-07-18
+
+### Fixed
+
+- The Classic error-log year-1 sentinel filter only recognized the wall-clock dialect: sentinels arriving as instants (`0001-01-01T00:00:00Z`, live payload) slipped through and surfaced as fake year-1 dates. Year extraction now parses both MELCloud date dialects; unparseable inputs still keep their entries (Luxon-mirroring semantics).
+
 ## [41.2.1] - 2026-07-17
 
 ### Fixed
@@ -227,7 +233,8 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
-[Unreleased]: https://github.com/OlivierZal/melcloud-api/compare/41.2.1...HEAD
+[Unreleased]: https://github.com/OlivierZal/melcloud-api/compare/41.2.2...HEAD
+[41.2.2]: https://github.com/OlivierZal/melcloud-api/compare/41.2.1...41.2.2
 [41.2.1]: https://github.com/OlivierZal/melcloud-api/compare/41.2.0...41.2.1
 [41.2.0]: https://github.com/OlivierZal/melcloud-api/compare/41.1.0...41.2.0
 [41.1.0]: https://github.com/OlivierZal/melcloud-api/compare/41.0.0...41.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "41.2.1",
+  "version": "41.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "41.2.1",
+      "version": "41.2.2",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "41.2.1",
+  "version": "41.2.2",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/api/classic.ts
+++ b/src/api/classic.ts
@@ -91,17 +91,30 @@ const parsePlainDate = (iso: string): Temporal.PlainDate => {
   }
 }
 
-// Year extraction that mirrors the original Luxon behavior on parse
-// failure: a bad input does NOT short-circuit as "invalid year 1" — it
-// falls through and the entry is kept. Only the canonical `0001-01-01`
-// sentinel that MELCloud returns gets filtered.
-const safePlainDateYear = (iso: string): number => {
+const instantYear = (iso: string): number | null => {
+  try {
+    return Temporal.Instant.from(iso).toZonedDateTimeISO('UTC').year
+  } catch {
+    return null
+  }
+}
+
+const plainDateYear = (iso: string): number | null => {
   try {
     return Temporal.PlainDate.from(iso).year
   } catch {
-    return 0
+    return null
   }
 }
+
+// Year extraction across both MELCloud date dialects — the sentinel
+// arrives as an instant too (`0001-01-01T00:00:00Z`, live payload
+// 2026-07-18), which `PlainDate.from` rejects. Parse-failure behavior
+// still mirrors the original Luxon semantics: a bad input does NOT
+// short-circuit as "invalid year 1" — it falls through and the entry
+// is kept. Only the year-1 sentinel gets filtered.
+const safePlainDateYear = (iso: string): number =>
+  instantYear(iso) ?? plainDateYear(iso) ?? 0
 
 const isLanguage = isKeyOf(ClassicLanguage)
 

--- a/tests/unit/classic-api.test.ts
+++ b/tests/unit/classic-api.test.ts
@@ -647,6 +647,23 @@ describe('mELCloud Classic API', () => {
       expect(okValue(result).errors).toHaveLength(0)
     })
 
+    it('filters out the instant-dialect sentinel (live payload 2026-07-18)', async () => {
+      mockLoginAndList()
+      const api = await createApi({ password: 'pass', username: 'user' })
+      mockRequest.mockResolvedValue(
+        wrap([
+          errorEntry({
+            EndDate: '2025-09-29T20:56:00+01:00',
+            ErrorMessage: 'Unknown Error',
+            StartDate: '0001-01-01T00:00:00Z',
+          }),
+        ]),
+      )
+      const result = await api.getErrorLog({}, [1])
+
+      expect(okValue(result).errors).toHaveLength(0)
+    })
+
     it('keeps entries with unparseable StartDate (no invalid-year sentinel)', async () => {
       mockLoginAndList()
       const api = await createApi({ password: 'pass', username: 'user' })


### PR DESCRIPTION
## Le garde-fou `INVALID_YEAR = 1` existait — mais ne parlait qu'un dialecte

Olivier a repéré des dates « 1 janv. 1 » dans l'historique d'erreurs de com.melcloud alors que le filtre sentinel existe. Sonde du payload brut (`Report/GetUnitErrorLog2`, Hydrobox) :

```
StartDate: "0001-01-01T00:00:00Z"   ← forme INSTANT (suffixe Z)
```

`safePlainDateYear` utilisait `Temporal.PlainDate.from`, qui **rejette la forme instant** (le split de dialectes MELCloud déjà documenté) → `catch → 0 ≠ 1` → sentinel non filtré → dates fake chez les consommateurs. (Bonus : le « 00:09 » affiché venait de l'offset LMT historique de Paris appliqué par Intl à un instant de l'an 1.)

## Fix

Extraction d'année **bi-dialecte** (`instantYear ?? plainDateYear ?? 0`), sémantique Luxon préservée (input imparsable ⇒ entrée conservée). Test live-payload ajouté (`0001-01-01T00:00:00Z` filtré) à côté des cas existants (sentinel wall-clock filtré, garbage conservé).

Release 41.2.2 ; com.melcloud la récupère par `^41.2.0` (refresh lockfile sur la PR #1432 de l'historique agrégé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)