### PR TITLE
fix: classify Home OIDC refusals so the login backoff engages (41.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Claude automation workflows (mirrors [OlivierZal/com.melcloud#1409](https://github.com/OlivierZal/com.melcloud/pull/1409)): every newly opened issue is triaged automatically — existing labels applied, duplicates looked up, one diagnostic comment posted; collaborator issues that @-mention Claude keep their interactive `claude.yml` handling — and a red `CI`/`Zizmor` run on a dependabot branch triggers one auto-fix attempt that diagnoses from the failed logs, fixes on the branch, verifies the full suite, and pushes through the Claude GitHub App token so CI re-runs and the existing auto-merge completes. The `workflow_run` trigger is deliberate (dependabot-triggered runs get a read-only token and cannot reach `CLAUDE_CODE_OAUTH_TOKEN`; the dependabot actor gate doubles as the loop guard) and is ignored for `dangerous-triggers` in the zizmor config.
 
+## [41.2.3] - 2026-07-18
+
+### Fixed
+
+- Home OIDC refusals (a re-rendered Cognito login page, or a callback ending without an authorization code) threw plain `Error`s, so the login backoff never engaged and doomed sign-ins were retried on every sync. Both paths now throw `AuthenticationError` — engaging the backoff and the session-lost notification — and carry the actual reason: the Cognito error message when the page re-renders, the landing URL plus the OIDC `error`/`error_description` when the callback has no code.
+
 ## [41.2.2] - 2026-07-18
 
 ### Fixed
@@ -233,7 +239,8 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
-[Unreleased]: https://github.com/OlivierZal/melcloud-api/compare/41.2.2...HEAD
+[Unreleased]: https://github.com/OlivierZal/melcloud-api/compare/41.2.3...HEAD
+[41.2.3]: https://github.com/OlivierZal/melcloud-api/compare/41.2.2...41.2.3
 [41.2.2]: https://github.com/OlivierZal/melcloud-api/compare/41.2.1...41.2.2
 [41.2.1]: https://github.com/OlivierZal/melcloud-api/compare/41.2.0...41.2.1
 [41.2.0]: https://github.com/OlivierZal/melcloud-api/compare/41.1.0...41.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "41.2.2",
+  "version": "41.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "41.2.2",
+      "version": "41.2.3",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "41.2.2",
+  "version": "41.2.3",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -487,8 +487,9 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
       // into the shared {@link AuthenticationError} domain type so
       // callers of `authenticate()` get a stable error shape (mirror
       // of the Classic `LoginData: null → AuthenticationError` path).
-      // Non-401 errors (PAR failures, Cognito redirect chain issues,
-      // network timeouts) propagate unchanged.
+      // Cognito refusals arrive already classified from token-auth;
+      // the remaining non-401 errors (PAR failures, network timeouts)
+      // propagate unchanged.
       if (
         isHttpError(error) &&
         error.response.status === HTTP_TOO_MANY_REQUESTS

--- a/src/api/token-auth.ts
+++ b/src/api/token-auth.ts
@@ -3,6 +3,7 @@ import { createHash, randomBytes } from 'node:crypto'
 import { CookieJar } from 'tough-cookie'
 
 import type { HomeTokenResponse } from '../types/index.ts'
+import { AuthenticationError } from '../errors/index.ts'
 import {
   HomeParResponseSchema,
   HomeTokenResponseSchema,
@@ -407,6 +408,17 @@ const par = async ({
     .request_uri
 }
 
+// The Cognito hosted UI re-renders the login page with its reason in an
+// `errorMessage` element when it refuses a submission.
+const refusedSubmissionMessage = (html: string): string => {
+  const match =
+    /(?:id|class)="errorMessage[^"]*"[^>]*>(?<message>[^<]*)</v.exec(html)
+  const reason = match?.groups?.message?.trim() ?? ''
+  return reason === '' ?
+      'Credential submission was not redirected'
+    : `MELCloud Home rejected the sign-in: ${reason}`
+}
+
 /**
  * Navigate to the Cognito login page and submit credentials.
  * @param options - The credential submission options.
@@ -449,7 +461,10 @@ const submitCredentials = async ({
   })
   const callbackLocation = String(submitResponse.headers.location ?? '')
   if (callbackLocation === '') {
-    throw new Error('No redirect after credential submission')
+    // A re-rendered login page instead of a redirect is Cognito refusing
+    // the credentials: classified so the login backoff engages instead of
+    // hammering doomed sign-ins on every sync.
+    throw new AuthenticationError(refusedSubmissionMessage(submitResponse.data))
   }
   return resolveUrl({ base: action, location: callbackLocation })
 }
@@ -471,10 +486,22 @@ const extractAuthorizationCode = async (
     url: callbackUrl,
     ...(abortSignal !== undefined && { abortSignal }),
   })
-  const { searchParams } = new URL(url)
+  const { host, pathname, protocol, searchParams } = new URL(url)
   const code = searchParams.get('code')
   if (code === null) {
-    throw new Error('No authorization code in callback')
+    // The IdP concluded the flow without granting a code — a refusal, not
+    // a transport failure. The landing spot and the OIDC error params
+    // carry the actual reason (query values other than these never leak).
+    const oidcError = searchParams.get('error')
+    const description = searchParams.get('error_description')
+    const details = [
+      `landed on ${protocol}//${host}${pathname}`,
+      ...(oidcError === null ? [] : [`error=${oidcError}`]),
+      ...(description === null ? [] : [description]),
+    ].join('; ')
+    throw new AuthenticationError(
+      `No authorization code in callback (${details})`,
+    )
   }
   return code
 }

--- a/tests/unit/home-api.test.ts
+++ b/tests/unit/home-api.test.ts
@@ -1536,6 +1536,82 @@ describe('melcloud home API', () => {
   })
 
   describe('form parsing', () => {
+    it('should classify a refused submission with the Cognito reason', async () => {
+      // PAR, redirect chain to the login page
+      mockFetch
+        .mockResolvedValueOnce(mockFetchResponse({ request_uri: 'urn:test' }))
+        .mockResolvedValueOnce(mockFetchResponse(cognitoLoginPage(), {}, 200))
+        // Credential POST: re-rendered login page, no redirect
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            '<p id="errorMessage" class="errorMessage">Incorrect username or password.</p>',
+            {},
+            200,
+          ),
+        )
+      const logger = createLogger()
+      const api = await melCloudHomeApi.create({
+        baseURL: BASE_URL,
+        logger,
+        password: 'pass',
+        transport: mockHttpClient,
+        username: 'user@test.com',
+      })
+
+      expect(api.isAuthenticated()).toBe(false)
+      expect(logger.error).toHaveBeenCalledWith(
+        'Session resume failed:',
+        expect.objectContaining({
+          message:
+            'MELCloud Home rejected the sign-in: Incorrect username or password.',
+          name: 'AuthenticationError',
+        }),
+      )
+    })
+
+    it('should classify a code-less callback with its landing details', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockFetchResponse({ request_uri: 'urn:test' }))
+        .mockResolvedValueOnce(mockFetchResponse(cognitoLoginPage(), {}, 200))
+        // Credential POST → redirect to the callback
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            '',
+            {
+              location:
+                'https://auth.melcloudhome.com/signin-oidc-meu?state=xyz',
+            },
+            302,
+          ),
+        )
+        // Callback chain ends without a code but with the OIDC error
+        .mockResolvedValueOnce(
+          mockFetchResponse(
+            "<script>window.location='melcloudhome://?error=access_denied&amp;error_description=Password attempts exceeded'</script>",
+            {},
+            200,
+          ),
+        )
+      const logger = createLogger()
+      const api = await melCloudHomeApi.create({
+        baseURL: BASE_URL,
+        logger,
+        password: 'pass',
+        transport: mockHttpClient,
+        username: 'user@test.com',
+      })
+
+      expect(api.isAuthenticated()).toBe(false)
+      expect(logger.error).toHaveBeenCalledWith(
+        'Session resume failed:',
+        expect.objectContaining({
+          message:
+            'No authorization code in callback (landed on melcloudhome://; error=access_denied; Password attempts exceeded)',
+          name: 'AuthenticationError',
+        }),
+      )
+    })
+
     it('should throw when form action is missing', async () => {
       // PAR succeeds
       mockFetch.mockResolvedValueOnce(


### PR DESCRIPTION
## Deux diagnostics utilisateurs (« authenticatie mislukt », v45.4.0)

```
Session resume failed: Error: No authorization code in callback   ← Error GÉNÉRIQUE
    at extractAuthorizationCode (token-auth.ts:477)
```
…deux tentatives en 6 s : non classée `AuthenticationError`, l'erreur **contourne le backoff de login** (41.2.0) → logins condamnés re-tentés à chaque sync/401 (risque de lockout Cognito), et le message jette l'info utile (où le flux a atterri, pourquoi).

## Fix

Les deux formes de refus OIDC sont classées **`AuthenticationError`** (⇒ backoff 15 min/2 h + notification session-perdue) avec la **vraie raison** embarquée :

- **POST credentials sans redirect** (page de login re-rendue) → texte `errorMessage` de Cognito scrapé : `MELCloud Home rejected the sign-in: Incorrect username or password.`
- **Callback sans `code`** → `No authorization code in callback (landed on <URL sans query>; error=…; <error_description>)` — seuls `error`/`error_description` sont exposés, jamais le reste de la query.

Le commentaire de `doAuthenticate` est aligné (les refus Cognito arrivent désormais classés à la source). Tests : les deux formes, avec assertions sur `name` + message exact.

Pour les 2 utilisateurs : leur prochain diagnostic dira précisément pourquoi Cognito refuse (mauvais mot de passe Home ≠ Classic, compte non migré, throttle…).

Release 41.2.3 ; com.melcloud la récupère par `^41.2.0` (refresh lockfile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)