### PR TITLE
fix: 42.0.2 — Classic ATA multi-day energy reports crashed on rebuilt date labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -276,6 +276,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[42.0.2]: https://github.com/OlivierZal/melcloud-api/compare/42.0.1...42.0.2
 [42.0.1]: https://github.com/OlivierZal/melcloud-api/compare/42.0.0...42.0.1
 [42.0.0]: https://github.com/OlivierZal/melcloud-api/compare/41.3.0...42.0.0
 [41.3.0]: https://github.com/OlivierZal/melcloud-api/compare/41.2.3...41.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [42.0.2] - 2026-07-19
+
+### Fixed
+
+- Classic ATA multi-day energy reports crashed in 42.0.1 (`RangeError: Non-finite day`): the labels rebuilt as localized dates were handed back to the shared formatter still tagged `day_of_week`, which re-parsed `"18 juil."` as a day number. Rebuilt (and clock) labels now carry `LabelType.raw`, which the formatter passes through untouched — ATW multi-day reports never crashed because their wire labels are `raw` already.
+
 ## [42.0.1] - 2026-07-19
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.0.1",
+  "version": "42.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "42.0.1",
+      "version": "42.0.2",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.0.1",
+  "version": "42.0.2",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/facades/classic-base-device.ts
+++ b/src/facades/classic-base-device.ts
@@ -71,7 +71,10 @@ const ISO_SUNDAY = 7
 // ATW) — when the bucket count matches the window's calendar-day span,
 // those rebuild as localized dates anchored on `from`, aligning the
 // axis with the Home energy charts; otherwise day-of-week entries get
-// the 1-based ISO repair and anything else passes through.
+// the 1-based ISO repair. Final strings return `LabelType.raw` so the
+// shared formatter passes them through — re-parsing a rebuilt date as
+// a day-of-week number throws (the 42.0.1 crash on multi-day ATA
+// reports).
 const toEnergyReportLabels = (
   labels: readonly number[],
   {
@@ -83,15 +86,18 @@ const toEnergyReportLabels = (
     window: Resolved<ReportQuery>
     locale?: string | undefined
   },
-): string[] => {
+): { labels: string[]; labelType: ClassicLabelType } => {
   if (labelType === ClassicLabelType.time) {
     const formatter = new Intl.DateTimeFormat(locale, {
       hour: '2-digit',
       minute: '2-digit',
     })
-    return labels.map((label) =>
-      formatter.format(new Temporal.PlainTime(label)),
-    )
+    return {
+      labels: labels.map((label) =>
+        formatter.format(new Temporal.PlainTime(label)),
+      ),
+      labelType: ClassicLabelType.raw,
+    }
   }
   if (labels.length === getDuration(window)) {
     const formatter = new Intl.DateTimeFormat(locale, {
@@ -99,17 +105,23 @@ const toEnergyReportLabels = (
       month: 'short',
     })
     const start = Temporal.PlainDateTime.from(window.from).toPlainDate()
-    return labels.map((_unused, index) =>
-      formatter.format(start.add({ days: index })),
-    )
+    return {
+      labels: labels.map((_unused, index) =>
+        formatter.format(start.add({ days: index })),
+      ),
+      labelType: ClassicLabelType.raw,
+    }
   }
-  return labels.map((label) =>
-    String(
-      label === 0 && labelType === ClassicLabelType.day_of_week ?
-        ISO_SUNDAY
-      : label,
+  return {
+    labels: labels.map((label) =>
+      String(
+        label === 0 && labelType === ClassicLabelType.day_of_week ?
+          ISO_SUNDAY
+        : label,
+      ),
     ),
-  )
+    labelType,
+  }
 }
 
 // Calendar-day delta between two ISO wall-clock strings. Computed on
@@ -281,16 +293,17 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
     }
     return mapResult(await this.api.getEnergy<T>({ postData }), (data) => {
       const { labels, labelType, series } = extractEnergyReport(data)
+      const report = toEnergyReportLabels(labels, {
+        labelType,
+        locale: this.api.locale,
+        window: { from, to },
+      })
       return getChartLineOptions(
         {
           Data: series.map(({ data: values }) => [...values]),
           FromDate: from,
-          Labels: toEnergyReportLabels(labels, {
-            labelType,
-            locale: this.api.locale,
-            window: { from, to },
-          }),
-          LabelType: labelType,
+          Labels: report.labels,
+          LabelType: report.labelType,
           Points: labels.length,
           Series: series.length,
           ToDate: to,

--- a/tests/unit/classic-facades.test.ts
+++ b/tests/unit/classic-facades.test.ts
@@ -848,6 +848,50 @@ describe('ata device facade', () => {
     expect(value.labels[1]).toBe('Mon')
   })
 
+  it('rebuilds multi-day energy labels as dates', async () => {
+    const { facade } = createAtaFacade({
+      getEnergy: vi.fn<ClassicAPIAdapter['getEnergy']>().mockResolvedValue(
+        ok(
+          cast({
+            Auto: [0, 0, 0, 0, 0, 0, 0],
+            Cooling: [1, 1, 1, 1, 1, 1, 1],
+            Dry: [0, 0, 0, 0, 0, 0, 0],
+            Fan: [0, 0, 0, 0, 0, 0, 0],
+            Heating: [0, 0, 0, 0, 0, 0, 0],
+            Labels: [1, 2, 3, 4, 5, 6, 0],
+            LabelType: 4,
+            Other: [0, 0, 0, 0, 0, 0, 0],
+            TotalAutoConsumed: 0,
+            TotalCoolingConsumed: 7,
+            TotalDryConsumed: 0,
+            TotalFanConsumed: 0,
+            TotalHeatingConsumed: 0,
+            TotalOtherConsumed: 0,
+            UsageDisclaimerPercentages: '100',
+          }),
+        ),
+      ),
+      locale: 'fr-FR',
+    })
+
+    const { labels } = okValue(
+      await facade.getEnergyReport({ from: '2024-01-08', to: '2024-01-15' }),
+    )
+
+    // Seven weekday buckets over seven calendar days rebuild as dates —
+    // and must never reach the day-of-week formatter again (42.0.1
+    // crashed re-parsing the rebuilt strings as day numbers).
+    expect(labels).toStrictEqual([
+      '8 janv.',
+      '9 janv.',
+      '10 janv.',
+      '11 janv.',
+      '12 janv.',
+      '13 janv.',
+      '14 janv.',
+    ])
+  })
+
   it('formats a one-day energy report with clock labels', async () => {
     const { facade } = createAtaFacade({
       getEnergy: vi.fn<ClassicAPIAdapter['getEnergy']>().mockResolvedValue(


### PR DESCRIPTION
On-device regression report from Olivier: the energy report crashed for 3-7 days, Classic ATA only.

Root cause: #1610's rebuilt date labels («18 juil.») were handed back to `getChartLineOptions` still tagged `day_of_week`, and the shared formatter re-parses those as day numbers — `new Temporal.PlainDate(2024, 1, Number('18 juil.'))` → `RangeError: Non-finite day: NaN`. ATW multi-day reports survived because their wire labels are `LabelType.raw` (passthrough), and 1-day reports because `time` also passes through.

Fix: `toEnergyReportLabels` now returns the effective label type alongside the labels — `raw` whenever it produced final strings (dates or clock labels), the original type only on the numeric-repair path. Regression test reproduces the exact crash before the fix (7 weekday buckets over 7 calendar days).

Version bumped to 42.0.2 (42.0.1 shipped the crash). Suite: 906 tests, 100% coverage, lint/format/typecheck/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)