### PR TITLE
feat: background session resume option for instant create() (41.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - Claude automation workflows (mirrors [OlivierZal/com.melcloud#1409](https://github.com/OlivierZal/com.melcloud/pull/1409)): every newly opened issue is triaged automatically — existing labels applied, duplicates looked up, one diagnostic comment posted; collaborator issues that @-mention Claude keep their interactive `claude.yml` handling — and a red `CI`/`Zizmor` run on a dependabot branch triggers one auto-fix attempt that diagnoses from the failed logs, fixes on the branch, verifies the full suite, and pushes through the Claude GitHub App token so CI re-runs and the existing auto-merge completes. The `workflow_run` trigger is deliberate (dependabot-triggered runs get a read-only token and cannot reach `CLAUDE_CODE_OAUTH_TOKEN`; the dependabot actor gate doubles as the loop guard) and is ignored for `dangerous-triggers` in the zizmor config.
 
+## [41.3.0] - 2026-07-18
+
+### Added
+
+- `shouldResumeSessionInBackground` config option: `create()` resolves immediately and the persisted-session restore (probe or full login — tens of seconds on slow networks) runs off the critical path, with the lifecycle contract unchanged (auto-sync arming, `onAuthenticationLost`, login backoff). Keeps host-app inits within tight budgets such as Homey's 30-second `ready` timeout.
+
 ## [41.2.3] - 2026-07-18
 
 ### Fixed
@@ -239,7 +245,8 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
-[Unreleased]: https://github.com/OlivierZal/melcloud-api/compare/41.2.3...HEAD
+[Unreleased]: https://github.com/OlivierZal/melcloud-api/compare/41.3.0...HEAD
+[41.3.0]: https://github.com/OlivierZal/melcloud-api/compare/41.2.3...41.3.0
 [41.2.3]: https://github.com/OlivierZal/melcloud-api/compare/41.2.2...41.2.3
 [41.2.2]: https://github.com/OlivierZal/melcloud-api/compare/41.2.1...41.2.2
 [41.2.1]: https://github.com/OlivierZal/melcloud-api/compare/41.2.0...41.2.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "41.2.3",
+  "version": "41.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "41.2.3",
+      "version": "41.3.0",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "41.2.3",
+  "version": "41.3.0",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -8,6 +8,7 @@ import {
   AuthenticationThrottledError,
   RateLimitError,
 } from '../errors/index.ts'
+import { fireAndForget } from '../fire-and-forget.ts'
 import {
   type HttpClientConfig,
   type HttpResponse,
@@ -454,10 +455,11 @@ export abstract class BaseAPI implements Disposable {
    */
   public async start(shouldResumeInBackground = false): Promise<void> {
     if (shouldResumeInBackground) {
-      // eslint-disable-next-line unicorn/prefer-await -- fire-and-forget off the caller's critical path; rejections are logged, never propagated
-      this.initialize().catch((error: unknown) => {
-        this.logger.error('Background session resume failed:', error)
-      })
+      fireAndForget(
+        this.initialize(),
+        this.logger,
+        'Background session resume failed:',
+      )
       return
     }
     await this.initialize()

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -444,6 +444,25 @@ export abstract class BaseAPI implements Disposable {
     this.#syncManager.setInterval(minutes)
   }
 
+  /**
+   * Run the initial session restore, honoring the configured mode.
+   * `initialize()` never rejects by design (probe and resume failures
+   * are swallowed and surfaced through the lifecycle events), so the
+   * background variant only needs the fire-and-forget form.
+   * @param shouldResumeInBackground - When `true`, the restore runs off
+   * the caller's critical path and `create()` resolves immediately.
+   */
+  public async start(shouldResumeInBackground = false): Promise<void> {
+    if (shouldResumeInBackground) {
+      // eslint-disable-next-line unicorn/prefer-await -- fire-and-forget off the caller's critical path; rejections are logged, never propagated
+      this.initialize().catch((error: unknown) => {
+        this.logger.error('Background session resume failed:', error)
+      })
+      return
+    }
+    await this.initialize()
+  }
+
   protected applyCredentials(username?: string, password?: string): void {
     if (username !== undefined) {
       this.username = username

--- a/src/api/classic.ts
+++ b/src/api/classic.ts
@@ -276,7 +276,7 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
    */
   public static async create(config?: ClassicAPIConfig): Promise<ClassicAPI> {
     const api = new ClassicAPI(config)
-    await api.initialize()
+    await api.start(config?.shouldResumeSessionInBackground === true)
     return api
   }
 

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -229,7 +229,7 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
    */
   public static async create(config?: HomeAPIConfig): Promise<HomeAPI> {
     const api = new HomeAPI(config)
-    await api.initialize()
+    await api.start(config?.shouldResumeSessionInBackground === true)
     return api
   }
 

--- a/src/api/sync-manager.ts
+++ b/src/api/sync-manager.ts
@@ -1,3 +1,4 @@
+import { fireAndForget } from '../fire-and-forget.ts'
 import { DisposableTimeout } from '../resilience/index.ts'
 import { MS_PER_MINUTE } from '../time-units.ts'
 import type { Logger } from './types.ts'
@@ -35,10 +36,7 @@ export class SyncManager implements Disposable {
   public planNext(): void {
     if (this.#interval > 0) {
       this.#timeout.schedule(() => {
-        // eslint-disable-next-line unicorn/prefer-await -- fire-and-forget inside a synchronous timer callback; rejections are logged, never propagated
-        this.#syncFunction().catch((error: unknown) => {
-          this.#logger.error('Auto-sync failed:', error)
-        })
+        fireAndForget(this.#syncFunction(), this.#logger, 'Auto-sync failed:')
       }, this.#interval)
     }
   }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -33,6 +33,16 @@ export interface BaseAPIConfig extends UndefinedTolerant<LoginCredentials> {
   /** External setting manager for persisting credentials and session data. */
   readonly settingManager?: SettingManager | undefined
   /**
+   * Restore the persisted session in the background instead of awaiting
+   * it inside `create()`. Session probing and full logins can take tens
+   * of seconds on slow networks, which blows a host app's init budget
+   * (e.g. Homey's 30 s `ready` timeout). The lifecycle contract is
+   * unchanged — auto-sync arming, `onAuthenticationLost`, login
+   * backoff — it just runs off the critical path; `isAuthenticated()`
+   * may report `false` until the background restore lands.
+   */
+  readonly shouldResumeSessionInBackground?: boolean | undefined
+  /**
    * Auto-sync timer in minutes. `false` disables the timer entirely
    * (manual `list()` / `fetch()` only). Omit to use the subclass
    * default (1 for Home, 5 for Classic).

--- a/src/fire-and-forget.ts
+++ b/src/fire-and-forget.ts
@@ -1,0 +1,20 @@
+import type { Logger } from './api/types.ts'
+
+/**
+ * The one sanctioned fire-and-forget seam: detach already-started work
+ * from the caller's critical path, logging a rejection instead of
+ * propagating it.
+ * @param promise - The already-started work to detach.
+ * @param logger - Sink for a rejection.
+ * @param message - Context line prefixed to the logged rejection.
+ */
+export const fireAndForget = (
+  promise: Promise<unknown>,
+  logger: Logger,
+  message: string,
+): void => {
+  // eslint-disable-next-line unicorn/prefer-await -- the single fire-and-forget seam: rejections are logged, never propagated
+  promise.catch((error: unknown) => {
+    logger.error(message, error)
+  })
+}

--- a/src/observability/events-emitter.ts
+++ b/src/observability/events-emitter.ts
@@ -7,6 +7,7 @@ import type {
   RequestStartEvent,
   SyncCallback,
 } from '../api/types.ts'
+import { fireAndForget } from '../fire-and-forget.ts'
 
 /**
  * Thin wrapper around a {@link LifecycleEvents} bundle that swallows
@@ -94,13 +95,11 @@ export class LifecycleEmitter {
 
   #watchRejection(callback: string, result: unknown): void {
     if (result instanceof Promise) {
-      // eslint-disable-next-line unicorn/prefer-await -- the observer contract is fire-and-forget: rejections are logged, never propagated
-      result.catch((error: unknown) => {
-        this.#logger.error(
-          `LifecycleEvents.${callback} callback rejected — ignoring`,
-          error,
-        )
-      })
+      fireAndForget(
+        result,
+        this.#logger,
+        `LifecycleEvents.${callback} callback rejected — ignoring`,
+      )
     }
   }
 }

--- a/tests/unit/home-api.test.ts
+++ b/tests/unit/home-api.test.ts
@@ -1535,6 +1535,79 @@ describe('melcloud home API', () => {
     })
   })
 
+  describe('background session resume', () => {
+    it('should resolve create() without awaiting the session restore', async () => {
+      expect.assertions(1)
+
+      // A login chain that never resolves: create() must not depend on it.
+      mockFetch.mockReturnValue(
+        new Promise<never>(() => {
+          // pending forever
+        }),
+      )
+      const api = await melCloudHomeApi.create({
+        baseURL: BASE_URL,
+        logger: createLogger(),
+        password: 'pass',
+        shouldResumeSessionInBackground: true,
+        transport: mockHttpClient,
+        username: 'user@test.com',
+      })
+
+      expect(api.isAuthenticated()).toBe(false)
+    })
+
+    it('should complete the restore in the background', async () => {
+      expect.assertions(1)
+
+      setupSuccessfulLogin()
+      const api = await melCloudHomeApi.create({
+        baseURL: BASE_URL,
+        logger: createLogger(),
+        password: 'pass',
+        shouldResumeSessionInBackground: true,
+        transport: mockHttpClient,
+        username: 'user@test.com',
+      })
+
+      await vi.waitFor(() => {
+        if (!api.isAuthenticated()) {
+          throw new Error('session restore still pending')
+        }
+      })
+
+      expect(api.isAuthenticated()).toBe(true)
+    })
+
+    it('should log a background restore rejection without propagating', async () => {
+      expect.assertions(1)
+
+      setupSuccessfulLogin()
+      const logger = createLogger()
+      const api = await melCloudHomeApi.create({
+        baseURL: BASE_URL,
+        logger,
+        password: 'pass',
+        transport: mockHttpClient,
+        username: 'user@test.com',
+      })
+      vi.spyOn(api, 'initialize').mockRejectedValue(new Error('boom'))
+
+      await api.start(true)
+
+      await vi.waitFor(() => {
+        if (vi.mocked(logger.error).mock.calls.length === 0) {
+          throw new Error('not logged yet')
+        }
+      })
+
+      expect(logger.error).toHaveBeenCalledWith(
+        'Background session resume failed:',
+        expect.objectContaining({ message: 'boom' }),
+      )
+    })
+  })
+
   describe('form parsing', () => {
     it('should classify a refused submission with the Cognito reason', async () => {
       // PAR, redirect chain to the login page


### PR DESCRIPTION
## Diagnostic utilisateur : `ready_timeout` au boot (Homey Early 2018, v45.4.0)

```
Unable to initialize app Error: ready_timeout
…puis : Cannot access this.homey.app because the app instance has been destroyed
```

`create()` **attend le réseau** : `initialize()` = probe de session puis login complet (chaîne OIDC Cognito côté Home) + fetch initial, sous les policies de retry. Sur un Homey 2018 lent + réseau lent, les deux `create()` séquentiels de com.melcloud dépassent le budget de 30 s du SDK → `ready_timeout` → app détruite, et les promesses en vol produisent l'erreur « destroyed » collatérale (**les hooks `onUninit` de l'app ne sont pas en cause**).

## Fix

Option `shouldResumeSessionInBackground` : `create()` rend la main immédiatement, `initialize()` part en fire-and-forget — il ne rejette jamais par construction (échecs avalés + événements), et le contrat lifecycle est inchangé (armement de l'auto-sync, `onAuthenticationLost`, backoff de login) — simplement hors du chemin critique. `isAuthenticated()` peut rendre `false` le temps que la restauration aboutisse (documenté).

Tests : `create()` résout avec un login jamais-résolu ; restauration aboutie en arrière-plan (waitFor) ; rejet de fond loggé sans propagation (couvre le handler). com.melcloud consommera l'option dans ses deux `create()` (45.6.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)