### PR TITLE
fix: 42.0.3 — Weekly-period truncation of mode annotations on wide windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-- Home ATW mode bands and operation-mode durations vanished beyond the first ~week of windows wider than 7 days: the BFF truncates the labeled comfort-graph annotations at period `Weekly` (live-probed via `scripts/probe-weekly-annotations.ts`: a 21-day Weekly query carried spans through day ~6 only — exactly the on-device symptom — while the same window in 7-day `Hourly` chunks covered it fully). The annotation consumers (temperature-chart bands, operation-modes pie) now chunk at 7 days so every request stays on the faithful `Hourly` period; chunk fan-outs run in batches of 6 requests (a year is 53 chunks) with a failed batch short-circuiting the rest.
+- Home ATW mode bands and operation-mode durations vanished beyond the first ~week of windows wider than 7 days: the BFF truncates the labeled comfort-graph annotations at period `Weekly` (live-probed via `scripts/probe-weekly-annotations.ts`: a 21-day Weekly query carried spans through day 6 only — exactly the on-device symptom — while the same window in 7-day `Hourly` chunks covered it fully). The annotation consumers (temperature-chart bands, operation-modes pie) now chunk at 7 days so every request stays on the faithful `Hourly` period; chunk fan-outs run in batches of 6 requests (a year is 53 chunks) with a failed batch short-circuiting the rest.
 
 ## [42.0.2] - 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [42.0.3] - 2026-07-19
+
+### Fixed
+
+- Home ATW mode bands and operation-mode durations vanished beyond the first ~week of windows wider than 7 days: the BFF truncates the labeled comfort-graph annotations at period `Weekly` (live-probed via `scripts/probe-weekly-annotations.ts`: a 21-day Weekly query carried spans through day ~6 only — exactly the on-device symptom — while the same window in 7-day `Hourly` chunks covered it fully). The annotation consumers (temperature-chart bands, operation-modes pie) now chunk at 7 days so every request stays on the faithful `Hourly` period; chunk fan-outs run in batches of 6 requests (a year is 53 chunks) with a failed batch short-circuiting the rest.
+
 ## [42.0.2] - 2026-07-19
 
 ### Fixed
@@ -276,6 +282,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[42.0.3]: https://github.com/OlivierZal/melcloud-api/compare/42.0.2...42.0.3
 [42.0.2]: https://github.com/OlivierZal/melcloud-api/compare/42.0.1...42.0.2
 [42.0.1]: https://github.com/OlivierZal/melcloud-api/compare/42.0.0...42.0.1
 [42.0.0]: https://github.com/OlivierZal/melcloud-api/compare/41.3.0...42.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.0.2",
+  "version": "42.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "42.0.2",
+      "version": "42.0.3",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.0.2",
+  "version": "42.0.3",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/facades/home-device-atw.ts
+++ b/src/facades/home-device-atw.ts
@@ -30,6 +30,7 @@ import {
   type HomeChartGridUnit,
   type HomeChartWindow,
   fetchHomeReportChunks,
+  MAX_ANNOTATION_CHUNK_DAYS,
   resolveHomeDayWindow,
   resolveHomeHourWindow,
   resolveHomeReportWindow,
@@ -465,6 +466,7 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
       await fetchHomeReportChunks(
         async (params) => this.api.getAtwTemperatures(this.id, params),
         window,
+        MAX_ANNOTATION_CHUNK_DAYS,
       ),
       (reports) => toHomeOperationModeOptions(reports, window),
     )
@@ -551,6 +553,7 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
       fetchHomeReportChunks(
         async (params) => this.api.getAtwTemperatures(this.id, params),
         window,
+        MAX_ANNOTATION_CHUNK_DAYS,
       ),
       fetchHomeReportChunks(
         async (params) => this.api.getAtwInternalTemperatures(this.id, params),

--- a/src/facades/home-report.ts
+++ b/src/facades/home-report.ts
@@ -40,6 +40,15 @@ export interface HomeChartWindow {
 // split wide windows into chunks and merge the reports.
 export const MAX_REPORT_CHUNK_DAYS = 30
 
+// Worse for the labeled mode annotations: at period `Weekly` the BFF
+// truncates them to roughly the first two weeks of the window
+// (live-probed 2026-07-19 via `scripts/probe-weekly-annotations.ts`:
+// a 21-day Weekly query carried spans through day ~6 only, while the
+// same window in 7-day Hourly chunks covered it fully). Annotation
+// consumers (mode bands, operation-mode durations) therefore chunk at
+// the Hourly-period span.
+export const MAX_ANNOTATION_CHUNK_DAYS = 7
+
 const windowDaysOf = (window: HomeChartWindow): number =>
   window.from.until(window.to).total({ relativeTo: window.from, unit: 'days' })
 
@@ -54,18 +63,21 @@ export const toHomeReportPeriod = (window: HomeChartWindow): string =>
   windowDaysOf(window) > MAX_HOURLY_GRID_DAYS ? 'Weekly' : 'Hourly'
 
 /**
- * Split a window into consecutive chunks of at most
- * {@link MAX_REPORT_CHUNK_DAYS} days, oldest first.
+ * Split a window into consecutive chunks of at most `chunkDays` days,
+ * oldest first.
  * @param window - Resolved chart window.
+ * @param chunkDays - Chunk span cap ({@link MAX_REPORT_CHUNK_DAYS} by
+ * default; {@link MAX_ANNOTATION_CHUNK_DAYS} for annotation consumers).
  * @returns The chunk windows (at least one).
  */
 export const splitHomeReportWindow = (
   window: HomeChartWindow,
+  chunkDays: number = MAX_REPORT_CHUNK_DAYS,
 ): HomeChartWindow[] => {
   const chunks: HomeChartWindow[] = []
   let { from } = window
   while (Temporal.ZonedDateTime.compare(from, window.to) < 0) {
-    const next = from.add({ days: MAX_REPORT_CHUNK_DAYS })
+    const next = from.add({ days: chunkDays })
     const to =
       Temporal.ZonedDateTime.compare(next, window.to) > 0 ? window.to : next
     chunks.push({ from, to })
@@ -140,13 +152,41 @@ export const mergeHomeReportChunks = (
   ]
 }
 
+// A year at the 7-day annotation cap is 53 requests — too many for
+// one parallel burst. Batches run this many chunks at a time; the
+// recursive shape (over a loop) keeps the batch sequencing loop-free,
+// and a failed batch short-circuits the remainder.
+const MAX_PARALLEL_CHUNKS = 6
+
+const fetchChunkBatches = async (
+  fetch: (chunk: HomeChartWindow) => Promise<Result<HomeReportData[]>>,
+  chunks: readonly HomeChartWindow[],
+): Promise<Result<HomeReportData[]>[]> => {
+  if (chunks.length === 0) {
+    return []
+  }
+  const batch = await Promise.all(
+    chunks.slice(0, MAX_PARALLEL_CHUNKS).map(async (chunk) => fetch(chunk)),
+  )
+  if (batch.some((result) => !result.ok)) {
+    return batch
+  }
+  return [
+    ...batch,
+    ...(await fetchChunkBatches(fetch, chunks.slice(MAX_PARALLEL_CHUNKS))),
+  ]
+}
+
 /**
- * Fetch a report over the window in chunks of at most
- * {@link MAX_REPORT_CHUNK_DAYS} days, in parallel, and merge the
- * responses: wide single requests time out (minute-grained payloads)
- * or come back with summarized annotations (collapsed mode durations).
+ * Fetch a report over the window in chunks of at most `chunkDays`
+ * days, batched in parallel, and merge the responses: wide single
+ * requests time out (minute-grained payloads) or come back with
+ * summarized annotations (collapsed mode durations).
  * @param fetch - One report request (endpoint bound by the caller).
  * @param window - Resolved chart window.
+ * @param chunkDays - Chunk span cap ({@link MAX_REPORT_CHUNK_DAYS} by
+ * default; {@link MAX_ANNOTATION_CHUNK_DAYS} keeps every chunk on the
+ * `Hourly` period, whose annotations are faithful).
  * @returns The merged report, or the first chunk failure.
  */
 export const fetchHomeReportChunks = async (
@@ -156,11 +196,12 @@ export const fetchHomeReportChunks = async (
     to: string
   }) => Promise<Result<HomeReportData[]>>,
   window: HomeChartWindow,
+  chunkDays?: number,
 ): Promise<Result<HomeReportData[]>> => {
-  const results = await Promise.all(
-    splitHomeReportWindow(window).map(async (chunk) =>
+  const results = await fetchChunkBatches(
+    async (chunk) =>
       fetch({ ...toHomeWireWindow(chunk), period: toHomeReportPeriod(chunk) }),
-    ),
+    splitHomeReportWindow(window, chunkDays),
   )
   const values: HomeReportData[][] = []
   for (const result of results) {

--- a/tests/unit/home-device-atw-facade.test.ts
+++ b/tests/unit/home-device-atw-facade.test.ts
@@ -600,19 +600,30 @@ describe('home device atw facade', () => {
         }),
       )
 
-      // 69 days split at the 30-day cap: three chunks per endpoint,
-      // sampled Weekly (beyond the hourly-grid span).
-      expect(api.getAtwTemperatures).toHaveBeenCalledTimes(3)
+      // 69 days: the annotation-bearing comfort-graph chunks at the
+      // 7-day cap (Weekly truncates the mode annotations), Hourly
+      // period throughout; the internal report keeps the 30-day cap.
+      expect(api.getAtwTemperatures).toHaveBeenCalledTimes(10)
       expect(api.getAtwTemperatures).toHaveBeenNthCalledWith(1, 'atw-1', {
         from: '2026-03-01T00:00:00Z',
-        period: 'Weekly',
-        to: '2026-03-31T00:00:00Z',
+        period: 'Hourly',
+        to: '2026-03-08T00:00:00Z',
       })
-      expect(api.getAtwTemperatures).toHaveBeenNthCalledWith(3, 'atw-1', {
-        from: '2026-04-30T00:00:00Z',
-        period: 'Weekly',
+      expect(api.getAtwTemperatures).toHaveBeenNthCalledWith(10, 'atw-1', {
+        from: '2026-05-03T00:00:00Z',
+        period: 'Hourly',
         to: '2026-05-09T00:00:00Z',
       })
+      expect(api.getAtwInternalTemperatures).toHaveBeenCalledTimes(3)
+      expect(api.getAtwInternalTemperatures).toHaveBeenNthCalledWith(
+        1,
+        'atw-1',
+        {
+          from: '2026-03-01T00:00:00Z',
+          period: 'Weekly',
+          to: '2026-03-31T00:00:00Z',
+        },
+      )
       // Identical chunk payloads merge to one deduplicated series.
       expect(value.series).toHaveLength(1)
     })
@@ -623,7 +634,7 @@ describe('home device atw facade', () => {
       vi.mocked(api.getAtwTemperatures)
         .mockResolvedValueOnce(ok([comfortReport]))
         .mockResolvedValueOnce(cast(failure))
-        .mockResolvedValueOnce(ok([comfortReport]))
+        .mockResolvedValue(ok([comfortReport]))
       vi.mocked(api.getAtwInternalTemperatures).mockResolvedValue(ok([]))
       const facade = new HomeDeviceAtwFacade(api, createModel())
 


### PR DESCRIPTION
On-device report from Olivier (screenshots): at 21 days the temperature chart's mode bands stop dead around day 6 while the 4-day view shows daily activity.

Probed live (`scripts/probe-weekly-annotations.ts`, read-only, committed): the BFF truncates **labeled** comfort-graph annotations at period `Weekly` — a 21-day Weekly query returns 270 spans ending `2026-07-04T17:01` (exactly the screenshot's cliff), while the same window in 7-day `Hourly` chunks returns 472 spans through `2026-07-18`; at 30 days Weekly it's worse (spans end `06-30`). This also silently deflated the operation-modes pie (`Stop`-inflated) on every window wider than 7 days.

Fix:
- `fetchHomeReportChunks`/`splitHomeReportWindow` accept a chunk-span cap; the annotation consumers (ATW temperature bands, operation-modes pie) chunk at `MAX_ANNOTATION_CHUNK_DAYS = 7`, keeping every request on the faithful `Hourly` period. The internal-temperatures report (no labeled annotations) keeps the 30-day cap.
- Chunk fan-outs are batched 6 requests at a time (a year at the 7-day cap is 53 chunks — too many for one burst), recursive shape per the codebase's loop-free sequential convention, failed batch short-circuits the rest.

Suite: 906 tests, 100% coverage, lint/format/typecheck/build clean. Version 42.0.3, changelog updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)