### PR TITLE
fix: 42.0.5 — mode bands only within the hourly grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [42.0.5] - 2026-07-19
+
+### Fixed
+
+- Mode bands now chart only within the hourly grid (7 days): on the daily grid of wider windows every burst rounded up to a full-day rectangle and the stacked translucent rectangles read as one solid dark wall that matched no legend swatch (on-device 14-day symptom). The single-chunk band window also ends the on-device load lottery that had reached 21 days; wider temperature charts keep the fast Weekly sampling without annotations.
+
 ## [42.0.4] - 2026-07-19
 
 ### Fixed
@@ -289,6 +295,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[42.0.5]: https://github.com/OlivierZal/melcloud-api/compare/42.0.4...42.0.5
 [42.0.4]: https://github.com/OlivierZal/melcloud-api/compare/42.0.3...42.0.4
 [42.0.3]: https://github.com/OlivierZal/melcloud-api/compare/42.0.2...42.0.3
 [42.0.2]: https://github.com/OlivierZal/melcloud-api/compare/42.0.1...42.0.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.0.4",
+  "version": "42.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "42.0.4",
+      "version": "42.0.5",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.0.4",
+  "version": "42.0.5",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/facades/home-device-atw.ts
+++ b/src/facades/home-device-atw.ts
@@ -552,9 +552,9 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
   // with the internal-temperatures report (flow/return/tank), only the
   // window and grid resolution differ. Comfort-graph first so its tank
   // series wins the dedup and the band annotations are present. Beyond
-  // the band load budget the comfort-graph falls back to the fast
-  // Weekly chunking and the annotations are dropped — the Weekly wire
-  // truncates them anyway, and a truncated band reads as a lie.
+  // the band window (the hourly grid) the annotations are dropped —
+  // a daily grid inflates them into a solid wall, and the Weekly wire
+  // truncates them anyway.
   async #fetchTemperatureChart(
     window: HomeChartWindow,
     gridUnit?: HomeChartGridUnit,
@@ -565,7 +565,6 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
       fetchHomeReportChunks(
         async (params) => this.api.getAtwTemperatures(this.id, params),
         window,
-        shouldChartBands ? MAX_ANNOTATION_CHUNK_DAYS : undefined,
       ),
       fetchHomeReportChunks(
         async (params) => this.api.getAtwInternalTemperatures(this.id, params),

--- a/src/facades/home-report.ts
+++ b/src/facades/home-report.ts
@@ -49,13 +49,15 @@ export const MAX_REPORT_CHUNK_DAYS = 30
 // the Hourly-period span.
 export const MAX_ANNOTATION_CHUNK_DAYS = 7
 
-// Each 7-day Hourly comfort-graph call costs ~9 s at the BFF whatever
-// the concurrency (probed 2026-07-19, `scripts/probe-report-load.ts`:
-// wall 9.0-9.9 s for 3, 5 and 9 parallel chunks alike), so wide
-// temperature windows outlive the widget's 10-second init budget.
-// Mode bands stay where a single batch covers the window; wider
-// temperature charts skip them and fetch fast Weekly samples instead.
-export const MAX_BAND_WINDOW_DAYS = 21
+// Mode bands only make sense on the hourly grid: a daily grid rounds
+// every burst up to a full-day rectangle and the stacked translucent
+// rectangles read as one solid dark wall (on-device 14-day symptom).
+// The cap doubles as the load budget — each 7-day Hourly comfort-graph
+// call costs ~9 s at the BFF whatever the concurrency (probed
+// 2026-07-19, `scripts/probe-report-load.ts`), so a band-bearing
+// window stays a single chunk. Wider temperature charts fetch fast
+// Weekly samples without annotations instead.
+export const MAX_BAND_WINDOW_DAYS = 7
 
 const windowDaysOf = (window: HomeChartWindow): number =>
   window.from.until(window.to).total({ relativeTo: window.from, unit: 'days' })

--- a/tests/unit/home-device-atw-facade.test.ts
+++ b/tests/unit/home-device-atw-facade.test.ts
@@ -619,7 +619,7 @@ describe('home device atw facade', () => {
       expect(value.series).toHaveLength(1)
     })
 
-    it('chunks a band-bearing window at the annotation cap', async () => {
+    it('drops the bands just beyond the hourly grid', async () => {
       const api = createApi()
       vi.mocked(api.getAtwTemperatures).mockResolvedValue(ok([comfortReport]))
       vi.mocked(api.getAtwInternalTemperatures).mockResolvedValue(ok([]))
@@ -632,15 +632,15 @@ describe('home device atw facade', () => {
         }),
       )
 
-      // 15 days fits the band budget: 7-day Hourly comfort chunks, the
-      // mode annotations chart as bands.
-      expect(api.getAtwTemperatures).toHaveBeenCalledTimes(3)
-      expect(api.getAtwTemperatures).toHaveBeenNthCalledWith(1, 'atw-1', {
+      // 15 days renders on a daily grid, where bands inflate into a
+      // solid wall: one fast Weekly call, annotations dropped.
+      expect(api.getAtwTemperatures).toHaveBeenCalledTimes(1)
+      expect(api.getAtwTemperatures).toHaveBeenCalledWith('atw-1', {
         from: '2026-04-25T00:00:00Z',
-        period: 'Hourly',
-        to: '2026-05-02T00:00:00Z',
+        period: 'Weekly',
+        to: '2026-05-10T00:00:00Z',
       })
-      expect(value.bands).toBeDefined()
+      expect(value.bands).toBeUndefined()
     })
 
     it('propagates a chunk failure untouched', async () => {


### PR DESCRIPTION
On-device follow-up from Olivier (screenshots): 21 days now blocks too, and 14 days renders the bands as a continuous dark-blue wall matching no legend swatch, while 4 and 7 days look right.

Both symptoms share one cause pair:
- **Grid inflation**: beyond 7 days the chart grid is daily; `floorGridIndex` rounds every short mode burst up to a full-day rectangle, and dozens of stacked `rgba(…, 0.2)` rectangles compose into an opaque dark wall («bleu foncé inconnu» — alpha stacking of the Cooling hue).
- **Load lottery**: each 7-day Hourly comfort-graph call costs ~9 s at the BFF (probed in #1613), so the 3-chunk 21-day window keeps crossing the on-device budget.

Fix: `MAX_BAND_WINDOW_DAYS` drops to **7** — bands chart only where the grid is hourly (their faithful rendering, per the 4/7-day screenshots) and the band-bearing fetch is a single chunk. Wider temperature windows keep the fast Weekly sampling with annotations dropped. The operation-modes pie is untouched (no grid — it keeps its faithful 7-day Hourly chunks).

Suite: 907 tests, 100% coverage, lint/format/typecheck/build clean. Version 42.0.5, changelog updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)