### PR TITLE
feat: public logOut() to clear session, credentials and registry (42.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [42.1.0] - 2026-07-19
+
+### Added
+
+- Public `logOut()` on the API clients — the inverse of `authenticate()`. In one owned, tested place it clears the persisted session (tokens/context/expiry), the stored username/password and the automatic-login backoff, stops the auto-sync timer, and empties the device/building registry, so `isAuthenticated()` reads `false` and no stale devices linger — identically on Classic and Home. User-initiated, so it neither arms the login backoff nor emits `onAuthenticationLost`. Downstream hosts should call this instead of deleting the SDK's persisted setting keys directly (which drifted per API: Classic de-authed immediately on the live `contextKey` read, while Home kept an in-memory `#user` until a later request happened to 401).
+
 ## [42.0.6] - 2026-07-19
 
 ### Fixed
@@ -301,6 +307,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[42.1.0]: https://github.com/OlivierZal/melcloud-api/compare/42.0.6...42.1.0
 [42.0.6]: https://github.com/OlivierZal/melcloud-api/compare/42.0.5...42.0.6
 [42.0.5]: https://github.com/OlivierZal/melcloud-api/compare/42.0.4...42.0.5
 [42.0.4]: https://github.com/OlivierZal/melcloud-api/compare/42.0.3...42.0.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.0.6",
+  "version": "42.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "42.0.6",
+      "version": "42.1.0",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.0.6",
+  "version": "42.1.0",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -257,14 +257,22 @@ export abstract class BaseAPI implements Disposable {
    * Subclass hook: clear every persisted session credential (tokens,
    * context keys, expiry — whatever the API persists). Ownership is
    * deliberately narrow: the base {@link authenticate} template wipes
-   * before an explicit login, and the reactive-401 path
+   * before an explicit login, the reactive-401 path
    * ({@link reauthenticate}) wipes after the server rejected the
-   * credential. Nothing else may clear — in particular the
-   * {@link tryReuseSession} probe, where a transient failure is
-   * indistinguishable from a rejection and must leave the session
-   * untouched.
+   * credential, and {@link logOut} wipes on an explicit sign-out.
+   * Nothing else may clear — in particular the {@link tryReuseSession}
+   * probe, where a transient failure is indistinguishable from a
+   * rejection and must leave the session untouched.
    */
   protected abstract clearPersistedSession(): void
+
+  /**
+   * Subclass hook: empty the device/building registry so a logged-out
+   * instance exposes no stale devices. Implemented by syncing the
+   * registry collections with empty data (the upsert + prune removes
+   * every entry).
+   */
+  protected abstract clearRegistry(): void
 
   protected abstract doAuthenticate(
     credentials: LoginCredentials,
@@ -381,6 +389,26 @@ export abstract class BaseAPI implements Disposable {
     if (!(await this.resumeSession()) && this.#hasRecoverableState()) {
       this.#emitAuthenticationLostOnce()
     }
+  }
+
+  /**
+   * Log out: the inverse of {@link authenticate}. Clears the persisted
+   * session (tokens/context/expiry), the stored username/password and
+   * the automatic-login backoff, stops the auto-sync timer, and empties
+   * the registry — so {@link isAuthenticated} reads `false` and no
+   * stale devices linger, identically on Classic and Home.
+   *
+   * User-initiated, so unlike a rejected sign-in it neither arms the
+   * backoff nor emits `onAuthenticationLost`. A subsequent
+   * {@link authenticate} is the only way back in.
+   */
+  public logOut(): void {
+    this.clearPersistedSession()
+    this.username = ''
+    this.password = ''
+    this.#setLoginBackoffUntil(null)
+    this.clearSync()
+    this.clearRegistry()
   }
 
   /**

--- a/src/api/classic.ts
+++ b/src/api/classic.ts
@@ -649,6 +649,13 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
     this.expiry = ''
   }
 
+  protected override clearRegistry(): void {
+    this.#registry.syncDevices([])
+    this.#registry.syncAreas([])
+    this.#registry.syncFloors([])
+    this.#registry.syncBuildings([])
+  }
+
   protected override async doAuthenticate({
     password,
     username,

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -503,6 +503,10 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
     this.expiry = ''
   }
 
+  protected override clearRegistry(): void {
+    this.#registry.sync([])
+  }
+
   protected override async doAuthenticate({
     password,
     username,

--- a/tests/unit/base-api.test.ts
+++ b/tests/unit/base-api.test.ts
@@ -55,6 +55,8 @@ const { client: mockHttpClient, requestSpy: mockRequest } =
 class TestAPI extends BaseAPI {
   public readonly clearPersistedSessionMock = vi.fn<() => void>()
 
+  public readonly clearRegistryMock = vi.fn<() => void>()
+
   public readonly doAuthenticateMock = vi.fn<() => Promise<void>>()
 
   public readonly getAuthHeadersMock = vi.fn<() => Record<string, string>>()
@@ -138,6 +140,10 @@ class TestAPI extends BaseAPI {
 
   protected override clearPersistedSession(): void {
     this.clearPersistedSessionMock()
+  }
+
+  protected override clearRegistry(): void {
+    this.clearRegistryMock()
   }
 
   protected override async doAuthenticate(): Promise<void> {
@@ -1075,6 +1081,62 @@ describe('automatic login backoff', () => {
       await api.resumeSession()
 
       expect(api.doAuthenticateMock).toHaveBeenCalledTimes(3)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('logOut', () => {
+  it('clears session, credentials, backoff and registry', () => {
+    const { settingManager } = createSettingStore({
+      loginBackoffUntil: '123',
+      password: 'p',
+      username: 'u',
+    })
+    const api = new TestAPI({ settingManager })
+
+    api.logOut()
+
+    expect(api.clearPersistedSessionMock).toHaveBeenCalledTimes(1)
+    expect(api.clearRegistryMock).toHaveBeenCalledTimes(1)
+    expect(settingManager.get('username')).toBe('')
+    expect(settingManager.get('password')).toBe('')
+    expect(settingManager.get('loginBackoffUntil')).toBe('')
+  })
+
+  it('leaves nothing to resume — a later resumeSession is a no-op', async () => {
+    const { settingManager } = createSettingStore({
+      password: 'p',
+      username: 'u',
+    })
+    const api = new TestAPI({ settingManager })
+
+    api.logOut()
+
+    await expect(api.resumeSession()).resolves.toBe(false)
+    expect(api.doAuthenticateMock).not.toHaveBeenCalled()
+  })
+
+  it('clears a backoff armed by a rejected sign-in', async () => {
+    vi.useFakeTimers()
+    mockTemporalNowInstant()
+    try {
+      const { settingManager } = createSettingStore({
+        password: 'p',
+        username: 'u',
+      })
+      const api = new TestAPI({ settingManager })
+      api.doAuthenticateMock.mockRejectedValueOnce(new AuthenticationError('x'))
+
+      await expect(
+        api.authenticate({ password: 'p', username: 'u' }),
+      ).rejects.toThrow('x')
+      expect(settingManager.get('loginBackoffUntil')).not.toBe('')
+
+      api.logOut()
+
+      expect(settingManager.get('loginBackoffUntil')).toBe('')
     } finally {
       vi.useRealTimers()
     }

--- a/tests/unit/classic-api.test.ts
+++ b/tests/unit/classic-api.test.ts
@@ -531,6 +531,38 @@ describe('mELCloud Classic API', () => {
 
       expect(api.registry.devices.getById(42)?.name).toBe('Populated')
     })
+
+    it('empties the device registry and de-authenticates on logOut', async () => {
+      const building = classicBuildingWithStructure({
+        Structure: {
+          Areas: [],
+          Devices: [
+            classicRawDevice({ DeviceID: 42, DeviceName: 'Populated' }),
+          ],
+          Floors: [],
+        },
+      })
+      mockRequest.mockImplementation(async (config) => {
+        await Promise.resolve()
+        if (config.url === '/Login/ClientLogin3') {
+          return loginResponse()
+        }
+        if (config.url === '/User/ListDevices') {
+          return wrap([building])
+        }
+        return wrap({})
+      })
+      const api = await createApi()
+      await api.authenticate({ password: 'pass', username: 'user' })
+
+      expect(api.isAuthenticated()).toBe(true)
+
+      api.logOut()
+
+      expect(api.registry.getDevices()).toHaveLength(0)
+      expect(api.registry.buildings.getById(1)).toBeUndefined()
+      expect(api.isAuthenticated()).toBe(false)
+    })
   })
 
   describe('language settings', () => {

--- a/tests/unit/home-api.test.ts
+++ b/tests/unit/home-api.test.ts
@@ -602,6 +602,21 @@ describe('melcloud home API', () => {
       expect(api.context?.language).toBe('fr')
     })
 
+    it('empties the device registry and de-authenticates on logOut', async () => {
+      setupSuccessfulLogin()
+      const api = await createApi()
+      mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
+      await api.list()
+
+      expect(api.registry.getById('device-1')).toBeDefined()
+      expect(api.isAuthenticated()).toBe(true)
+
+      api.logOut()
+
+      expect(api.registry.getAll()).toHaveLength(0)
+      expect(api.isAuthenticated()).toBe(false)
+    })
+
     it('should return empty array on failure', async () => {
       setupSuccessfulLogin()
       const api = await createApi()


### PR DESCRIPTION
Adds the missing symmetric verb to the auth lifecycle: `authenticate()` (login) / `resumeSession()` / **`logOut()`** (sign-out).

**Why.** Downstream `com.melcloud`'s settings "reset credentials" button currently deletes the SDK's persisted SettingManager keys *directly from the webview* — an anti-pattern (webview reaching into melcloud-api's private persistence) with two concrete costs surfaced in an audit:
- **Drift risk:** the hardcoded key list duplicates melcloud-api's private property names + the backoff literal + the app's prefix scheme, with no shared constant or test; the next persisted-key change breaks it silently.
- **Inconsistent teardown:** because `isAuthenticated()` reads differ, the same unset de-authed **Classic** immediately (live `contextKey` read → `''`) but left **Home** reporting authenticated on an in-memory `#user` until a later request 401'd — and in both cases the auto-sync timer kept firing and the registry stayed stale until app restart.

**What.** `public logOut()` on `BaseAPI`, in one owned + tested place:
1. `clearPersistedSession()` (tokens/context/`#user`/expiry),
2. clears `username`/`password` (which `clearPersistedSession` deliberately does not),
3. resets the login backoff (`#setLoginBackoffUntil(null)`),
4. `clearSync()` (stop the timer),
5. new `clearRegistry()` hook — Classic prunes buildings/floors/areas/devices, Home `sync([])` — so `isAuthenticated()` is `false` and no stale devices linger.

User-initiated, so it neither arms the backoff nor emits `onAuthenticationLost`. Additive → **42.1.0**.

Consumed by `com.melcloud` via a new `DELETE /{api}/sessions` endpoint (that PR pins 42.1.0 and deletes its `CREDENTIAL_SETTING_KEYS` list).

Suite: 915 tests, 100% coverage (statements/branches/functions/lines), lint/format/typecheck/build clean. CLAUDE.md's `clearPersistedSession` ownership note updated to list `logOut` as the third sanctioned caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)