### PR TITLE
fix: chunk wide Home report windows to keep annotations faithful (42.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [42.0.1] - 2026-07-19
+
+### Fixed
+
+- Home report charts failed beyond ~7 days (the widget's "loading problem" on wide ranges): a single wide request either hit the 10-second client timeout (minute-grained payloads) or came back with silently summarized annotations — live-probed: a 90-day query reported _less_ hot-water time than its own 30-day subwindow. The facades now split report windows into chunks of at most 30 days, fetched in parallel with a window-fitted period (`Hourly` within seven days, `Weekly` beyond — `Daily` collapses the mode annotations), and merge the responses: samples concatenated per series, boundary-crossing mode spans deduplicated (the BFF returns them in both adjacent chunks), LOCF seeds from the oldest chunk. A 90-day operation-modes pie now resolves in a few seconds with faithful durations.
+
 ## [42.0.0] - 2026-07-18
 
 ### Changed
@@ -260,6 +266,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[42.0.1]: https://github.com/OlivierZal/melcloud-api/compare/42.0.0...42.0.1
 [42.0.0]: https://github.com/OlivierZal/melcloud-api/compare/41.3.0...42.0.0
 [41.3.0]: https://github.com/OlivierZal/melcloud-api/compare/41.2.3...41.3.0
 [41.2.3]: https://github.com/OlivierZal/melcloud-api/compare/41.2.2...41.2.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.0.0",
+  "version": "42.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "42.0.0",
+      "version": "42.0.1",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.0.0",
+  "version": "42.0.1",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/facades/classic-base-device.ts
+++ b/src/facades/classic-base-device.ts
@@ -35,8 +35,10 @@ import {
   fromListToSetAta,
   getChartLineOptions,
   getChartPieOptions,
+  hoursUpTo,
   isSetDeviceDataAtaInList,
   isUpdateDeviceData,
+  mergeHourlyChartResults,
   now,
   typedFromEntries,
   typedKeys,
@@ -266,22 +268,19 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
   }
 
   public async getHourlyTemperatures(
-    hour: Hour = this.currentHour(),
+    hour?: Hour,
   ): Promise<Result<ReportChartLineOptions>> {
-    return mapResult(
-      await this.api.getHourlyTemperatures({
-        postData: { device: this.id, hour },
-      }),
-      (data) =>
-        withMinuteClockLabels(
-          getChartLineOptions(data, {
-            legend: this.internalTemperaturesLegend,
-            locale: this.api.locale,
-            unit: '°C',
-          }),
-          { hour, locale: this.api.locale },
-        ),
+    if (hour !== undefined) {
+      return this.#fetchTemperaturesHour(hour)
+    }
+    // No hour: the whole of today, hour by hour — the wire only speaks
+    // one-hour windows.
+    const hourly = await Promise.all(
+      hoursUpTo(this.currentHour()).map(async (hourOfDay) =>
+        this.#fetchTemperaturesHour(hourOfDay),
+      ),
     )
+    return mergeHourlyChartResults(hourly)
   }
 
   public async getInternalTemperatures(
@@ -385,6 +384,25 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
         (flag, key) => flag | BigInt(this.flags[key]),
         BigInt(CLASSIC_FLAG_UNCHANGED),
       ),
+    )
+  }
+
+  async #fetchTemperaturesHour(
+    hour: Hour,
+  ): Promise<Result<ReportChartLineOptions>> {
+    return mapResult(
+      await this.api.getHourlyTemperatures({
+        postData: { device: this.id, hour },
+      }),
+      (data) =>
+        withMinuteClockLabels(
+          getChartLineOptions(data, {
+            legend: this.internalTemperaturesLegend,
+            locale: this.api.locale,
+            unit: '°C',
+          }),
+          { hour, locale: this.api.locale },
+        ),
     )
   }
 }

--- a/src/facades/classic-base-device.ts
+++ b/src/facades/classic-base-device.ts
@@ -40,6 +40,7 @@ import {
   now,
   typedFromEntries,
   typedKeys,
+  withMinuteClockLabels,
 } from '../utils.ts'
 import type {
   ClassicDeviceFacade,
@@ -272,11 +273,14 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
         postData: { device: this.id, hour },
       }),
       (data) =>
-        getChartLineOptions(data, {
-          legend: this.internalTemperaturesLegend,
-          locale: this.api.locale,
-          unit: '°C',
-        }),
+        withMinuteClockLabels(
+          getChartLineOptions(data, {
+            legend: this.internalTemperaturesLegend,
+            locale: this.api.locale,
+            unit: '°C',
+          }),
+          { hour, locale: this.api.locale },
+        ),
     )
   }
 

--- a/src/facades/classic-base-device.ts
+++ b/src/facades/classic-base-device.ts
@@ -15,7 +15,7 @@ import {
   isClassicDeviceOfType,
 } from '../entities/index.ts'
 import { NoChangesError } from '../errors/index.ts'
-import { Temporal } from '../temporal.ts'
+import { Intl, Temporal } from '../temporal.ts'
 import {
   type ClassicDeviceID,
   type ClassicEnergyData,
@@ -63,21 +63,33 @@ const ENERGY_REPORT_UNIT = 'kWh'
 // ISO 8601 weekday number for Sunday.
 const ISO_SUNDAY = 7
 
-// `EnergyCost/Report` day-of-week labels are .NET 0-based (Sunday = 0)
-// while the shared formatter expects the 1-based ISO labels of the
-// `Report/*` endpoints (Monday = 1): remap Sunday and keep Monday to
-// Saturday, on which the two conventions already agree.
+// `EnergyCost/Report` labels need two repairs before the shared
+// formatter: day-of-week entries are .NET 0-based (Sunday = 0) while
+// `Report/*` speaks 1-based ISO (Monday = 1), and one-day reports
+// arrive as bare hour numbers (`LabelType.time`) that would render as
+// a naked `0..23` axis — format those as clock labels.
 const toEnergyReportLabels = (
   labels: readonly number[],
   labelType: ClassicLabelType,
-): string[] =>
-  labels.map((label) =>
+  locale: string | undefined,
+): string[] => {
+  if (labelType === ClassicLabelType.time) {
+    const formatter = new Intl.DateTimeFormat(locale, {
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+    return labels.map((label) =>
+      formatter.format(new Temporal.PlainTime(label)),
+    )
+  }
+  return labels.map((label) =>
     String(
       label === 0 && labelType === ClassicLabelType.day_of_week ?
         ISO_SUNDAY
       : label,
     ),
   )
+}
 
 // Calendar-day delta between two ISO wall-clock strings. Computed on
 // `PlainDateTime` so the result reflects the literal Y-M-D-h-m-s span
@@ -252,7 +264,7 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
         {
           Data: series.map(({ data: values }) => [...values]),
           FromDate: from,
-          Labels: toEnergyReportLabels(labels, labelType),
+          Labels: toEnergyReportLabels(labels, labelType, this.api.locale),
           LabelType: labelType,
           Points: labels.length,
           Series: series.length,

--- a/src/facades/classic-base.ts
+++ b/src/facades/classic-base.ts
@@ -34,7 +34,12 @@ import {
   mapResult,
   toClassicDeviceId,
 } from '../types/index.ts'
-import { getChartLineOptions, withMinuteClockLabels } from '../utils.ts'
+import {
+  getChartLineOptions,
+  hoursUpTo,
+  mergeHourlyChartResults,
+  withMinuteClockLabels,
+} from '../utils.ts'
 import { HourSchema, parseOrThrow } from '../validation/index.ts'
 import type {
   ClassicFacade,
@@ -281,22 +286,19 @@ export abstract class ClassicBaseFacade<
   }
 
   public async getSignalStrength(
-    hour: Hour = this.currentHour(),
+    hour?: Hour,
   ): Promise<Result<ReportChartLineOptions>> {
-    return mapResult(
-      await this.api.getSignal({
-        postData: { devices: this.#deviceIds, hour },
-      }),
-      (data) =>
-        withMinuteClockLabels(
-          getChartLineOptions(data, {
-            legend: this.#deviceNames,
-            locale: this.api.locale,
-            unit: 'dBm',
-          }),
-          { hour, locale: this.api.locale },
-        ),
+    if (hour !== undefined) {
+      return this.#fetchSignalHour(hour)
+    }
+    // No hour: the whole of today, hour by hour — the wire only speaks
+    // one-hour windows.
+    const hourly = await Promise.all(
+      hoursUpTo(this.currentHour()).map(async (hourOfDay) =>
+        this.#fetchSignalHour(hourOfDay),
+      ),
     )
+    return mergeHourlyChartResults(hourly)
   }
 
   /**
@@ -349,6 +351,23 @@ export abstract class ClassicBaseFacade<
       HourSchema,
       Temporal.Now.plainTimeISO(this.api.timezone).hour,
       'currentHour',
+    )
+  }
+
+  async #fetchSignalHour(hour: Hour): Promise<Result<ReportChartLineOptions>> {
+    return mapResult(
+      await this.api.getSignal({
+        postData: { devices: this.#deviceIds, hour },
+      }),
+      (data) =>
+        withMinuteClockLabels(
+          getChartLineOptions(data, {
+            legend: this.#deviceNames,
+            locale: this.api.locale,
+            unit: 'dBm',
+          }),
+          { hour, locale: this.api.locale },
+        ),
     )
   }
 

--- a/src/facades/classic-base.ts
+++ b/src/facades/classic-base.ts
@@ -34,7 +34,7 @@ import {
   mapResult,
   toClassicDeviceId,
 } from '../types/index.ts'
-import { getChartLineOptions } from '../utils.ts'
+import { getChartLineOptions, withMinuteClockLabels } from '../utils.ts'
 import { HourSchema, parseOrThrow } from '../validation/index.ts'
 import type {
   ClassicFacade,
@@ -288,11 +288,14 @@ export abstract class ClassicBaseFacade<
         postData: { devices: this.#deviceIds, hour },
       }),
       (data) =>
-        getChartLineOptions(data, {
-          legend: this.#deviceNames,
-          locale: this.api.locale,
-          unit: 'dBm',
-        }),
+        withMinuteClockLabels(
+          getChartLineOptions(data, {
+            legend: this.#deviceNames,
+            locale: this.api.locale,
+            unit: 'dBm',
+          }),
+          { hour, locale: this.api.locale },
+        ),
     )
   }
 

--- a/src/facades/home-base-device.ts
+++ b/src/facades/home-base-device.ts
@@ -9,6 +9,7 @@ import {
 } from '../types/index.ts'
 import type { ReportChartLineOptions } from './report-types.ts'
 import {
+  resolveHomeDayWindow,
   resolveHomeHourWindow,
   toHomeSignalOptions,
   toHomeWireWindow,
@@ -117,21 +118,25 @@ export abstract class HomeBaseDeviceFacade<TData extends HomeDeviceData> {
   }
 
   /**
-   * Fetches the Wi-Fi signal chart for one hour of today, resampled on
-   * a minute grid — the Home counterpart of the Classic
-   * `getSignalStrength` contract.
-   * @param hour - Hour of today (0-23); defaults to the current hour.
+   * Fetches the Wi-Fi signal chart — the whole of today on a
+   * five-minute grid, or one specific hour on a minute grid. The Home
+   * counterpart of the Classic `getSignalStrength` contract.
+   * @param hour - Optional hour of today (0-23); omitted covers today.
    * @returns Structured line chart options (`dBm`), or a typed failure.
    */
   public async getSignalStrength(
     hour?: Hour,
   ): Promise<Result<ReportChartLineOptions>> {
-    const window = resolveHomeHourWindow(hour, this.chartTimezone)
+    const window =
+      hour === undefined ?
+        resolveHomeDayWindow(this.chartTimezone)
+      : resolveHomeHourWindow(hour, this.chartTimezone)
     return mapResult(
       await this.api.getSignal(this.id, toHomeWireWindow(window)),
       (data) =>
         toHomeSignalOptions({
           data,
+          gridUnit: hour === undefined ? 'fiveMinutes' : 'minute',
           locale: this.api.locale,
           name: this.name,
           window,

--- a/src/facades/home-device-ata.ts
+++ b/src/facades/home-device-ata.ts
@@ -29,7 +29,7 @@ import type { ReportChartLineOptions, ReportQuery } from './report-types.ts'
 import { toClassicAtaGroupState, toHomeAtaValues } from './home-ata-group.ts'
 import { HomeBaseDeviceFacade } from './home-base-device.ts'
 import {
-  HOME_REPORT_PERIOD,
+  fetchHomeReportChunks,
   resolveHomeReportWindow,
   toHomeEnergyOptions,
   toHomeLineOptions,
@@ -255,10 +255,10 @@ export class HomeDeviceAtaFacade extends HomeBaseDeviceFacade<HomeAtaDeviceData>
   ): Promise<Result<ReportChartLineOptions>> {
     const window = resolveHomeReportWindow(query, this.chartTimezone)
     return mapResult(
-      await this.api.getAtaTemperatures(this.id, {
-        ...toHomeWireWindow(window),
-        period: HOME_REPORT_PERIOD,
-      }),
+      await fetchHomeReportChunks(
+        async (params) => this.api.getAtaTemperatures(this.id, params),
+        window,
+      ),
       (reports) =>
         toHomeLineOptions({
           locale: this.api.locale,

--- a/src/facades/home-device-ata.ts
+++ b/src/facades/home-device-ata.ts
@@ -31,13 +31,14 @@ import { HomeBaseDeviceFacade } from './home-base-device.ts'
 import {
   fetchHomeReportChunks,
   resolveHomeReportWindow,
+  toHomeEnergyBucketUnit,
   toHomeEnergyOptions,
   toHomeLineOptions,
   toHomeWireWindow,
 } from './home-report.ts'
 
-// Telemetry interval producing one energy bucket per UTC day.
-const DAILY_ENERGY_INTERVAL = 'Day'
+// Telemetry intervals per bucket granularity (UTC-aligned wire buckets).
+const ENERGY_INTERVALS = { day: 'Day', hour: 'Hour' } as const
 
 // The ATA cumulative energy measure reports watt-hours (100 Wh pulses,
 // live-probed 2026-07-18: a daily bucket of `571.0` for ~0.57 kWh).
@@ -205,13 +206,15 @@ export class HomeDeviceAtaFacade extends HomeBaseDeviceFacade<HomeAtaDeviceData>
     query?: ReportQuery,
   ): Promise<Result<ReportChartLineOptions>> {
     const window = resolveHomeReportWindow(query, this.chartTimezone)
+    const bucketUnit = toHomeEnergyBucketUnit(window)
     return mapResult(
       await this.api.getAtaEnergy(this.id, {
         ...toHomeWireWindow(window),
-        interval: DAILY_ENERGY_INTERVAL,
+        interval: ENERGY_INTERVALS[bucketUnit],
       }),
       (data) =>
         toHomeEnergyOptions({
+          bucketUnit,
           locale: this.api.locale,
           sources: [
             { data, name: 'Consumed', scale: KILOWATT_HOURS_PER_WATT_HOUR },

--- a/src/facades/home-device-atw.ts
+++ b/src/facades/home-device-atw.ts
@@ -32,15 +32,16 @@ import {
   resolveHomeDayWindow,
   resolveHomeHourWindow,
   resolveHomeReportWindow,
+  toHomeEnergyBucketUnit,
   toHomeEnergyOptions,
   toHomeLineOptions,
   toHomeOperationModeOptions,
   toHomeWireWindow,
 } from './home-report.ts'
 
-// Telemetry interval producing one energy bucket per UTC day; the ATW
-// interval measures already report kWh per bucket.
-const DAILY_ENERGY_INTERVAL = 'Day'
+// Telemetry intervals per bucket granularity (UTC-aligned wire
+// buckets); the ATW interval measures already report kWh per bucket.
+const ENERGY_INTERVALS = { day: 'Day', hour: 'Hour' } as const
 
 const IDENTITY_SCALE = 1
 
@@ -356,9 +357,10 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
     query?: ReportQuery,
   ): Promise<Result<ReportChartLineOptions>> {
     const window = resolveHomeReportWindow(query, this.chartTimezone)
+    const bucketUnit = toHomeEnergyBucketUnit(window)
     const params = {
       ...toHomeWireWindow(window),
-      interval: DAILY_ENERGY_INTERVAL,
+      interval: ENERGY_INTERVALS[bucketUnit],
     }
     const [consumed, produced] = await Promise.all([
       this.api.getAtwEnergy(this.id, { ...params, measure: 'consumed' }),
@@ -372,6 +374,7 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
     }
     return ok(
       toHomeEnergyOptions({
+        bucketUnit,
         locale: this.api.locale,
         sources: [
           { data: consumed.value, name: 'Consumed', scale: IDENTITY_SCALE },

--- a/src/facades/home-device-atw.ts
+++ b/src/facades/home-device-atw.ts
@@ -26,8 +26,10 @@ import type {
 } from './report-types.ts'
 import { HomeBaseDeviceFacade } from './home-base-device.ts'
 import {
+  type HomeChartGridUnit,
   type HomeChartWindow,
   fetchHomeReportChunks,
+  resolveHomeDayWindow,
   resolveHomeHourWindow,
   resolveHomeReportWindow,
   toHomeEnergyOptions,
@@ -389,21 +391,27 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
   }
 
   /**
-   * Fetches the hourly temperature chart — the merged comfort-graph and
-   * internal-temperatures series over one hour of today on a minute
-   * grid, with operation-mode background bands. The Home counterpart of
-   * the Classic `getHourlyTemperatures` contract (a superset: the
-   * Classic hourly wire only carries the internal series).
-   * @param hour - Hour of today (0-23); defaults to the current hour.
+   * Fetches the fine temperature chart — the merged comfort-graph and
+   * internal-temperatures series with operation-mode background bands,
+   * over the whole of today on a five-minute grid, or over one specific
+   * hour on a minute grid. The Home counterpart of the Classic
+   * `getHourlyTemperatures` contract (a superset: the Classic hourly
+   * wire only carries the internal series).
+   * @param hour - Optional hour of today (0-23); omitted covers today.
    * @returns Structured line chart options (`°C`), or a typed failure.
    */
   public async getHourlyTemperatures(
     hour?: Hour,
   ): Promise<Result<ReportChartLineOptions>> {
-    return this.#fetchTemperatureChart(
-      resolveHomeHourWindow(hour, this.chartTimezone),
-      'minute',
-    )
+    return hour === undefined ?
+        this.#fetchTemperatureChart(
+          resolveHomeDayWindow(this.chartTimezone),
+          'fiveMinutes',
+        )
+      : this.#fetchTemperatureChart(
+          resolveHomeHourWindow(hour, this.chartTimezone),
+          'minute',
+        )
   }
 
   /**
@@ -527,7 +535,7 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
   // series wins the dedup and the band annotations are present.
   async #fetchTemperatureChart(
     window: HomeChartWindow,
-    gridUnit?: 'minute',
+    gridUnit?: HomeChartGridUnit,
   ): Promise<Result<ReportChartLineOptions>> {
     const [comfort, internal] = await Promise.all([
       fetchHomeReportChunks(

--- a/src/facades/home-device-atw.ts
+++ b/src/facades/home-device-atw.ts
@@ -27,7 +27,7 @@ import type {
 import { HomeBaseDeviceFacade } from './home-base-device.ts'
 import {
   type HomeChartWindow,
-  HOME_REPORT_PERIOD,
+  fetchHomeReportChunks,
   resolveHomeHourWindow,
   resolveHomeReportWindow,
   toHomeEnergyOptions,
@@ -418,10 +418,10 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
   ): Promise<Result<ReportChartLineOptions>> {
     const window = resolveHomeReportWindow(query, this.chartTimezone)
     return mapResult(
-      await this.api.getAtwInternalTemperatures(this.id, {
-        ...toHomeWireWindow(window),
-        period: HOME_REPORT_PERIOD,
-      }),
+      await fetchHomeReportChunks(
+        async (params) => this.api.getAtwInternalTemperatures(this.id, params),
+        window,
+      ),
       (reports) =>
         toHomeLineOptions({
           locale: this.api.locale,
@@ -445,10 +445,10 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
   ): Promise<Result<ReportChartPieOptions>> {
     const window = resolveHomeReportWindow(query, this.chartTimezone)
     return mapResult(
-      await this.api.getAtwTemperatures(this.id, {
-        ...toHomeWireWindow(window),
-        period: HOME_REPORT_PERIOD,
-      }),
+      await fetchHomeReportChunks(
+        async (params) => this.api.getAtwTemperatures(this.id, params),
+        window,
+      ),
       (reports) => toHomeOperationModeOptions(reports, window),
     )
   }
@@ -529,13 +529,15 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
     window: HomeChartWindow,
     gridUnit?: 'minute',
   ): Promise<Result<ReportChartLineOptions>> {
-    const params = {
-      ...toHomeWireWindow(window),
-      period: HOME_REPORT_PERIOD,
-    }
     const [comfort, internal] = await Promise.all([
-      this.api.getAtwTemperatures(this.id, params),
-      this.api.getAtwInternalTemperatures(this.id, params),
+      fetchHomeReportChunks(
+        async (params) => this.api.getAtwTemperatures(this.id, params),
+        window,
+      ),
+      fetchHomeReportChunks(
+        async (params) => this.api.getAtwInternalTemperatures(this.id, params),
+        window,
+      ),
     ])
     if (!comfort.ok) {
       return comfort

--- a/src/facades/home-report.ts
+++ b/src/facades/home-report.ts
@@ -739,9 +739,19 @@ export const toHomeEnergyOptions = ({
   )
   return {
     from: window.from.toPlainDateTime().toString(),
-    labels: slots.map((slot) =>
-      formatter.format(Temporal.PlainDateTime.from(slot)),
-    ),
+    // Hour buckets render on the display clock (a 23:00 UTC bucket is
+    // the user's 01:00); day buckets keep their calendar date.
+    labels: slots.map((slot) => {
+      const wire = Temporal.PlainDateTime.from(slot)
+      return formatter.format(
+        bucketUnit === 'hour' ?
+          wire
+            .toZonedDateTime(WIRE_TIME_ZONE)
+            .withTimeZone(window.from.timeZoneId)
+            .toPlainDateTime()
+        : wire,
+      )
+    }),
     series: sources.map(({ data, name, scale }) => {
       const bySlot = sumEnergyBySlot(data, scale, bucketUnit)
       return { data: slots.map((slot) => bySlot.get(slot) ?? 0), name }

--- a/src/facades/home-report.ts
+++ b/src/facades/home-report.ts
@@ -1,11 +1,13 @@
-import type {
-  HomeEnergyData,
-  HomeReportAnnotation,
-  HomeReportData,
-  HomeReportPoint,
-  Hour,
-} from '../types/index.ts'
 import { Intl, Temporal } from '../temporal.ts'
+import {
+  type HomeEnergyData,
+  type HomeReportAnnotation,
+  type HomeReportData,
+  type HomeReportPoint,
+  type Hour,
+  type Result,
+  ok,
+} from '../types/index.ts'
 import type {
   ReportChartBand,
   ReportChartLineOptions,
@@ -30,8 +32,145 @@ export interface HomeChartWindow {
   readonly to: Temporal.ZonedDateTime
 }
 
-/** Aggregation period passed to the Home report endpoints. */
-export const HOME_REPORT_PERIOD = 'Hourly'
+// Report annotations degrade with the requested window, not just the
+// period: beyond ~30 days the BFF summarizes them (operation-mode
+// durations collapse — live-probed 2026-07-19: a 90-day query reported
+// LESS hot water than its own 30-day subwindow), and minute-grained
+// payloads blow the client timeout past ~7 days. Facades therefore
+// split wide windows into chunks and merge the reports.
+export const MAX_REPORT_CHUNK_DAYS = 30
+
+const windowDaysOf = (window: HomeChartWindow): number =>
+  window.from.until(window.to).total({ relativeTo: window.from, unit: 'days' })
+
+/**
+ * Aggregation period for one report request: minute-grained `Hourly`
+ * within the hourly-grid span, sampled `Weekly` beyond it (`Daily`
+ * collapses the mode annotations — live-probed 2026-07-19).
+ * @param window - Resolved chunk window.
+ * @returns The period to request.
+ */
+export const toHomeReportPeriod = (window: HomeChartWindow): string =>
+  windowDaysOf(window) > MAX_HOURLY_GRID_DAYS ? 'Weekly' : 'Hourly'
+
+/**
+ * Split a window into consecutive chunks of at most
+ * {@link MAX_REPORT_CHUNK_DAYS} days, oldest first.
+ * @param window - Resolved chart window.
+ * @returns The chunk windows (at least one).
+ */
+export const splitHomeReportWindow = (
+  window: HomeChartWindow,
+): HomeChartWindow[] => {
+  const chunks: HomeChartWindow[] = []
+  let { from } = window
+  while (Temporal.ZonedDateTime.compare(from, window.to) < 0) {
+    const next = from.add({ days: MAX_REPORT_CHUNK_DAYS })
+    const to =
+      Temporal.ZonedDateTime.compare(next, window.to) > 0 ? window.to : next
+    chunks.push({ from, to })
+    from = to
+  }
+  return chunks.length > 0 ? chunks : [window]
+}
+
+const mergeChunkDatasets = (
+  reports: readonly HomeReportData[],
+): HomeReportData['datasets'] => {
+  const pointsById = new Map<string, Map<string, HomeReportPoint>>()
+  for (const report of reports) {
+    for (const dataset of report.datasets) {
+      const points =
+        pointsById.get(dataset.id) ?? new Map<string, HomeReportPoint>()
+      for (const point of dataset.data) {
+        points.set(point.x, point)
+      }
+      pointsById.set(dataset.id, points)
+    }
+  }
+  return pointsById
+    .entries()
+    .map(([id, points]) => ({
+      data: points.values().toArray(),
+      id,
+      label: id,
+    }))
+    .toArray()
+}
+
+const mergeChunkAnnotations = (
+  reports: readonly HomeReportData[],
+): HomeReportAnnotation[] => {
+  const annotations = new Map<string, HomeReportAnnotation>()
+  for (const report of reports) {
+    const spans = report.annotations ?? []
+    for (const annotation of spans) {
+      annotations.set(
+        `${annotation.label ?? ''}|${annotation.xMin}|${annotation.xMax}`,
+        annotation,
+      )
+    }
+  }
+  return annotations.values().toArray()
+}
+
+/**
+ * Merge chunked report responses into a single report: samples
+ * concatenated per dataset id (deduplicated by timestamp), annotations
+ * deduplicated by identity (the BFF returns boundary-crossing spans in
+ * both adjacent chunks — a naive merge would double-count them), LOCF
+ * seeds from the oldest chunk.
+ * @param chunks - Report payloads, oldest chunk first.
+ * @returns A single-report array for the chart pipeline.
+ */
+export const mergeHomeReportChunks = (
+  chunks: readonly (readonly HomeReportData[])[],
+): HomeReportData[] => {
+  const reports = chunks.flat()
+  const [first] = reports
+  if (first === undefined || reports.length === 1) {
+    return [...reports]
+  }
+  return [
+    {
+      ...first,
+      annotations: mergeChunkAnnotations(reports),
+      datasets: mergeChunkDatasets(reports),
+    },
+  ]
+}
+
+/**
+ * Fetch a report over the window in chunks of at most
+ * {@link MAX_REPORT_CHUNK_DAYS} days, in parallel, and merge the
+ * responses: wide single requests time out (minute-grained payloads)
+ * or come back with summarized annotations (collapsed mode durations).
+ * @param fetch - One report request (endpoint bound by the caller).
+ * @param window - Resolved chart window.
+ * @returns The merged report, or the first chunk failure.
+ */
+export const fetchHomeReportChunks = async (
+  fetch: (params: {
+    from: string
+    period: string
+    to: string
+  }) => Promise<Result<HomeReportData[]>>,
+  window: HomeChartWindow,
+): Promise<Result<HomeReportData[]>> => {
+  const results = await Promise.all(
+    splitHomeReportWindow(window).map(async (chunk) =>
+      fetch({ ...toHomeWireWindow(chunk), period: toHomeReportPeriod(chunk) }),
+    ),
+  )
+  const values: HomeReportData[][] = []
+  for (const result of results) {
+    if (!result.ok) {
+      return result
+    }
+    values.push([...result.value])
+  }
+  return ok(mergeHomeReportChunks(values))
+}
 
 // The Home wire speaks UTC wall-clock on queries and samples alike
 // (live-probed 2026-07-18: the freshest sample equals "now" in UTC).

--- a/src/facades/home-report.ts
+++ b/src/facades/home-report.ts
@@ -21,7 +21,7 @@ import type {
  * on its own time grid), so every chart is rebuilt on a regular grid.
  * @category Facades
  */
-export type HomeChartGridUnit = 'day' | 'hour' | 'minute'
+export type HomeChartGridUnit = 'day' | 'fiveMinutes' | 'hour' | 'minute'
 
 /**
  * Report window resolved to absolute instants in the display timezone.
@@ -223,6 +223,7 @@ const seriesNameOverrides: Record<string, string> = {
 
 const durationByUnit: Record<HomeChartGridUnit, Temporal.DurationLike> = {
   day: { days: 1 },
+  fiveMinutes: { minutes: 5 },
   hour: { hours: 1 },
   minute: { minutes: 1 },
 }
@@ -316,6 +317,17 @@ export const resolveHomeHourWindow = (
 }
 
 /**
+ * Resolve the window from today's midnight to now in the display
+ * timezone — what the "today" charts (fine temperatures, signal) cover.
+ * @param timezone - IANA display timezone (UTC when unset).
+ * @returns The resolved window.
+ */
+export const resolveHomeDayWindow = (timezone: string): HomeChartWindow => {
+  const now = Temporal.Now.zonedDateTimeISO(timezone)
+  return { from: now.startOfDay(), to: now }
+}
+
+/**
  * Serialize a window into the ISO instant pair consumed by the raw
  * report/telemetry endpoints.
  * @param window - Resolved chart window.
@@ -366,8 +378,11 @@ const gridLabelOptions = (
   if (unit === 'day') {
     return { day: 'numeric', month: 'short' }
   }
+  if (unit === 'fiveMinutes' || unit === 'minute') {
+    return { hour: '2-digit', minute: '2-digit' }
+  }
+  // Only the hourly unit reaches this point.
   const isMultiDay =
-    unit === 'hour' &&
     window.from.until(window.to).total({
       relativeTo: window.from,
       unit: 'days',
@@ -696,15 +711,16 @@ export const toHomeEnergyOptions = ({
  * minute grid over the requested hour.
  * @param options - Conversion inputs.
  * @param options.data - Telemetry payload (`rssi` samples).
+ * @param options.gridUnit - Grid resolution (minute by default).
  * @param options.locale - BCP-47 locale tag for axis labels.
  * @param options.name - Series name (the device display name, matching
  * the Classic signal legend).
- * @param options.window - Resolved one-hour window (in the display
- * timezone).
+ * @param options.window - Resolved window (in the display timezone).
  * @returns Structured line chart options (`dBm`).
  */
 export const toHomeSignalOptions = ({
   data,
+  gridUnit = 'minute',
   locale,
   name,
   window,
@@ -712,6 +728,7 @@ export const toHomeSignalOptions = ({
   data: HomeEnergyData
   name: string
   window: HomeChartWindow
+  gridUnit?: HomeChartGridUnit | undefined
   locale?: string | undefined
 }): ReportChartLineOptions => {
   const samples = data.measureData
@@ -721,10 +738,10 @@ export const toHomeSignalOptions = ({
       Number(point.value),
     ])
     .toSorted(([first], [second]) => first - second)
-  const grid = buildGrid(window, 'minute')
+  const grid = buildGrid(window, gridUnit)
   return {
     from: window.from.toPlainDateTime().toString(),
-    labels: formatGridLabels({ grid, locale, unit: 'minute', window }),
+    labels: formatGridLabels({ grid, locale, unit: gridUnit, window }),
     series: [{ data: resampleSeries(samples, grid), name }],
     to: window.to.toPlainDateTime().toString(),
     unit: 'dBm',

--- a/src/facades/home-report.ts
+++ b/src/facades/home-report.ts
@@ -317,6 +317,16 @@ export const resolveHomeHourWindow = (
 }
 
 /**
+ * Wire bucket granularity for an energy-report window: hourly on a
+ * one-day span — matching the Classic one-day report — daily beyond.
+ * @param window - Resolved chart window.
+ * @returns The telemetry interval and bucket unit.
+ */
+export const toHomeEnergyBucketUnit = (
+  window: HomeChartWindow,
+): 'day' | 'hour' => (windowDaysOf(window) <= 1 ? 'hour' : 'day')
+
+/**
  * Resolve the window from today's midnight to now in the display
  * timezone — what the "today" charts (fine temperatures, signal) cover.
  * @param timezone - IANA display timezone (UTC when unset).
@@ -638,8 +648,9 @@ export const toHomeOperationModeOptions = (
   }
 }
 
-// Energy buckets are UTC calendar days on the wire: enumerate them by
-// their literal date instead of shifting them into the display timezone.
+// Energy buckets are UTC calendar days (or hours) on the wire:
+// enumerate them by their literal timestamps instead of shifting them
+// into the display timezone.
 const buildUtcDayGrid = (window: HomeChartWindow): string[] => {
   const last = window.to.withTimeZone(WIRE_TIME_ZONE).toPlainDate()
   const days: string[] = []
@@ -648,22 +659,46 @@ const buildUtcDayGrid = (window: HomeChartWindow): string[] => {
     Temporal.PlainDate.compare(day, last) <= 0;
     day = day.add({ days: 1 })
   ) {
-    days.push(day.toString())
+    days.push(day.toPlainDateTime().toString())
   }
   return days
 }
 
-const sumEnergyByDay = (
+const toWireHour = (bound: Temporal.ZonedDateTime): Temporal.PlainDateTime =>
+  bound
+    .withTimeZone(WIRE_TIME_ZONE)
+    .toPlainDateTime()
+    .round({ roundingMode: 'floor', smallestUnit: 'hour' })
+
+const buildUtcHourGrid = (window: HomeChartWindow): string[] => {
+  const last = toWireHour(window.to)
+  const hours: string[] = []
+  for (
+    let hour = toWireHour(window.from);
+    Temporal.PlainDateTime.compare(hour, last) <= 0;
+    hour = hour.add({ hours: 1 })
+  ) {
+    hours.push(hour.toString())
+  }
+  return hours
+}
+
+const sumEnergyBySlot = (
   data: HomeEnergyData,
   scale: number,
+  bucketUnit: 'day' | 'hour',
 ): Map<string, number> => {
-  const byDay = new Map<string, number>()
+  const bySlot = new Map<string, number>()
   const points = data.measureData.flatMap((measure) => measure.values)
   for (const point of points) {
-    const day = parseWireDateTime(point.time).toPlainDate().toString()
-    byDay.set(day, (byDay.get(day) ?? 0) + Number(point.value) * scale)
+    const time = parseWireDateTime(point.time)
+    const slot = (
+      bucketUnit === 'hour' ?
+        time.round({ roundingMode: 'floor', smallestUnit: 'hour' })
+      : time.toPlainDate().toPlainDateTime()).toString()
+    bySlot.set(slot, (bySlot.get(slot) ?? 0) + Number(point.value) * scale)
   }
-  return byDay
+  return bySlot
 }
 
 /**
@@ -671,12 +706,15 @@ const sumEnergyByDay = (
  * chart options on a daily grid: one series per source, missing days
  * as `0` (the wire omits idle buckets entirely).
  * @param options - Conversion inputs.
+ * @param options.bucketUnit - Wire bucket granularity (daily by
+ * default; hourly matches the Classic one-day report).
  * @param options.locale - BCP-47 locale tag for axis labels.
  * @param options.sources - One entry per charted series.
  * @param options.window - Resolved chart window (in the display timezone).
  * @returns Structured line chart options (`kWh`).
  */
 export const toHomeEnergyOptions = ({
+  bucketUnit = 'day',
   locale,
   sources,
   window,
@@ -687,19 +725,26 @@ export const toHomeEnergyOptions = ({
     readonly scale: number
   }[]
   window: HomeChartWindow
+  bucketUnit?: 'day' | 'hour' | undefined
   locale?: string | undefined
 }): ReportChartLineOptions => {
-  const days = buildUtcDayGrid(window)
-  const formatter = new Intl.DateTimeFormat(locale, {
-    day: 'numeric',
-    month: 'short',
-  })
+  const slots = (bucketUnit === 'hour' ? buildUtcHourGrid : buildUtcDayGrid)(
+    window,
+  )
+  const formatter = new Intl.DateTimeFormat(
+    locale,
+    bucketUnit === 'hour' ?
+      { hour: '2-digit', minute: '2-digit' }
+    : { day: 'numeric', month: 'short' },
+  )
   return {
     from: window.from.toPlainDateTime().toString(),
-    labels: days.map((day) => formatter.format(Temporal.PlainDate.from(day))),
+    labels: slots.map((slot) =>
+      formatter.format(Temporal.PlainDateTime.from(slot)),
+    ),
     series: sources.map(({ data, name, scale }) => {
-      const byDay = sumEnergyByDay(data, scale)
-      return { data: days.map((day) => byDay.get(day) ?? 0), name }
+      const bySlot = sumEnergyBySlot(data, scale, bucketUnit)
+      return { data: slots.map((slot) => bySlot.get(slot) ?? 0), name }
     }),
     to: window.to.toPlainDateTime().toString(),
     unit: 'kWh',

--- a/src/types/hour.ts
+++ b/src/types/hour.ts
@@ -27,3 +27,18 @@ export type Hour =
   | 7
   | 8
   | 9
+
+const LAST_HOUR = 23
+
+const isHour = (value: number): value is Hour =>
+  Number.isSafeInteger(value) && value >= 0 && value <= LAST_HOUR
+
+/**
+ * Every {@link Hour} in chronological order — the fan-out base for
+ * day-spanning hourly charts.
+ * @category Types
+ */
+export const HOURS: readonly Hour[] = Array.from(
+  { length: LAST_HOUR + 1 },
+  (_unused, index) => index,
+).filter((value) => isHour(value))

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -116,9 +116,9 @@ export type {
   HomeUser,
   HomeUserContext,
 } from './home.ts'
-export type { Hour } from './hour.ts'
 export type { Resolved, UndefinedTolerant } from './utility.ts'
 
+export { type Hour, HOURS } from './hour.ts'
 export {
   type ClassicAreaID,
   type ClassicBuildingID,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,17 +3,20 @@ import type {
   ReportChartPieOptions,
   ReportQuery,
 } from './facades/index.ts'
-import type {
-  ClassicOperationModeLogData,
-  ClassicReportData,
-  ClassicSetDeviceDataAtaInList,
-  ClassicUpdateDeviceData,
-  Hour,
-  KeyOfClassicSetDeviceDataAtaNotInList,
-  Resolved,
-} from './types/index.ts'
 import { type ClassicDeviceType, ClassicLabelType } from './constants.ts'
 import { Intl, Temporal } from './temporal.ts'
+import {
+  type ClassicOperationModeLogData,
+  type ClassicReportData,
+  type ClassicSetDeviceDataAtaInList,
+  type ClassicUpdateDeviceData,
+  type Hour,
+  type KeyOfClassicSetDeviceDataAtaNotInList,
+  type Resolved,
+  type Result,
+  HOURS,
+  ok,
+} from './types/index.ts'
 
 // API encodes year-month as YYYYMM integer (e.g., 202306 for June 2023)
 const YEAR_MONTH_DIVISOR = 100
@@ -319,6 +322,53 @@ export const getChartLineOptions = (
   to,
   unit,
 })
+
+/**
+ * Every hour of today up to and including `hour`, midnight first — the
+ * fan-out the day-spanning hourly charts iterate.
+ * @param hour - Last hour to include (usually the current hour).
+ * @returns The hours `0..hour`.
+ */
+export const hoursUpTo = (hour: Hour): Hour[] =>
+  HOURS.filter((candidate) => candidate <= hour)
+
+/**
+ * Merge consecutive one-hour line charts into one day-spanning chart:
+ * labels and per-series samples concatenate in hour order (the legend
+ * is identical across hours), bounds stretch from the first `from` to
+ * the last `to`.
+ * @param results - Per-hour results, midnight first.
+ * @returns The merged chart, or the first hourly failure.
+ */
+export const mergeHourlyChartResults = (
+  results: readonly Result<ReportChartLineOptions>[],
+): Result<ReportChartLineOptions> => {
+  const values: ReportChartLineOptions[] = []
+  for (const result of results) {
+    if (!result.ok) {
+      return result
+    }
+    values.push(result.value)
+  }
+  const [first] = values
+  const last = values.at(LAST)
+  if (first === undefined || last === undefined) {
+    return ok({ from: '', labels: [], series: [], to: '', unit: '' })
+  }
+  return ok({
+    from: first.from,
+    labels: values.flatMap(({ labels }) => labels),
+    series: first.series.map((series, index) => ({
+      data: values.flatMap((value) => value.series[index]?.data ?? []),
+      name: series.name,
+    })),
+    to: last.to,
+    unit: first.unit,
+  })
+}
+
+// Index of a collection's last element for `Array#at`.
+const LAST = -1
 
 // Raw minute labels of the one-hour report endpoints span this bound.
 const MAX_MINUTE_LABEL = 59

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -348,7 +348,9 @@ export const withMinuteClockLabels = (
     labels: options.labels.map((label) => {
       const minute = Number(label)
       return (
-          Number.isSafeInteger(minute) && minute >= 0 && minute <= MAX_MINUTE_LABEL
+          Number.isSafeInteger(minute) &&
+            minute >= 0 &&
+            minute <= MAX_MINUTE_LABEL
         ) ?
           formatter.format(new Temporal.PlainTime(hour, minute))
         : label

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ import type {
   ClassicReportData,
   ClassicSetDeviceDataAtaInList,
   ClassicUpdateDeviceData,
+  Hour,
   KeyOfClassicSetDeviceDataAtaNotInList,
   Resolved,
 } from './types/index.ts'
@@ -318,6 +319,42 @@ export const getChartLineOptions = (
   to,
   unit,
 })
+
+// Raw minute labels of the one-hour report endpoints span this bound.
+const MAX_MINUTE_LABEL = 59
+
+/**
+ * Replace the raw minute labels (`0`-`59`) of a one-hour chart with
+ * locale-formatted clock labels anchored on `hour`: the `Report/*`
+ * hourly endpoints only carry bare minutes, which read ambiguously on
+ * an axis (and inconsistently next to the Home charts' clock labels).
+ * Non-minute labels pass through untouched.
+ * @param options - Chart options carrying raw minute labels.
+ * @param format - Label formatting inputs.
+ * @param format.hour - Hour of today the minutes belong to.
+ * @param format.locale - BCP-47 locale tag; defaults to the runtime locale.
+ * @returns The options with clock labels.
+ */
+export const withMinuteClockLabels = (
+  options: ReportChartLineOptions,
+  { hour, locale }: { hour: Hour; locale?: string | undefined },
+): ReportChartLineOptions => {
+  const formatter = new Intl.DateTimeFormat(locale, {
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+  return {
+    ...options,
+    labels: options.labels.map((label) => {
+      const minute = Number(label)
+      return (
+          Number.isSafeInteger(minute) && minute >= 0 && minute <= MAX_MINUTE_LABEL
+        ) ?
+          formatter.format(new Temporal.PlainTime(hour, minute))
+        : label
+    }),
+  }
+}
 
 /**
  * Transform operation mode log data into structured pie chart options.

--- a/tests/unit/classic-facades.test.ts
+++ b/tests/unit/classic-facades.test.ts
@@ -848,6 +848,40 @@ describe('ata device facade', () => {
     expect(value.labels[1]).toBe('Mon')
   })
 
+  it('formats a one-day energy report with clock labels', async () => {
+    const { facade } = createAtaFacade({
+      getEnergy: vi.fn<ClassicAPIAdapter['getEnergy']>().mockResolvedValue(
+        ok(
+          cast({
+            Auto: [0, 0],
+            Cooling: [0.2, 0.3],
+            Dry: [0, 0],
+            Fan: [0, 0],
+            Heating: [0, 0],
+            Labels: [9, 10],
+            LabelType: 0,
+            Other: [0, 0],
+            TotalAutoConsumed: 0,
+            TotalCoolingConsumed: 0.5,
+            TotalDryConsumed: 0,
+            TotalFanConsumed: 0,
+            TotalHeatingConsumed: 0,
+            TotalOtherConsumed: 0,
+            UsageDisclaimerPercentages: '100',
+          }),
+        ),
+      ),
+      locale: 'fr-FR',
+    })
+
+    const { labels } = okValue(
+      await facade.getEnergyReport({ from: '2024-01-07', to: '2024-01-08' }),
+    )
+
+    // The one-day report's bare hour numbers render as clock labels.
+    expect(labels).toStrictEqual(['09:00', '10:00'])
+  })
+
   it('calls operationModes', async () => {
     const { facade } = createAtaFacade()
     const value = okValue(await facade.getOperationModes())

--- a/tests/unit/classic-facades.test.ts
+++ b/tests/unit/classic-facades.test.ts
@@ -278,6 +278,22 @@ describe('building facade', () => {
     expect(api.getSignal).toHaveBeenCalledWith(expect.any(Object))
   })
 
+  it('formats the raw minute labels as clock labels', async () => {
+    const { facade } = createBuildingFacade({
+      getSignal: vi
+        .fn<ClassicAPIAdapter['getSignal']>()
+        .mockResolvedValue(
+          ok(classicReportData({ Labels: ['0', '30', '59', 'total'] })),
+        ),
+      locale: 'fr-FR',
+    })
+
+    const { labels } = okValue(await facade.getSignalStrength(12))
+
+    // Bare minutes anchor on the requested hour; non-minutes pass through.
+    expect(labels).toStrictEqual(['12:00', '12:30', '12:59', 'total'])
+  })
+
   it('defaults getSignalStrength hour to the current hour', async () => {
     const { api, facade } = createBuildingFacade()
     okValue(await facade.getSignalStrength())
@@ -852,6 +868,19 @@ describe('ata device facade', () => {
 
     expect(value).toHaveProperty('series')
     expect(api.getHourlyTemperatures).toHaveBeenCalledWith(expect.any(Object))
+  })
+
+  it('formats the hourly temperature labels as clock labels', async () => {
+    const { facade } = createAtaFacade({
+      getHourlyTemperatures: vi
+        .fn<ClassicAPIAdapter['getHourlyTemperatures']>()
+        .mockResolvedValue(ok(classicReportData({ Labels: ['5'] }))),
+      locale: 'fr-FR',
+    })
+
+    const { labels } = okValue(await facade.getHourlyTemperatures(9))
+
+    expect(labels).toStrictEqual(['09:05'])
   })
 
   it('defaults hourlyTemperatures hour to the current hour', async () => {

--- a/tests/unit/classic-facades.test.ts
+++ b/tests/unit/classic-facades.test.ts
@@ -28,6 +28,7 @@ import {
   isClassicAtwFacade,
   isClassicErvFacade,
 } from '../../src/facades/index.ts'
+import { Temporal } from '../../src/temporal.ts'
 import {
   type ClassicListDeviceDataAta,
   type ClassicSetDevicePostData,
@@ -294,14 +295,23 @@ describe('building facade', () => {
     expect(labels).toStrictEqual(['12:00', '12:30', '12:59', 'total'])
   })
 
-  it('defaults getSignalStrength hour to the current hour', async () => {
-    const { api, facade } = createBuildingFacade()
-    okValue(await facade.getSignalStrength())
+  it('covers the whole of today hour by hour when no hour is given', async () => {
+    vi.spyOn(Temporal.Now, 'plainTimeISO').mockReturnValue(
+      new Temporal.PlainTime(2),
+    )
+    try {
+      const { api, facade } = createBuildingFacade()
+      okValue(await facade.getSignalStrength())
 
-    const call = vi.mocked(api.getSignal).mock.calls[0]?.[0]
-
-    expect(call?.postData.hour).toBeGreaterThanOrEqual(0)
-    expect(call?.postData.hour).toBeLessThanOrEqual(23)
+      expect(api.getSignal).toHaveBeenCalledTimes(3)
+      expect(
+        vi
+          .mocked(api.getSignal)
+          .mock.calls.map(([{ postData }]) => postData.hour),
+      ).toStrictEqual([0, 1, 2])
+    } finally {
+      vi.mocked(Temporal.Now.plainTimeISO).mockRestore()
+    }
   })
 
   it('calls getTiles without selection', async () => {
@@ -883,14 +893,25 @@ describe('ata device facade', () => {
     expect(labels).toStrictEqual(['09:05'])
   })
 
-  it('defaults hourlyTemperatures hour to the current hour', async () => {
-    const { api, facade } = createAtaFacade()
-    okValue(await facade.getHourlyTemperatures())
+  it('covers the whole of today hour by hour when no hour is given', async () => {
+    vi.spyOn(Temporal.Now, 'plainTimeISO').mockReturnValue(
+      new Temporal.PlainTime(1),
+    )
+    try {
+      const { api, facade } = createAtaFacade()
+      const value = okValue(await facade.getHourlyTemperatures())
 
-    const call = vi.mocked(api.getHourlyTemperatures).mock.calls[0]?.[0]
-
-    expect(call?.postData.hour).toBeGreaterThanOrEqual(0)
-    expect(call?.postData.hour).toBeLessThanOrEqual(23)
+      expect(api.getHourlyTemperatures).toHaveBeenCalledTimes(2)
+      expect(
+        vi
+          .mocked(api.getHourlyTemperatures)
+          .mock.calls.map(([{ postData }]) => postData.hour),
+      ).toStrictEqual([0, 1])
+      // Two one-label hours concatenate into a two-label day.
+      expect(value.labels).toHaveLength(2)
+    } finally {
+      vi.mocked(Temporal.Now.plainTimeISO).mockRestore()
+    }
   })
 
   it('calls getTiles without selection', async () => {

--- a/tests/unit/home-device-ata-facade.test.ts
+++ b/tests/unit/home-device-ata-facade.test.ts
@@ -446,5 +446,30 @@ describe('home device ata facade', () => {
       expect(value.series[0]?.name).toBe('Test ClassicDevice')
       expect(value.series[0]?.data.at(-1)).toBe(-66)
     })
+
+    it('covers today on a five-minute grid when no hour is given', async () => {
+      const api = createApi()
+      vi.mocked(api.getSignal).mockResolvedValue(
+        ok({
+          measureData: [
+            {
+              type: 'rssi',
+              values: [{ time: '2026-03-01 00:02:00.000000000', value: '-70' }],
+            },
+          ],
+        }),
+      )
+      const facade = new HomeDeviceAtaFacade(api, createModel())
+
+      const value = okValue(await facade.getSignalStrength())
+
+      // Pinned to 12:00 UTC: midnight through now, 5-minute slots.
+      expect(api.getSignal).toHaveBeenCalledWith('device-1', {
+        from: '2026-03-01T00:00:00Z',
+        to: '2026-03-01T12:00:00Z',
+      })
+      expect(value.labels).toHaveLength(145)
+      expect(value.series[0]?.data[1]).toBe(-70)
+    })
   })
 })

--- a/tests/unit/home-device-ata-facade.test.ts
+++ b/tests/unit/home-device-ata-facade.test.ts
@@ -373,7 +373,7 @@ describe('home device ata facade', () => {
       await expect(facade.getTemperatures()).resolves.toBe(failure)
     })
 
-    it('charts the daily energy report in kWh from watt-hour buckets', async () => {
+    it('charts a multi-day energy report in daily kWh buckets', async () => {
       const api = createApi()
       vi.mocked(api.getAtaEnergy).mockResolvedValue(
         ok({
@@ -392,18 +392,51 @@ describe('home device ata facade', () => {
       const value = okValue(
         await facade.getEnergyReport({
           from: '2026-03-01T00:00:00Z',
-          to: '2026-03-02T00:00:00Z',
+          to: '2026-03-03T00:00:00Z',
         }),
       )
 
       expect(api.getAtaEnergy).toHaveBeenCalledWith('device-1', {
         from: '2026-03-01T00:00:00Z',
         interval: 'Day',
-        to: '2026-03-02T00:00:00Z',
+        to: '2026-03-03T00:00:00Z',
       })
       expect(value.unit).toBe('kWh')
       expect(value.series[0]?.name).toBe('Consumed')
       expect(value.series[0]?.data[0]).toBeCloseTo(0.571)
+    })
+
+    it('switches a one-day energy report to hourly buckets', async () => {
+      const api = createApi()
+      vi.mocked(api.getAtaEnergy).mockResolvedValue(
+        ok({
+          measureData: [
+            {
+              type: 'cumulative_energy_consumed_since_last_upload',
+              values: [
+                { time: '2026-03-01 09:00:00.000000000', value: '200.0' },
+              ],
+            },
+          ],
+        }),
+      )
+      const facade = new HomeDeviceAtaFacade(api, createModel())
+
+      const value = okValue(
+        await facade.getEnergyReport({
+          from: '2026-03-01T00:00:00Z',
+          to: '2026-03-02T00:00:00Z',
+        }),
+      )
+
+      // One day: hourly wire buckets, matching the Classic report.
+      expect(api.getAtaEnergy).toHaveBeenCalledWith('device-1', {
+        from: '2026-03-01T00:00:00Z',
+        interval: 'Hour',
+        to: '2026-03-02T00:00:00Z',
+      })
+      expect(value.labels).toHaveLength(25)
+      expect(value.series[0]?.data[9]).toBeCloseTo(0.2)
     })
   })
 

--- a/tests/unit/home-device-atw-facade.test.ts
+++ b/tests/unit/home-device-atw-facade.test.ts
@@ -25,8 +25,9 @@ const energyBucket = (value: string): ReturnType<typeof ok<object>> =>
     ],
   })
 
-const createApi = (): HomeAPIAdapter =>
+const createApi = (overrides: Partial<HomeAPIAdapter> = {}): HomeAPIAdapter =>
   mock<HomeAPIAdapter>({
+    ...overrides,
     getAtwEnergy: vi.fn<HomeAPIAdapter['getAtwEnergy']>(),
     getAtwErrorLog: vi.fn<HomeAPIAdapter['getAtwErrorLog']>(),
     getAtwInternalTemperatures:
@@ -564,7 +565,8 @@ describe('home device atw facade', () => {
     })
 
     it('covers today on a five-minute grid when no hour is given', async () => {
-      const api = createApi()
+      // Pin the label locale: the runner's default is not ours.
+      const api = createApi({ locale: 'fr-FR' })
       vi.mocked(api.getAtwTemperatures).mockResolvedValue(ok([comfortReport]))
       vi.mocked(api.getAtwInternalTemperatures).mockResolvedValue(ok([]))
       const facade = new HomeDeviceAtwFacade(api, createModel())

--- a/tests/unit/home-device-atw-facade.test.ts
+++ b/tests/unit/home-device-atw-facade.test.ts
@@ -668,7 +668,7 @@ describe('home device atw facade', () => {
 
       const params = {
         from: '2026-05-09T00:00:00Z',
-        interval: 'Day',
+        interval: 'Hour',
         to: '2026-05-10T00:00:00Z',
       }
 

--- a/tests/unit/home-device-atw-facade.test.ts
+++ b/tests/unit/home-device-atw-facade.test.ts
@@ -563,6 +563,54 @@ describe('home device atw facade', () => {
       expect(value.labels).toHaveLength(61)
     })
 
+    it('chunks a wide window and merges the reports', async () => {
+      const api = createApi()
+      vi.mocked(api.getAtwTemperatures).mockResolvedValue(ok([comfortReport]))
+      vi.mocked(api.getAtwInternalTemperatures).mockResolvedValue(ok([]))
+      const facade = new HomeDeviceAtwFacade(api, createModel())
+
+      const value = okValue(
+        await facade.getTemperatures({
+          from: '2026-03-01T00:00:00Z',
+          to: '2026-05-09T00:00:00Z',
+        }),
+      )
+
+      // 69 days split at the 30-day cap: three chunks per endpoint,
+      // sampled Weekly (beyond the hourly-grid span).
+      expect(api.getAtwTemperatures).toHaveBeenCalledTimes(3)
+      expect(api.getAtwTemperatures).toHaveBeenNthCalledWith(1, 'atw-1', {
+        from: '2026-03-01T00:00:00Z',
+        period: 'Weekly',
+        to: '2026-03-31T00:00:00Z',
+      })
+      expect(api.getAtwTemperatures).toHaveBeenNthCalledWith(3, 'atw-1', {
+        from: '2026-04-30T00:00:00Z',
+        period: 'Weekly',
+        to: '2026-05-09T00:00:00Z',
+      })
+      // Identical chunk payloads merge to one deduplicated series.
+      expect(value.series).toHaveLength(1)
+    })
+
+    it('propagates a chunk failure untouched', async () => {
+      const api = createApi()
+      const failure = { ok: false as const, status: 503 }
+      vi.mocked(api.getAtwTemperatures)
+        .mockResolvedValueOnce(ok([comfortReport]))
+        .mockResolvedValueOnce(cast(failure))
+        .mockResolvedValueOnce(ok([comfortReport]))
+      vi.mocked(api.getAtwInternalTemperatures).mockResolvedValue(ok([]))
+      const facade = new HomeDeviceAtwFacade(api, createModel())
+
+      await expect(
+        facade.getTemperatures({
+          from: '2026-03-01T00:00:00Z',
+          to: '2026-05-09T00:00:00Z',
+        }),
+      ).resolves.toBe(failure)
+    })
+
     it('aggregates operation modes into Classic-shaped pie data', async () => {
       const api = createApi()
       vi.mocked(api.getAtwTemperatures).mockResolvedValue(ok([comfortReport]))

--- a/tests/unit/home-device-atw-facade.test.ts
+++ b/tests/unit/home-device-atw-facade.test.ts
@@ -547,13 +547,13 @@ describe('home device atw facade', () => {
       await expect(facade.getHourlyTemperatures(9)).resolves.toBe(failure)
     })
 
-    it('builds the hourly chart on a minute grid', async () => {
+    it('builds one specific hour on a minute grid', async () => {
       const api = createApi()
       vi.mocked(api.getAtwTemperatures).mockResolvedValue(ok([comfortReport]))
       vi.mocked(api.getAtwInternalTemperatures).mockResolvedValue(ok([]))
       const facade = new HomeDeviceAtwFacade(api, createModel())
 
-      const value = okValue(await facade.getHourlyTemperatures())
+      const value = okValue(await facade.getHourlyTemperatures(9))
 
       expect(api.getAtwTemperatures).toHaveBeenCalledWith('atw-1', {
         from: '2026-05-09T09:00:00Z',
@@ -561,6 +561,24 @@ describe('home device atw facade', () => {
         to: '2026-05-09T10:00:00Z',
       })
       expect(value.labels).toHaveLength(61)
+    })
+
+    it('covers today on a five-minute grid when no hour is given', async () => {
+      const api = createApi()
+      vi.mocked(api.getAtwTemperatures).mockResolvedValue(ok([comfortReport]))
+      vi.mocked(api.getAtwInternalTemperatures).mockResolvedValue(ok([]))
+      const facade = new HomeDeviceAtwFacade(api, createModel())
+
+      const value = okValue(await facade.getHourlyTemperatures())
+
+      // Pinned to 09:30 UTC: midnight through now, 5-minute slots.
+      expect(api.getAtwTemperatures).toHaveBeenCalledWith('atw-1', {
+        from: '2026-05-09T00:00:00Z',
+        period: 'Hourly',
+        to: '2026-05-09T09:30:00Z',
+      })
+      expect(value.labels).toHaveLength(115)
+      expect(value.labels[0]).toBe('00:00')
     })
 
     it('chunks a wide window and merges the reports', async () => {

--- a/tests/unit/home-report.test.ts
+++ b/tests/unit/home-report.test.ts
@@ -2,11 +2,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { HomeReportData } from '../../src/types/index.ts'
 import {
+  mergeHomeReportChunks,
   resolveHomeHourWindow,
   resolveHomeReportWindow,
+  splitHomeReportWindow,
   toHomeEnergyOptions,
   toHomeLineOptions,
   toHomeOperationModeOptions,
+  toHomeReportPeriod,
   toHomeSeriesName,
   toHomeSignalOptions,
   toHomeWireWindow,
@@ -126,6 +129,163 @@ describe(resolveHomeHourWindow, () => {
     expect(window.from.toString()).toBe(
       '2026-07-18T22:00:00+02:00[Europe/Paris]',
     )
+  })
+})
+
+describe.concurrent(splitHomeReportWindow, () => {
+  it('keeps a window within the chunk cap whole', () => {
+    const window = resolveHomeReportWindow(
+      { from: '2026-06-18T00:00:00', to: '2026-07-18T00:00:00' },
+      'UTC',
+    )
+
+    expect(splitHomeReportWindow(window)).toStrictEqual([window])
+  })
+
+  it('splits a wide window into contiguous 30-day chunks', () => {
+    const window = resolveHomeReportWindow(
+      { from: '2026-04-19T00:00:00', to: '2026-07-18T00:00:00' },
+      'UTC',
+    )
+
+    const chunks = splitHomeReportWindow(window)
+
+    expect(
+      chunks.map(({ from, to }) => [
+        from.toPlainDateTime().toString(),
+        to.toPlainDateTime().toString(),
+      ]),
+    ).toStrictEqual([
+      ['2026-04-19T00:00:00', '2026-05-19T00:00:00'],
+      ['2026-05-19T00:00:00', '2026-06-18T00:00:00'],
+      ['2026-06-18T00:00:00', '2026-07-18T00:00:00'],
+    ])
+  })
+
+  it('clips the last chunk to the window end', () => {
+    const window = resolveHomeReportWindow(
+      { from: '2026-06-13T00:00:00', to: '2026-07-18T00:00:00' },
+      'UTC',
+    )
+
+    const chunks = splitHomeReportWindow(window)
+
+    expect(chunks).toHaveLength(2)
+    expect(chunks[1]?.to.toPlainDateTime().toString()).toBe(
+      '2026-07-18T00:00:00',
+    )
+  })
+})
+
+describe.concurrent(toHomeReportPeriod, () => {
+  it('falls back to the whole window when it is empty', () => {
+    const window = resolveHomeReportWindow(
+      { from: '2026-07-18T00:00:00', to: '2026-07-18T00:00:00' },
+      'UTC',
+    )
+
+    expect(splitHomeReportWindow(window)).toStrictEqual([window])
+  })
+
+  it.each([
+    { expected: 'Hourly', from: '2026-07-11T00:00:00' },
+    { expected: 'Weekly', from: '2026-07-10T00:00:00' },
+  ])('requests $expected from $from', ({ expected, from }) => {
+    const window = resolveHomeReportWindow(
+      { from, to: '2026-07-18T00:00:00' },
+      'UTC',
+    )
+
+    expect(toHomeReportPeriod(window)).toBe(expected)
+  })
+})
+
+describe.concurrent(mergeHomeReportChunks, () => {
+  it('passes a single chunk through untouched', () => {
+    const single = [report()]
+
+    expect(mergeHomeReportChunks([single])).toStrictEqual(single)
+  })
+
+  it('concatenates samples per id and deduplicates boundary spans', () => {
+    const boundarySpan = {
+      label: `${OVERLAY_PREFIX}HOT_WATER`,
+      xMax: '2026-07-01T01:00:00',
+      xMin: '2026-06-30T23:00:00',
+    }
+    const merged = mergeHomeReportChunks([
+      [
+        report({
+          annotations: [boundarySpan],
+          datasets: [
+            {
+              data: [
+                homeReportPoint('2026-06-30T12:00:00', 20),
+                homeReportPoint('2026-06-30T23:59:00', 21),
+              ],
+              id: 'room_temperature',
+              label: 'first',
+            },
+          ],
+          previousTriggers: [
+            {
+              measure: 'room_temperature',
+              trigger: '2026-06-29T00:00:00',
+              value: 19,
+            },
+          ],
+        }),
+      ],
+      [
+        report({
+          // The BFF returns the same boundary-crossing span to both
+          // adjacent chunks: it must merge to ONE annotation.
+          annotations: [boundarySpan],
+          datasets: [
+            {
+              data: [
+                homeReportPoint('2026-06-30T23:59:00', 21),
+                homeReportPoint('2026-07-01T12:00:00', 22),
+              ],
+              id: 'room_temperature',
+              label: 'second',
+            },
+          ],
+        }),
+      ],
+    ])
+
+    expect(merged).toHaveLength(1)
+
+    const [result] = merged
+
+    expect(result?.annotations).toStrictEqual([boundarySpan])
+    expect(result?.datasets).toHaveLength(1)
+    expect(result?.datasets[0]?.data).toStrictEqual([
+      homeReportPoint('2026-06-30T12:00:00', 20),
+      homeReportPoint('2026-06-30T23:59:00', 21),
+      homeReportPoint('2026-07-01T12:00:00', 22),
+    ])
+    // LOCF seeds come from the oldest chunk.
+    expect(result?.previousTriggers).toStrictEqual([
+      {
+        measure: 'room_temperature',
+        trigger: '2026-06-29T00:00:00',
+        value: 19,
+      },
+    ])
+  })
+
+  it('keeps unlabelled missing-data spans distinct while merging', () => {
+    const grey = { xMax: '2026-07-01T02:00:00', xMin: '2026-07-01T01:00:00' }
+    const merged = mergeHomeReportChunks([
+      [report({ annotations: [grey] })],
+      [report({ annotations: [grey] })],
+      // A chunk with no annotations key at all contributes nothing.
+      [report()],
+    ])
+
+    expect(merged[0]?.annotations).toStrictEqual([grey])
   })
 })
 

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -1,14 +1,19 @@
 import { describe, expect, it } from 'vitest'
 
+import type { ReportChartLineOptions } from '../../src/facades/index.ts'
+import { ok } from '../../src/types/index.ts'
 import {
   fromListToSetAta,
   fromSetToListAta,
+  hoursUpTo,
   isSetDeviceDataAtaInList,
   isSetDeviceDataAtaNotInList,
   isUpdateDeviceData,
+  mergeHourlyChartResults,
   omitUndefined,
   typedFromEntries,
 } from '../../src/utils.ts'
+import { cast, okValue } from '../helpers.ts'
 
 describe.concurrent('ata set-to-list conversion', () => {
   it('maps set keys to list keys', () => {
@@ -104,5 +109,78 @@ describe.concurrent(omitUndefined, () => {
 
   it('returns an empty object when every value is undefined', () => {
     expect(omitUndefined({ temperature: undefined })).toStrictEqual({})
+  })
+})
+
+describe.concurrent(hoursUpTo, () => {
+  it('lists midnight through the given hour', () => {
+    expect(hoursUpTo(0)).toStrictEqual([0])
+    expect(hoursUpTo(3)).toStrictEqual([0, 1, 2, 3])
+    expect(hoursUpTo(23)).toHaveLength(24)
+  })
+})
+
+const hourOptions = (
+  labels: string[],
+  data: (number | null)[],
+): ReturnType<typeof ok<ReportChartLineOptions>> =>
+  ok({
+    from: labels[0] ?? '',
+    labels,
+    series: [{ data, name: 'Signal' }],
+    to: labels.at(-1) ?? '',
+    unit: 'dBm',
+  })
+
+describe.concurrent(mergeHourlyChartResults, () => {
+  it('concatenates consecutive hours into one chart', () => {
+    const merged = okValue(
+      mergeHourlyChartResults([
+        hourOptions(['00:00', '00:30'], [-60, -61]),
+        hourOptions(['01:00', '01:30'], [-62, null]),
+      ]),
+    )
+
+    expect(merged.labels).toStrictEqual(['00:00', '00:30', '01:00', '01:30'])
+    expect(merged.series).toStrictEqual([
+      { data: [-60, -61, -62, null], name: 'Signal' },
+    ])
+    expect(merged.from).toBe('00:00')
+    expect(merged.to).toBe('01:30')
+    expect(merged.unit).toBe('dBm')
+  })
+
+  it('propagates the first hourly failure untouched', () => {
+    const failure: ReturnType<typeof mergeHourlyChartResults> = cast({
+      ok: false,
+    })
+
+    expect(
+      mergeHourlyChartResults([hourOptions(['00:00'], [-60]), failure]),
+    ).toBe(failure)
+  })
+
+  it('pads a series absent from a later hour with nothing', () => {
+    const merged = okValue(
+      mergeHourlyChartResults([
+        hourOptions(['00:00'], [-60]),
+        ok({
+          from: '01:00',
+          labels: ['01:00'],
+          series: [],
+          to: '01:00',
+          unit: 'dBm',
+        }),
+      ]),
+    )
+
+    expect(merged.series).toStrictEqual([{ data: [-60], name: 'Signal' }])
+  })
+
+  it('resolves an empty chart for an empty day', () => {
+    const merged = okValue(mergeHourlyChartResults([]))
+
+    expect(merged.labels).toStrictEqual([])
+    expect(merged.series).toStrictEqual([])
   })
 })


### PR DESCRIPTION
Root cause of the com.melcloud charts widget's « problème de chargement de Varmepumpe (états opérationnels) » on wide date ranges — reproduced off-Homey against the live BFF.

## Diagnosis (live-probed 2026-07-19)

- A single wide report request (`comfort-graph` / `internaltemperatures` / `trendsummary`) **times out at the 10-second client cap** past ~7 days at `Hourly` grain (30/90-day queries failed at 10.0-10.2 s on both accounts).
- Switching the period is not enough: `Daily` **collapses the operation-mode annotations** (7-day check: Cooling 0.34 d vs 2.03 d real), and even `Weekly` degrades beyond ~30 days — a 90-day query reported **less** hot-water time (0.43 d) than its own 30-day subwindow (1.52 d), which is impossible. The BFF summarizes annotations per response, keyed to the requested window.

## Fix

`fetchHomeReportChunks` (home-report pipeline): split the window into **chunks of at most 30 days**, fetch them in parallel with a window-fitted period (`Hourly` within the hourly-grid span, `Weekly` beyond), then merge — samples concatenated per series (deduplicated by timestamp), **boundary-crossing mode spans deduplicated** (the BFF returns them to both adjacent chunks; a naive merge double-counts), LOCF seeds from the oldest chunk. All four report surfaces (ATA temperatures, ATW temperatures/internal/operation modes) route through it; the hourly chart is a single chunk as before.

## Verified live

| Query | Before | After |
|---|---|---|
| ATW operation modes 30 d | timeout 10.1 s | OK 2.8 s, durations faithful |
| ATW operation modes 90 d | timeout 10.2 s | OK 4.4 s, monotone vs 30 d (HotWater 3.71 ≥ 1.52) |
| ATW temperatures 90 d | timeout | OK 4.3 s, 11 series + 227 bands |
| ATA temperatures 30 d | timeout 10.0 s | OK 1.7 s |
| ATW hourly | OK | OK, unchanged (0.8 s) |

Coverage stays at 100 % (+9 tests: window splitting, period fit, chunk merge dedup, facade chunking + failure propagation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)