### PR TITLE
fix: 42.0.4 — band load budget for wide Home ATW temperature windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [42.0.4] - 2026-07-19
+
+### Fixed
+
+- The Home ATW temperature chart stopped loading at 30 days and wider: each 7-day `Hourly` comfort-graph call costs ~9 seconds at the BFF regardless of concurrency (probed via `scripts/probe-report-load.ts`: wall 9.0-9.9 s for 3, 5 and 9 parallel chunks alike), so windows needing several batches outlive the widget's 10-second budget. Mode bands now chart up to 21 days (one batch); wider temperature windows fall back to the fast Weekly sampling with the annotations dropped — the Weekly wire truncates them anyway.
+- Chunk batches widened from 6 to 16 parallel requests (the BFF absorbs at least 10 with no wall-clock penalty), keeping a 90-day operation-modes pie on a single ~10-second batch, and the pie now drops each chunk's minute-grained sample payload before merging (it only reads the annotations), sparing the host's constrained heap.
+
 ## [42.0.3] - 2026-07-19
 
 ### Fixed
@@ -282,6 +289,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[42.0.4]: https://github.com/OlivierZal/melcloud-api/compare/42.0.3...42.0.4
 [42.0.3]: https://github.com/OlivierZal/melcloud-api/compare/42.0.2...42.0.3
 [42.0.2]: https://github.com/OlivierZal/melcloud-api/compare/42.0.1...42.0.2
 [42.0.1]: https://github.com/OlivierZal/melcloud-api/compare/42.0.0...42.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.0.3",
+  "version": "42.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "42.0.3",
+      "version": "42.0.4",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.0.3",
+  "version": "42.0.4",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/facades/home-device-atw.ts
+++ b/src/facades/home-device-atw.ts
@@ -34,6 +34,7 @@ import {
   resolveHomeDayWindow,
   resolveHomeHourWindow,
   resolveHomeReportWindow,
+  shouldChartHomeBands,
   toHomeEnergyBucketUnit,
   toHomeEnergyOptions,
   toHomeLineOptions,
@@ -464,7 +465,14 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
     const window = resolveHomeReportWindow(query, this.chartTimezone)
     return mapResult(
       await fetchHomeReportChunks(
-        async (params) => this.api.getAtwTemperatures(this.id, params),
+        async (params) =>
+          mapResult(
+            await this.api.getAtwTemperatures(this.id, params),
+            // The pie only reads the annotations: drop each chunk's
+            // minute-grained sample payload before the merge piles
+            // them up on the host's constrained heap.
+            (reports) => reports.map((report) => ({ ...report, datasets: [] })),
+          ),
         window,
         MAX_ANNOTATION_CHUNK_DAYS,
       ),
@@ -543,17 +551,21 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
   // both merge the comfort-graph (room/set/outside + mode annotations)
   // with the internal-temperatures report (flow/return/tank), only the
   // window and grid resolution differ. Comfort-graph first so its tank
-  // series wins the dedup and the band annotations are present.
+  // series wins the dedup and the band annotations are present. Beyond
+  // the band load budget the comfort-graph falls back to the fast
+  // Weekly chunking and the annotations are dropped — the Weekly wire
+  // truncates them anyway, and a truncated band reads as a lie.
   async #fetchTemperatureChart(
     window: HomeChartWindow,
     gridUnit?: HomeChartGridUnit,
     cutoff?: Temporal.ZonedDateTime,
   ): Promise<Result<ReportChartLineOptions>> {
+    const shouldChartBands = shouldChartHomeBands(window)
     const [comfort, internal] = await Promise.all([
       fetchHomeReportChunks(
         async (params) => this.api.getAtwTemperatures(this.id, params),
         window,
-        MAX_ANNOTATION_CHUNK_DAYS,
+        shouldChartBands ? MAX_ANNOTATION_CHUNK_DAYS : undefined,
       ),
       fetchHomeReportChunks(
         async (params) => this.api.getAtwInternalTemperatures(this.id, params),
@@ -566,12 +578,16 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
     if (!internal.ok) {
       return internal
     }
+    const reports = [...comfort.value, ...internal.value]
     return ok(
       toHomeLineOptions({
         ...(gridUnit !== undefined && { gridUnit }),
         cutoff,
         locale: this.api.locale,
-        reports: [...comfort.value, ...internal.value],
+        reports:
+          shouldChartBands ? reports : (
+            reports.map((report) => ({ ...report, annotations: [] }))
+          ),
         unit: TEMPERATURE_UNIT,
         window,
       }),

--- a/src/facades/home-report.ts
+++ b/src/facades/home-report.ts
@@ -49,8 +49,25 @@ export const MAX_REPORT_CHUNK_DAYS = 30
 // the Hourly-period span.
 export const MAX_ANNOTATION_CHUNK_DAYS = 7
 
+// Each 7-day Hourly comfort-graph call costs ~9 s at the BFF whatever
+// the concurrency (probed 2026-07-19, `scripts/probe-report-load.ts`:
+// wall 9.0-9.9 s for 3, 5 and 9 parallel chunks alike), so wide
+// temperature windows outlive the widget's 10-second init budget.
+// Mode bands stay where a single batch covers the window; wider
+// temperature charts skip them and fetch fast Weekly samples instead.
+export const MAX_BAND_WINDOW_DAYS = 21
+
 const windowDaysOf = (window: HomeChartWindow): number =>
   window.from.until(window.to).total({ relativeTo: window.from, unit: 'days' })
+
+/**
+ * Whether a temperature-chart window is narrow enough to carry the
+ * operation-mode bands (see {@link MAX_BAND_WINDOW_DAYS}).
+ * @param window - Resolved chart window.
+ * @returns `true` when the bands fit the load budget.
+ */
+export const shouldChartHomeBands = (window: HomeChartWindow): boolean =>
+  windowDaysOf(window) <= MAX_BAND_WINDOW_DAYS
 
 /**
  * Aggregation period for one report request: minute-grained `Hourly`
@@ -153,10 +170,13 @@ export const mergeHomeReportChunks = (
 }
 
 // A year at the 7-day annotation cap is 53 requests — too many for
-// one parallel burst. Batches run this many chunks at a time; the
-// recursive shape (over a loop) keeps the batch sequencing loop-free,
-// and a failed batch short-circuits the remainder.
-const MAX_PARALLEL_CHUNKS = 6
+// one parallel burst — but batches must stay wide: the BFF absorbs at
+// least 10 parallel report calls with no wall-clock penalty (probed
+// 2026-07-19, `scripts/probe-report-load.ts`) while every extra batch
+// costs ~9 s. Batches run this many chunks at a time; the recursive
+// shape (over a loop) keeps the batch sequencing loop-free, and a
+// failed batch short-circuits the remainder.
+const MAX_PARALLEL_CHUNKS = 16
 
 const fetchChunkBatches = async (
   fetch: (chunk: HomeChartWindow) => Promise<Result<HomeReportData[]>>,

--- a/tests/unit/home-device-atw-facade.test.ts
+++ b/tests/unit/home-device-atw-facade.test.ts
@@ -600,32 +600,47 @@ describe('home device atw facade', () => {
         }),
       )
 
-      // 69 days: the annotation-bearing comfort-graph chunks at the
-      // 7-day cap (Weekly truncates the mode annotations), Hourly
-      // period throughout; the internal report keeps the 30-day cap.
-      expect(api.getAtwTemperatures).toHaveBeenCalledTimes(10)
+      // 69 days sits beyond the band load budget: the comfort-graph
+      // falls back to the fast 30-day Weekly chunking and the
+      // truncated annotations are dropped instead of charted.
+      expect(api.getAtwTemperatures).toHaveBeenCalledTimes(3)
       expect(api.getAtwTemperatures).toHaveBeenNthCalledWith(1, 'atw-1', {
         from: '2026-03-01T00:00:00Z',
-        period: 'Hourly',
-        to: '2026-03-08T00:00:00Z',
+        period: 'Weekly',
+        to: '2026-03-31T00:00:00Z',
       })
-      expect(api.getAtwTemperatures).toHaveBeenNthCalledWith(10, 'atw-1', {
-        from: '2026-05-03T00:00:00Z',
-        period: 'Hourly',
+      expect(api.getAtwTemperatures).toHaveBeenNthCalledWith(3, 'atw-1', {
+        from: '2026-04-30T00:00:00Z',
+        period: 'Weekly',
         to: '2026-05-09T00:00:00Z',
       })
-      expect(api.getAtwInternalTemperatures).toHaveBeenCalledTimes(3)
-      expect(api.getAtwInternalTemperatures).toHaveBeenNthCalledWith(
-        1,
-        'atw-1',
-        {
-          from: '2026-03-01T00:00:00Z',
-          period: 'Weekly',
-          to: '2026-03-31T00:00:00Z',
-        },
-      )
+      expect(value.bands).toBeUndefined()
       // Identical chunk payloads merge to one deduplicated series.
       expect(value.series).toHaveLength(1)
+    })
+
+    it('chunks a band-bearing window at the annotation cap', async () => {
+      const api = createApi()
+      vi.mocked(api.getAtwTemperatures).mockResolvedValue(ok([comfortReport]))
+      vi.mocked(api.getAtwInternalTemperatures).mockResolvedValue(ok([]))
+      const facade = new HomeDeviceAtwFacade(api, createModel())
+
+      const value = okValue(
+        await facade.getTemperatures({
+          from: '2026-04-25T00:00:00Z',
+          to: '2026-05-10T00:00:00Z',
+        }),
+      )
+
+      // 15 days fits the band budget: 7-day Hourly comfort chunks, the
+      // mode annotations chart as bands.
+      expect(api.getAtwTemperatures).toHaveBeenCalledTimes(3)
+      expect(api.getAtwTemperatures).toHaveBeenNthCalledWith(1, 'atw-1', {
+        from: '2026-04-25T00:00:00Z',
+        period: 'Hourly',
+        to: '2026-05-02T00:00:00Z',
+      })
+      expect(value.bands).toBeDefined()
     })
 
     it('propagates a chunk failure untouched', async () => {


### PR DESCRIPTION
On-device report from Olivier: the Home ATW temperature chart (with mode bands) stops loading at 30 days and wider; 21 days still loads.

Probed (`scripts/probe-report-load.ts`, committed): each 7-day `Hourly` comfort-graph call costs **~9 s at the BFF regardless of concurrency** — wall 9.0/9.9/9.9 s for 3, 5 and 9 parallel chunks (371/505/899 KiB). The widget's init budget is 10 s: one batch fits (barely), two don't. The bottleneck is BFF latency, not Homey memory.

Per Olivier's call («on peut peut-être skip les operation modes sur le graphique»):
- **Mode bands chart up to `MAX_BAND_WINDOW_DAYS = 21`** (one batch, his proven-working width). Wider temperature windows fall back to the fast 30-day Weekly chunking with annotations dropped — the Weekly wire truncates them anyway, and a truncated band reads as a lie. The widget hides the band legend automatically (`bands` absent).
- **Batches widen 6 → 16** (the BFF absorbs ≥10 parallel calls with zero wall penalty), keeping the 90-day operation-modes pie on a single ~10 s batch.
- **The pie drops each chunk's minute-grained datasets before merging** — it only reads annotations; no reason to pile 20k+ sample points on the Homey heap.

Suite: 907 tests, 100% coverage, lint/format/typecheck/build clean. Version 42.0.4, changelog updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)