### PR TITLE
fix: full-day chart axes and hourly one-day Home energy buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Home report charts failed beyond ~7 days (the widget's "loading problem" on wide ranges): a single wide request either hit the 10-second client timeout (minute-grained payloads) or came back with silently summarized annotations — live-probed: a 90-day query reported _less_ hot-water time than its own 30-day subwindow. The facades now split report windows into chunks of at most 30 days, fetched in parallel with a window-fitted period (`Hourly` within seven days, `Weekly` beyond — `Daily` collapses the mode annotations), and merge the responses: samples concatenated per series, boundary-crossing mode spans deduplicated (the BFF returns them in both adjacent chunks), LOCF seeds from the oldest chunk. A 90-day operation-modes pie now resolves in a few seconds with faithful durations.
+- The day-spanning charts (Wi-Fi signal and today's temperatures) keep a full-day axis again on both API sides: the Classic hour-by-hour merge pads the not-yet-elapsed hours with blank samples, and the Home day windows now span midnight to midnight with samples blanked past now — the axis reads 00:00-24:00 all day instead of shrinking to the current hour.
+- Home 1-day energy reports bucket hourly again: the day-versus-hour threshold now tolerates the sub-second drift between the caller's `from` stamp and the facade's `to` stamp, which pushed an exact 1-day window just over the limit and collapsed it onto daily bars spanning 2 calendar days.
 
 ## [42.0.0] - 2026-07-18
 

--- a/src/facades/classic-base-device.ts
+++ b/src/facades/classic-base-device.ts
@@ -40,6 +40,7 @@ import {
   isUpdateDeviceData,
   mergeHourlyChartResults,
   now,
+  padHourlyChartToMidnight,
   typedFromEntries,
   typedKeys,
   withMinuteClockLabels,
@@ -286,13 +287,20 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
       return this.#fetchTemperaturesHour(hour)
     }
     // No hour: the whole of today, hour by hour — the wire only speaks
-    // one-hour windows.
+    // one-hour windows; the not-yet-elapsed hours pad blank so the axis
+    // spans the whole day.
+    const currentHour = this.currentHour()
     const hourly = await Promise.all(
-      hoursUpTo(this.currentHour()).map(async (hourOfDay) =>
+      hoursUpTo(currentHour).map(async (hourOfDay) =>
         this.#fetchTemperaturesHour(hourOfDay),
       ),
     )
-    return mergeHourlyChartResults(hourly)
+    return mapResult(mergeHourlyChartResults(hourly), (options) =>
+      padHourlyChartToMidnight(options, {
+        afterHour: currentHour,
+        locale: this.api.locale,
+      }),
+    )
   }
 
   public async getInternalTemperatures(

--- a/src/facades/classic-base.ts
+++ b/src/facades/classic-base.ts
@@ -38,6 +38,7 @@ import {
   getChartLineOptions,
   hoursUpTo,
   mergeHourlyChartResults,
+  padHourlyChartToMidnight,
   withMinuteClockLabels,
 } from '../utils.ts'
 import { HourSchema, parseOrThrow } from '../validation/index.ts'
@@ -292,13 +293,20 @@ export abstract class ClassicBaseFacade<
       return this.#fetchSignalHour(hour)
     }
     // No hour: the whole of today, hour by hour — the wire only speaks
-    // one-hour windows.
+    // one-hour windows; the not-yet-elapsed hours pad blank so the axis
+    // spans the whole day.
+    const currentHour = this.currentHour()
     const hourly = await Promise.all(
-      hoursUpTo(this.currentHour()).map(async (hourOfDay) =>
+      hoursUpTo(currentHour).map(async (hourOfDay) =>
         this.#fetchSignalHour(hourOfDay),
       ),
     )
-    return mergeHourlyChartResults(hourly)
+    return mapResult(mergeHourlyChartResults(hourly), (options) =>
+      padHourlyChartToMidnight(options, {
+        afterHour: currentHour,
+        locale: this.api.locale,
+      }),
+    )
   }
 
   /**

--- a/src/facades/home-base-device.ts
+++ b/src/facades/home-base-device.ts
@@ -127,14 +127,18 @@ export abstract class HomeBaseDeviceFacade<TData extends HomeDeviceData> {
   public async getSignalStrength(
     hour?: Hour,
   ): Promise<Result<ReportChartLineOptions>> {
-    const window =
+    const { cutoff, window } =
       hour === undefined ?
         resolveHomeDayWindow(this.chartTimezone)
-      : resolveHomeHourWindow(hour, this.chartTimezone)
+      : {
+          cutoff: undefined,
+          window: resolveHomeHourWindow(hour, this.chartTimezone),
+        }
     return mapResult(
       await this.api.getSignal(this.id, toHomeWireWindow(window)),
       (data) =>
         toHomeSignalOptions({
+          cutoff,
           data,
           gridUnit: hour === undefined ? 'fiveMinutes' : 'minute',
           locale: this.api.locale,

--- a/src/facades/home-device-atw.ts
+++ b/src/facades/home-device-atw.ts
@@ -1,5 +1,6 @@
 import type { HomeAPIAdapter } from '../api/index.ts'
 import type { HomeDevice } from '../entities/home-device.ts'
+import type { Temporal } from '../temporal.ts'
 import {
   ClassicOperationModeStateHotWater,
   ClassicOperationModeStateZone,
@@ -406,15 +407,18 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
   public async getHourlyTemperatures(
     hour?: Hour,
   ): Promise<Result<ReportChartLineOptions>> {
-    return hour === undefined ?
-        this.#fetchTemperatureChart(
-          resolveHomeDayWindow(this.chartTimezone),
-          'fiveMinutes',
-        )
-      : this.#fetchTemperatureChart(
-          resolveHomeHourWindow(hour, this.chartTimezone),
-          'minute',
-        )
+    const { cutoff, window } =
+      hour === undefined ?
+        resolveHomeDayWindow(this.chartTimezone)
+      : {
+          cutoff: undefined,
+          window: resolveHomeHourWindow(hour, this.chartTimezone),
+        }
+    return this.#fetchTemperatureChart(
+      window,
+      hour === undefined ? 'fiveMinutes' : 'minute',
+      cutoff,
+    )
   }
 
   /**
@@ -539,6 +543,7 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
   async #fetchTemperatureChart(
     window: HomeChartWindow,
     gridUnit?: HomeChartGridUnit,
+    cutoff?: Temporal.ZonedDateTime,
   ): Promise<Result<ReportChartLineOptions>> {
     const [comfort, internal] = await Promise.all([
       fetchHomeReportChunks(
@@ -559,6 +564,7 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
     return ok(
       toHomeLineOptions({
         ...(gridUnit !== undefined && { gridUnit }),
+        cutoff,
         locale: this.api.locale,
         reports: [...comfort.value, ...internal.value],
         unit: TEMPERATURE_UNIT,

--- a/src/facades/home-report.ts
+++ b/src/facades/home-report.ts
@@ -185,6 +185,11 @@ const MAX_REPORT_SPAN_DAYS = 92
 
 const MILLISECONDS_PER_DAY = 86_400_000
 
+// A "one day" query resolves a hair over 1.0 days (the caller stamps
+// `from` a few milliseconds before the library stamps `to`), so the
+// hourly-bucket cutoff sits halfway to the next whole-day option.
+const MAX_HOURLY_ENERGY_DAYS = 1.5
+
 const MODE_OVERLAY_PREFIX = 'REPORT.COMFORT_GRAPH.OVERLAY_KEY.'
 
 // Comfort-graph overlay keys mapped onto the Classic operation-mode
@@ -324,17 +329,24 @@ export const resolveHomeHourWindow = (
  */
 export const toHomeEnergyBucketUnit = (
   window: HomeChartWindow,
-): 'day' | 'hour' => (windowDaysOf(window) <= 1 ? 'hour' : 'day')
+): 'day' | 'hour' =>
+  windowDaysOf(window) <= MAX_HOURLY_ENERGY_DAYS ? 'hour' : 'day'
 
 /**
- * Resolve the window from today's midnight to now in the display
- * timezone — what the "today" charts (fine temperatures, signal) cover.
+ * Resolve today's full-day window in the display timezone — what the
+ * "today" charts (fine temperatures, signal) cover — plus the "now"
+ * cutoff after which their grids stay blank.
  * @param timezone - IANA display timezone (UTC when unset).
- * @returns The resolved window.
+ * @returns The full-day window and the cutoff.
  */
-export const resolveHomeDayWindow = (timezone: string): HomeChartWindow => {
+export const resolveHomeDayWindow = (
+  timezone: string,
+): { cutoff: Temporal.ZonedDateTime; window: HomeChartWindow } => {
   const now = Temporal.Now.zonedDateTimeISO(timezone)
-  return { from: now.startOfDay(), to: now }
+  const from = now.startOfDay()
+  // The window spans the whole day so the axis always reads 00:00-24:00;
+  // the cutoff marks "now" — slots beyond it chart as gaps, not LOCF.
+  return { cutoff: now, window: { from, to: from.add({ days: 1 }) } }
 }
 
 /**
@@ -428,15 +440,20 @@ const toSamplePoints = (points: readonly HomeReportPoint[]): SamplePoint[] =>
     .toSorted(([first], [second]) => first - second)
 
 // Last-observation-carried-forward: each grid slot takes the freshest
-// sample at or before it, `null` before the first sample.
+// sample at or before it, `null` before the first sample and past the
+// cutoff (the not-yet-elapsed remainder of a full-day grid).
 const resampleSeries = (
   samples: readonly SamplePoint[],
   grid: readonly Temporal.ZonedDateTime[],
+  cutoffMilliseconds = Infinity,
 ): (number | null)[] => {
   let index = 0
   let last: number | null = null
   return grid.map((slot) => {
     const limit = slot.epochMilliseconds
+    if (limit > cutoffMilliseconds) {
+      return null
+    }
     for (; index < samples.length; index += 1) {
       const sample = samples[index]
       if (sample === undefined || sample[0] > limit) {
@@ -549,6 +566,8 @@ const toBands = (
  * regular grid, LOCF-resampled series under Classic legend names, and
  * operation-mode background bands from the comfort-graph annotations.
  * @param options - Conversion inputs.
+ * @param options.cutoff - Instant after which grid slots stay blank
+ * (the not-yet-elapsed remainder of a full-day window).
  * @param options.gridUnit - Grid resolution override (auto: hourly up
  * to seven days, daily beyond).
  * @param options.locale - BCP-47 locale tag for axis labels.
@@ -558,6 +577,7 @@ const toBands = (
  * @returns Structured line chart options.
  */
 export const toHomeLineOptions = ({
+  cutoff,
   gridUnit,
   locale,
   reports,
@@ -567,6 +587,7 @@ export const toHomeLineOptions = ({
   reports: readonly HomeReportData[]
   unit: string
   window: HomeChartWindow
+  cutoff?: Temporal.ZonedDateTime | undefined
   gridUnit?: HomeChartGridUnit | undefined
   locale?: string | undefined
 }): ReportChartLineOptions => {
@@ -580,7 +601,11 @@ export const toHomeLineOptions = ({
     series: mergeDatasets(reports)
       .filter(({ points }) => points.length > 0)
       .map(({ id, points }) => ({
-        data: resampleSeries(toSamplePoints(points), grid),
+        data: resampleSeries(
+          toSamplePoints(points),
+          grid,
+          cutoff?.epochMilliseconds,
+        ),
         name: toHomeSeriesName(id),
       })),
     to: window.to.toPlainDateTime().toString(),
@@ -765,6 +790,8 @@ export const toHomeEnergyOptions = ({
  * Rebuild RSSI telemetry into Classic-shaped line chart options on a
  * minute grid over the requested hour.
  * @param options - Conversion inputs.
+ * @param options.cutoff - Instant after which grid slots stay blank
+ * (the not-yet-elapsed remainder of a full-day window).
  * @param options.data - Telemetry payload (`rssi` samples).
  * @param options.gridUnit - Grid resolution (minute by default).
  * @param options.locale - BCP-47 locale tag for axis labels.
@@ -774,6 +801,7 @@ export const toHomeEnergyOptions = ({
  * @returns Structured line chart options (`dBm`).
  */
 export const toHomeSignalOptions = ({
+  cutoff,
   data,
   gridUnit = 'minute',
   locale,
@@ -783,6 +811,7 @@ export const toHomeSignalOptions = ({
   data: HomeEnergyData
   name: string
   window: HomeChartWindow
+  cutoff?: Temporal.ZonedDateTime | undefined
   gridUnit?: HomeChartGridUnit | undefined
   locale?: string | undefined
 }): ReportChartLineOptions => {
@@ -797,7 +826,9 @@ export const toHomeSignalOptions = ({
   return {
     from: window.from.toPlainDateTime().toString(),
     labels: formatGridLabels({ grid, locale, unit: gridUnit, window }),
-    series: [{ data: resampleSeries(samples, grid), name }],
+    series: [
+      { data: resampleSeries(samples, grid, cutoff?.epochMilliseconds), name },
+    ],
     to: window.to.toPlainDateTime().toString(),
     unit: 'dBm',
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -409,6 +409,40 @@ export const withMinuteClockLabels = (
 }
 
 /**
+ * Extend a merged day chart to midnight: the not-yet-elapsed hours get
+ * their clock labels with blank samples, so the axis always spans the
+ * whole day (parity with the Home full-day charts).
+ * @param options - Merged chart covering midnight up to `afterHour`.
+ * @param format - Padding inputs.
+ * @param format.afterHour - Last hour the chart already covers.
+ * @param format.locale - BCP-47 locale tag; defaults to the runtime locale.
+ * @returns The options padded to a full-day axis.
+ */
+export const padHourlyChartToMidnight = (
+  options: ReportChartLineOptions,
+  { afterHour, locale }: { afterHour: Hour; locale?: string | undefined },
+): ReportChartLineOptions => {
+  const formatter = new Intl.DateTimeFormat(locale, {
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+  const padLabels = HOURS.filter((hourOfDay) => hourOfDay > afterHour).flatMap(
+    (hourOfDay) =>
+      Array.from({ length: MAX_MINUTE_LABEL + 1 }, (_unused, minute) =>
+        formatter.format(new Temporal.PlainTime(hourOfDay, minute)),
+      ),
+  )
+  return {
+    ...options,
+    labels: [...options.labels, ...padLabels],
+    series: options.series.map((series) => ({
+      ...series,
+      data: [...series.data, ...padLabels.map(() => null)],
+    })),
+  }
+}
+
+/**
  * Transform operation mode log data into structured pie chart options.
  * @param data - The operation mode log entries.
  * @param root0 - The resolved report date range (defaults applied).

--- a/tests/unit/classic-facades.test.ts
+++ b/tests/unit/classic-facades.test.ts
@@ -932,7 +932,8 @@ describe('ata device facade', () => {
       new Temporal.PlainTime(1),
     )
     try {
-      const { api, facade } = createAtaFacade()
+      // Pin the label locale: the runner's default is not ours.
+      const { api, facade } = createAtaFacade({ locale: 'fr-FR' })
       const value = okValue(await facade.getHourlyTemperatures())
 
       expect(api.getHourlyTemperatures).toHaveBeenCalledTimes(2)

--- a/tests/unit/classic-facades.test.ts
+++ b/tests/unit/classic-facades.test.ts
@@ -941,8 +941,11 @@ describe('ata device facade', () => {
           .mocked(api.getHourlyTemperatures)
           .mock.calls.map(([{ postData }]) => postData.hour),
       ).toStrictEqual([0, 1])
-      // Two one-label hours concatenate into a two-label day.
-      expect(value.labels).toHaveLength(2)
+      // Two one-label hours concatenate, then hours 2-23 pad blank
+      // minutes so the axis spans the whole day.
+      expect(value.labels).toHaveLength(2 + 22 * 60)
+      expect(value.labels[2]).toBe('02:00')
+      expect(value.labels.at(-1)).toBe('23:59')
     } finally {
       vi.mocked(Temporal.Now.plainTimeISO).mockRestore()
     }

--- a/tests/unit/home-device-ata-facade.test.ts
+++ b/tests/unit/home-device-ata-facade.test.ts
@@ -438,6 +438,24 @@ describe('home device ata facade', () => {
       expect(value.labels).toHaveLength(25)
       expect(value.series[0]?.data[9]).toBeCloseTo(0.2)
     })
+
+    it('keeps hourly buckets when the one-day window drifts by ms', async () => {
+      const api = createApi()
+      vi.mocked(api.getAtaEnergy).mockResolvedValue(ok({ measureData: [] }))
+      const facade = new HomeDeviceAtaFacade(api, createModel())
+
+      // The caller stamps `from` a beat before the library stamps `to`.
+      okValue(
+        await facade.getEnergyReport({
+          from: '2026-03-01T00:00:00Z',
+          to: '2026-03-02T00:00:00.250Z',
+        }),
+      )
+
+      expect(vi.mocked(api.getAtaEnergy).mock.calls[0]?.[1]?.interval).toBe(
+        'Hour',
+      )
+    })
   })
 
   describe('signal chart', () => {
@@ -496,13 +514,17 @@ describe('home device ata facade', () => {
 
       const value = okValue(await facade.getSignalStrength())
 
-      // Pinned to 12:00 UTC: midnight through now, 5-minute slots.
+      // Pinned to 12:00 UTC: the whole day on 5-minute slots, blank
+      // after now.
       expect(api.getSignal).toHaveBeenCalledWith('device-1', {
         from: '2026-03-01T00:00:00Z',
-        to: '2026-03-01T12:00:00Z',
+        to: '2026-03-02T00:00:00Z',
       })
-      expect(value.labels).toHaveLength(145)
+      expect(value.labels).toHaveLength(289)
       expect(value.series[0]?.data[1]).toBe(-70)
+      expect(value.series[0]?.data[144]).toBe(-70)
+      expect(value.series[0]?.data[145]).toBeNull()
+      expect(value.series[0]?.data.at(-1)).toBeNull()
     })
   })
 })

--- a/tests/unit/home-device-atw-facade.test.ts
+++ b/tests/unit/home-device-atw-facade.test.ts
@@ -573,14 +573,18 @@ describe('home device atw facade', () => {
 
       const value = okValue(await facade.getHourlyTemperatures())
 
-      // Pinned to 09:30 UTC: midnight through now, 5-minute slots.
+      // Pinned to 09:30 UTC: the whole day on 5-minute slots, blank
+      // after now.
       expect(api.getAtwTemperatures).toHaveBeenCalledWith('atw-1', {
         from: '2026-05-09T00:00:00Z',
         period: 'Hourly',
-        to: '2026-05-09T09:30:00Z',
+        to: '2026-05-10T00:00:00Z',
       })
-      expect(value.labels).toHaveLength(115)
+      expect(value.labels).toHaveLength(289)
       expect(value.labels[0]).toBe('00:00')
+      // LOCF holds through now (09:30 = slot 114), blank afterwards.
+      expect(value.series[0]?.data[114]).toBe(25)
+      expect(value.series[0]?.data[115]).toBeNull()
     })
 
     it('chunks a wide window and merges the reports', async () => {

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -11,6 +11,7 @@ import {
   isUpdateDeviceData,
   mergeHourlyChartResults,
   omitUndefined,
+  padHourlyChartToMidnight,
   typedFromEntries,
 } from '../../src/utils.ts'
 import { cast, okValue } from '../helpers.ts'
@@ -182,5 +183,35 @@ describe.concurrent(mergeHourlyChartResults, () => {
 
     expect(merged.labels).toStrictEqual([])
     expect(merged.series).toStrictEqual([])
+  })
+})
+
+describe.concurrent(padHourlyChartToMidnight, () => {
+  it('pads the not-yet-elapsed hours with clock labels and blanks', () => {
+    const padded = padHourlyChartToMidnight(
+      okValue(hourOptions(['22:30'], [-60])),
+      { afterHour: 22, locale: 'fr-FR' },
+    )
+
+    expect(padded.labels).toHaveLength(61)
+    expect(padded.labels[0]).toBe('22:30')
+    expect(padded.labels[1]).toBe('23:00')
+    expect(padded.labels.at(-1)).toBe('23:59')
+    expect(padded.series).toStrictEqual([
+      {
+        data: [-60, ...Array.from({ length: 60 }, () => null)],
+        name: 'Signal',
+      },
+    ])
+  })
+
+  it('returns the chart untouched during the last hour of the day', () => {
+    const padded = padHourlyChartToMidnight(
+      okValue(hourOptions(['23:30'], [-60])),
+      { afterHour: 23, locale: 'fr-FR' },
+    )
+
+    expect(padded.labels).toStrictEqual(['23:30'])
+    expect(padded.series).toStrictEqual([{ data: [-60], name: 'Signal' }])
   })
 })


### PR DESCRIPTION
Follow-ups to #1607 from on-device feedback, folded into the unreleased 42.0.1 (CHANGELOG extended under that heading):

- **Full-day axes for the day-spanning charts, both API sides.** The Wi-Fi signal and today's-temperatures charts shrank to midnight→current-hour. Classic: the hour-by-hour merge now pads the not-yet-elapsed hours with locale clock labels and blank samples (`padHourlyChartToMidnight`). Home: `resolveHomeDayWindow` now spans midnight→midnight and returns the `now` cutoff alongside, which the resampler uses to blank grid slots past now (no LOCF projection into the future). The axis reads 00:00–24:00 all day.
- **Hourly buckets for 1-day Home energy reports.** A "1 day" query stamps `from` (caller) a few milliseconds before `to` (facade), so `windowDaysOf ≤ 1` failed and the report collapsed onto daily bars spanning 2 calendar dates. The hourly cutoff now sits at 1.5 days, halfway to the next whole-day option.

Suite: 903 tests, 100% coverage, lint/format/typecheck/build clean.

Note: the merged #1607 branch got recreated by a stray push of this same commit before rebasing onto main — `fix/report-window-chunking` can be deleted, everything lives here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)