### PR TITLE
fix: 42.0.6 — persist the login backoff across host restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [42.0.6] - 2026-07-19
+
+### Fixed
+
+- The automatic login backoff now persists its deadline through the `SettingManager`: it lived in memory only, so every host restart re-attempted a rejected sign-in immediately — field diagnostics showed four rejected Cognito sign-ins within 70 seconds across app restarts, each freshly created instance re-attempting despite the announced 15-minute pause (MELCloud throttles logins aggressively, so the hammering keeps a lockout alive). An explicit `authenticate()` — the user re-submitting credentials — still bypasses the gate and clears the persisted deadline on success; a corrupt persisted value reads as "no pause".
+
 ## [42.0.5] - 2026-07-19
 
 ### Fixed
@@ -295,6 +301,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[42.0.6]: https://github.com/OlivierZal/melcloud-api/compare/42.0.5...42.0.6
 [42.0.5]: https://github.com/OlivierZal/melcloud-api/compare/42.0.4...42.0.5
 [42.0.4]: https://github.com/OlivierZal/melcloud-api/compare/42.0.3...42.0.4
 [42.0.3]: https://github.com/OlivierZal/melcloud-api/compare/42.0.2...42.0.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.0.5",
+  "version": "42.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "42.0.5",
+      "version": "42.0.6",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.0.5",
+  "version": "42.0.6",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -119,9 +119,13 @@ const DEFAULT_AUTH_RETRY_COOLDOWN_MS = 1000
 // endpoint keeps a lockout alive. Transport failures do not arm it (the
 // normal retry paths handle those); an explicit `authenticate()` — the
 // user re-submitting credentials — bypasses the gate and resets it on
-// success.
+// success. The deadline persists through the SettingManager so host
+// restarts respect it too — field diagnostics showed four rejected
+// Cognito sign-ins within 70 seconds across app restarts, each fresh
+// instance re-attempting despite the announced pause.
 const LOGIN_BACKOFF_FAILURE_MS = 900_000
 const LOGIN_BACKOFF_THROTTLE_MS = 7_200_000
+const LOGIN_BACKOFF_SETTING_KEY = 'loginBackoffUntil'
 
 /**
  * Subclass-internal options injected into the {@link BaseAPI}
@@ -342,7 +346,7 @@ export abstract class BaseAPI implements Disposable {
       this.#armLoginBackoff(error)
       throw error
     }
-    this.#loginBackoffUntil = null
+    this.#setLoginBackoffUntil(null)
     await this.syncRegistry()
   }
 
@@ -680,8 +684,9 @@ export abstract class BaseAPI implements Disposable {
       error instanceof AuthenticationThrottledError ?
         LOGIN_BACKOFF_THROTTLE_MS
       : LOGIN_BACKOFF_FAILURE_MS
-    this.#loginBackoffUntil =
-      Temporal.Now.instant().epochMilliseconds + backoffMs
+    this.#setLoginBackoffUntil(
+      Temporal.Now.instant().epochMilliseconds + backoffMs,
+    )
     this.logger.error(
       `Automatic sign-ins paused for ${String(Math.round(backoffMs / MS_PER_MINUTE))} minutes after a rejected login`,
     )
@@ -755,10 +760,20 @@ export abstract class BaseAPI implements Disposable {
   }
 
   #isLoginBackedOff(): boolean {
-    return (
-      this.#loginBackoffUntil !== null &&
-      Temporal.Now.instant().epochMilliseconds < this.#loginBackoffUntil
-    )
+    const until = this.#loginBackoffUntil ?? this.#persistedLoginBackoffUntil()
+    return until !== null && Temporal.Now.instant().epochMilliseconds < until
+  }
+
+  // The persisted deadline covers instances created after a host
+  // restart; the in-memory field wins once this instance armed or
+  // cleared the gate itself.
+  #persistedLoginBackoffUntil(): number | null {
+    const raw = this.settingManager?.get(LOGIN_BACKOFF_SETTING_KEY) ?? ''
+    if (raw === '') {
+      return null
+    }
+    const until = Number(raw)
+    return Number.isFinite(until) ? until : null
   }
 
   async #runWithEvents<T>(
@@ -783,6 +798,16 @@ export abstract class BaseAPI implements Disposable {
       })
       throw error
     }
+  }
+
+  // `''` marks a cleared gate: the SettingManager contract has no
+  // delete operation.
+  #setLoginBackoffUntil(until: number | null): void {
+    this.#loginBackoffUntil = until
+    this.settingManager?.set(
+      LOGIN_BACKOFF_SETTING_KEY,
+      until === null ? '' : String(until),
+    )
   }
 
   private resolvePersistedCredentials(): LoginCredentials | null {

--- a/tests/unit/base-api.test.ts
+++ b/tests/unit/base-api.test.ts
@@ -977,6 +977,81 @@ describe('automatic login backoff', () => {
     expect(api.doAuthenticateMock).toHaveBeenCalledTimes(2)
   })
 
+  it('honours a persisted pause on a fresh instance', async () => {
+    vi.useFakeTimers()
+    mockTemporalNowInstant()
+    try {
+      const { settingManager } = createSettingStore({
+        password: 'p',
+        username: 'u',
+      })
+      const first = new TestAPI({ settingManager })
+      first.doAuthenticateMock.mockRejectedValue(new AuthenticationError('bad'))
+
+      await expect(
+        first.authenticate({ password: 'p', username: 'u' }),
+      ).rejects.toThrow('bad')
+
+      // A host restart creates a fresh instance over the same store:
+      // the persisted deadline keeps gating automatic sign-ins.
+      const second = new TestAPI({ settingManager })
+
+      await expect(second.resumeSession()).resolves.toBe(false)
+      expect(second.doAuthenticateMock).not.toHaveBeenCalled()
+
+      // Past the deadline the fresh instance signs in again (its
+      // default mock accepts the credentials).
+      vi.advanceTimersByTime(900_001)
+
+      await expect(second.resumeSession()).resolves.toBe(true)
+      expect(second.doAuthenticateMock).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores a corrupt persisted pause value', async () => {
+    const api = new TestAPI({
+      settingManager: createSettingStore({
+        loginBackoffUntil: 'garbage',
+        password: 'p',
+        username: 'u',
+      }).settingManager,
+    })
+
+    await expect(api.resumeSession()).resolves.toBe(true)
+
+    expect(api.doAuthenticateMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears the persisted pause on a successful explicit sign-in', async () => {
+    vi.useFakeTimers()
+    mockTemporalNowInstant()
+    try {
+      const { settingManager } = createSettingStore({
+        password: 'p',
+        username: 'u',
+      })
+      const first = new TestAPI({ settingManager })
+      first.doAuthenticateMock.mockRejectedValueOnce(
+        new AuthenticationError('bad'),
+      )
+
+      await expect(
+        first.authenticate({ password: 'p', username: 'u' }),
+      ).rejects.toThrow('bad')
+
+      await first.authenticate({ password: 'right', username: 'u' })
+
+      const second = new TestAPI({ settingManager })
+      await second.resumeSession()
+
+      expect(second.doAuthenticateMock).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('lets an explicit sign-in through and clears the gate on success', async () => {
     vi.useFakeTimers()
     mockTemporalNowInstant()


### PR DESCRIPTION
Field diagnostics from a store user (v45.6.1, Home account rejected by Cognito — the automated OIDC flow lands back on the login page, so their credentials need re-entering):

```
08:35:39 Automatic sign-ins paused for 15 minutes after a rejected login
08:36:18 Automatic sign-ins paused for 15 minutes after a rejected login
08:36:34.335 Automatic sign-ins paused … / .336 Session resume failed (via initialize → resumeSession)
08:36:46 Automatic sign-ins paused for 15 minutes after a rejected login
```

Four real Cognito attempts in 70 seconds despite the announced pause. Every automatic path (`ensureSession`, reactive-401 `reauthenticate`, `resumeSession`) checks the gate — but the gate lived **in memory**: each app restart (the `initialize → resumeSession` stack proves fresh instances) started with a clean `#loginBackoffUntil` and re-attempted immediately. MELCloud throttles logins aggressively, so the restart hammering keeps a lockout alive.

Fix: the deadline round-trips through the `SettingManager` (`loginBackoffUntil` key; `''` marks a cleared gate — the contract has no delete). Fresh instances honour the persisted pause; an explicit `authenticate()` — the user re-submitting credentials — still bypasses the gate and clears it on success; a corrupt persisted value reads as "no pause".

Suite: 910 tests, 100% coverage, lint/format/typecheck/build clean. Version 42.0.6, changelog updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)