### PR TITLE
feat: optional SettingManager.unset so logout deletes keys (42.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [42.2.0] - 2026-07-19
+
+### Added
+
+- Optional `unset` on the `SettingManager` interface. When a host delegates it, the `@setting` decorator deletes a key outright the moment its accessor is cleared to `''` (credentials, tokens, context key, expiry), and the login-backoff key is deleted when the pause is lifted — so `logOut()` leaves no empty-string leftovers in the host's store. Purely additive: hosts that do not provide `unset` keep the previous behaviour (clearing writes `''`, which reads back as absent all the same).
+
 ## [42.1.0] - 2026-07-19
 
 ### Added
@@ -307,6 +313,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[42.2.0]: https://github.com/OlivierZal/melcloud-api/compare/42.1.0...42.2.0
 [42.1.0]: https://github.com/OlivierZal/melcloud-api/compare/42.0.6...42.1.0
 [42.0.6]: https://github.com/OlivierZal/melcloud-api/compare/42.0.5...42.0.6
 [42.0.5]: https://github.com/OlivierZal/melcloud-api/compare/42.0.4...42.0.5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.1.0",
+  "version": "42.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "42.1.0",
+      "version": "42.2.0",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.1.0",
+  "version": "42.2.0",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -828,11 +828,20 @@ export abstract class BaseAPI implements Disposable {
     }
   }
 
-  // `''` marks a cleared gate: the SettingManager contract has no
-  // delete operation.
+  // Clearing the gate deletes the key when the host delegates `unset`,
+  // else stores `''` — `#persistedLoginBackoffUntil` reads both as "no
+  // pause".
   #setLoginBackoffUntil(until: number | null): void {
     this.#loginBackoffUntil = until
-    this.settingManager?.set(
+    const { settingManager } = this
+    if (settingManager === undefined) {
+      return
+    }
+    if (until === null && settingManager.unset !== undefined) {
+      settingManager.unset(LOGIN_BACKOFF_SETTING_KEY)
+      return
+    }
+    settingManager.set(
       LOGIN_BACKOFF_SETTING_KEY,
       until === null ? '' : String(until),
     )

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -170,6 +170,12 @@ export interface SettingManager {
   readonly get: (key: string) => string | null | undefined
   /** Store a setting value by key. */
   readonly set: (key: string, value: string) => void
+  /**
+   * Delete a setting key. Optional: when a host does not provide it, the
+   * SDK clears by storing an empty string instead, which reads back as
+   * absent all the same.
+   */
+  readonly unset?: (key: string) => void
 }
 
 /**

--- a/src/decorators/setting.ts
+++ b/src/decorators/setting.ts
@@ -23,8 +23,19 @@ const setting = (
       return this.settingManager?.get(key) ?? target.get.call(this)
     },
     set(this: HasSettingManager, value: string): void {
-      if (this.settingManager !== undefined) {
-        this.settingManager.set(key, value)
+      const { settingManager } = this
+      if (settingManager !== undefined) {
+        // An empty string is the cleared sentinel for every persisted
+        // field (credentials, tokens, context key, expiry): delete the
+        // key outright when the host delegates `unset`, so a logout
+        // leaves no empty leftovers. `get` falls back to the accessor's
+        // own `''` default when the key is absent, so this reads back
+        // identically.
+        if (value === '' && settingManager.unset !== undefined) {
+          settingManager.unset(key)
+        } else {
+          settingManager.set(key, value)
+        }
         return
       }
       target.set.call(this, value)

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -99,20 +99,27 @@ export const createMockHttpClient = (
 
 export const createSettingStore = (
   initial: Record<string, string> = {},
+  { hasUnset = false }: { hasUnset?: boolean } = {},
 ): {
   setSpy: ReturnType<typeof vi.fn<(key: string, value: string) => void>>
   settingManager: SettingManager
+  unsetSpy: ReturnType<typeof vi.fn<(key: string) => void>>
 } => {
   const store = new Map(Object.entries(initial))
   const setSpy = vi.fn<(key: string, value: string) => void>((key, value) => {
     store.set(key, value)
+  })
+  const unsetSpy = vi.fn<(key: string) => void>((key) => {
+    store.delete(key)
   })
   return {
     setSpy,
     settingManager: {
       set: setSpy,
       get: (key: string) => store.get(key) ?? null,
+      ...(hasUnset && { unset: unsetSpy }),
     },
+    unsetSpy,
   }
 }
 

--- a/tests/unit/base-api.test.ts
+++ b/tests/unit/base-api.test.ts
@@ -1141,4 +1141,25 @@ describe('logOut', () => {
       vi.useRealTimers()
     }
   })
+
+  it('deletes the keys outright when the host delegates unset', () => {
+    const { settingManager, unsetSpy } = createSettingStore(
+      {
+        loginBackoffUntil: '123',
+        password: 'p',
+        username: 'u',
+      },
+      { hasUnset: true },
+    )
+    const api = new TestAPI({ settingManager })
+
+    api.logOut()
+
+    // Absent, not an empty string, and routed through `unset`.
+    expect(settingManager.get('username')).toBeNull()
+    expect(settingManager.get('password')).toBeNull()
+    expect(settingManager.get('loginBackoffUntil')).toBeNull()
+    expect(unsetSpy).toHaveBeenCalledWith('username')
+    expect(unsetSpy).toHaveBeenCalledWith('loginBackoffUntil')
+  })
 })


### PR DESCRIPTION
Follow-up to #1616 (42.1.0 `logOut()`). `logOut()` clears the persisted fields by setting the accessors to `''`, but the `SettingManager` contract had only `get`/`set` — so it could only overwrite with an empty string, never delete the Homey key. The old webview-side reset used `homey.settings.unset`, so this was a subtle regression to "empty leftovers".

This completes the delegation symmetry (`get`/`set`/**`unset`**):
- `SettingManager` gains an **optional** `unset?: (key) => void`.
- The `@setting` decorator deletes the key when the accessor is cleared to `''` (the cleared sentinel for every credential/token/context/expiry field) and a host provides `unset`; `get()` already falls back to the accessor's `''` default when a key is absent, so it reads back identically.
- The manually-persisted login-backoff key is deleted the same way when the pause is lifted.
- Fully backward-compatible: a host without `unset` keeps writing `''`.

Consumed by `com.melcloud` (its `#createSettingManager` will add `unset: (key) => homey.settings.unset(prefixKey(key))`), so a logout leaves the settings store clean.

Suite: 916 tests, 100% coverage (both the `unset`-present and `unset`-absent branches), lint/format/typecheck/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)