### PR TITLE
fix: post-churn audit — live 429/401 classification, logOut completeness, Z-tolerant Classic queries (42.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [42.3.0] - 2026-07-20
+
+### Fixed
+
+- Home sign-in refusals now classify correctly: the OIDC helper raises real `HttpError`s on non-2xx PAR/token responses, so a MELCloud Home HTTP 429 arms the 2-hour login-throttle pause (it previously surfaced as a plain `Error` and kept hammering the throttled endpoint) and transport-level 401s normalize to `AuthenticationError`.
+- `logOut()` now clears the cached Home `/context` payload, as the `context` getter always documented — a signed-out client no longer exposes the previous account's buildings and devices.
+- `logOut()` wins over async work it overlapped: a background session resume or sync cycle that completes after a sign-out can no longer resurrect the session (re-persisted tokens, repopulated registry, re-armed timer). The stale completion is detected and its state discarded.
+- Classic report queries accept Z- and offset-suffixed ISO timestamps (`new Date().toISOString()` output): instants are lowered to wall-clock in the display timezone, mirroring the Home facades, instead of throwing an uncaught `RangeError`.
+
+### Changed
+
+- The login-backoff deadline persists through the `@setting` accessor like every other persisted field (same key, data-compatible), dropping the hand-rolled get/set/unset plumbing.
+- Internal dedup: the no-op-tolerant group-write block, the day-grid enumeration, the energy interval table and the day-in-milliseconds constant each live in one place now; redundant credential re-stores in both `doAuthenticate` hooks removed.
+
 ## [42.2.0] - 2026-07-19
 
 ### Added
@@ -313,6 +327,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[42.3.0]: https://github.com/OlivierZal/melcloud-api/compare/42.2.0...42.3.0
 [42.2.0]: https://github.com/OlivierZal/melcloud-api/compare/42.1.0...42.2.0
 [42.1.0]: https://github.com/OlivierZal/melcloud-api/compare/42.0.6...42.1.0
 [42.0.6]: https://github.com/OlivierZal/melcloud-api/compare/42.0.5...42.0.6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,11 @@ is on: no runtime enums, no parameter properties, no runtime namespaces.
   assume all auth failures surface as 401 `HttpError`.
 - Wire-format types mirror the MELCloud APIs verbatim (PascalCase fields,
   one-letter report keys); do not rename them to satisfy style rules.
-- `EffectiveFlags` bitfields (`src/facades/classic-flags.ts`) are the one
-  sanctioned home of hex magic numbers and bitwise operators.
+- `EffectiveFlags` bitfields: `src/facades/classic-flags.ts` is the one
+  sanctioned home of hex magic numbers (files-scoped `no-magic-numbers`
+  off); the two bitfield operators live behind documented inline
+  `no-bitwise` disables at their use sites (`classic-update-devices.ts`
+  flag test, `classic-base-device.ts` flag accumulation).
 - The Home ATW wire speaks two dialects: `/context` settings report zone
   modes in PascalCase (`HeatCurve`, `CoolFlowTemperature`) but the PUT
   endpoint only accepts camelCase and answers a bare 400 otherwise — the

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -49,6 +49,9 @@ const typeLikeSortOptions = {
 
 const config = defineConfig([
   {
+    // `scripts/` holds one-shot wire probes committed as dated evidence
+    // artifacts (cited from CLAUDE.md), not shipped code — they stay
+    // outside the lint scope by decision, like the build outputs.
     ignores: ['coverage/', 'dist/', 'docs/', 'scripts/'],
   },
   {
@@ -762,6 +765,9 @@ const config = defineConfig([
       'unicorn/no-non-function-verb-prefix': 'error',
       // Unaware of `Symbol.dispose`.
       'unicorn/no-nonstandard-builtin-properties': 'off',
+      // The MELCloud wire speaks `null` (`LoginData: null` on rejected
+      // credentials, group "leave unchanged" sentinels) — banning null
+      // literals fights the domain.
       'unicorn/no-null': 'off',
       // Owned by `@typescript-eslint/no-unnecessary-boolean-literal-compare`.
       'unicorn/no-unnecessary-boolean-comparison': 'off',
@@ -826,6 +832,7 @@ const config = defineConfig([
   {
     files: ['*.config.ts'],
     rules: {
+      // Config loaders (eslint, vitest, typedoc) consume default exports.
       'import-x/no-default-export': 'off',
       'import-x/prefer-default-export': [
         'error',
@@ -931,6 +938,8 @@ const config = defineConfig([
       // decorator protocol rebinds `this` at call time, which an arrow
       // cannot receive.
       'unicorn/consistent-function-style': 'off',
+      // Replacement accessors/methods receive `this` through the
+      // decorator protocol — there is no class body to put it in.
       'unicorn/no-this-outside-of-class': 'off',
     },
   },
@@ -947,6 +956,8 @@ const config = defineConfig([
   {
     files: ['src/temporal.ts'],
     rules: {
+      // The sanctioned `temporal-polyfill` entry point is the one module
+      // allowed to import it.
       'no-restricted-imports': 'off',
     },
   },
@@ -954,6 +965,7 @@ const config = defineConfig([
     extends: [vitest.configs.recommended],
     files: ['tests/**/*.ts'],
     rules: {
+      // Fixtures and assertions are literal-heavy by nature.
       '@typescript-eslint/no-magic-numbers': 'off',
       // The vitest-concurrent pattern destructures the test-context
       // `expect` (required for exact assertion counts), shadowing the
@@ -967,6 +979,8 @@ const config = defineConfig([
       ],
       // Owned by `vitest/unbound-method`, the mock-aware port.
       '@typescript-eslint/unbound-method': 'off',
+      // Suites are one `describe` per function — length caps target
+      // production code, not test tables.
       'max-lines-per-function': 'off',
       'max-statements': 'off',
       // Mock builders nest factories.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.2.0",
+  "version": "42.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "42.2.0",
+      "version": "42.3.0",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.2.0",
+  "version": "42.3.0",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -125,7 +125,6 @@ const DEFAULT_AUTH_RETRY_COOLDOWN_MS = 1000
 // instance re-attempting despite the announced pause.
 const LOGIN_BACKOFF_FAILURE_MS = 900_000
 const LOGIN_BACKOFF_THROTTLE_MS = 7_200_000
-const LOGIN_BACKOFF_SETTING_KEY = 'loginBackoffUntil'
 
 /**
  * Subclass-internal options injected into the {@link BaseAPI}
@@ -179,6 +178,12 @@ export abstract class BaseAPI implements Disposable {
   @setting
   protected accessor expiry = ''
 
+  // Epoch-ms deadline before which automatic re-logins are refused;
+  // `''` means no pause. Persisted like the credentials so the gate
+  // survives a host restart.
+  @setting
+  protected accessor loginBackoffUntil = ''
+
   @setting
   protected accessor password = ''
 
@@ -199,8 +204,11 @@ export abstract class BaseAPI implements Disposable {
   // authenticated again (including the post-auth sync of a re-login).
   #hasEmittedAuthenticationLost = false
 
-  // Epoch-ms deadline before which automatic re-logins are refused.
-  #loginBackoffUntil: number | null = null
+  // Bumped by every logOut so async work that was in flight when the
+  // user signed out (a background resume, a sync cycle) can detect the
+  // sign-out on completion and discard what it stored — the explicit
+  // sign-out always wins over work it overlapped.
+  #logOutEpoch = 0
 
   readonly #rateLimitPolicy: RateLimitPolicy
 
@@ -344,6 +352,7 @@ export abstract class BaseAPI implements Disposable {
    * @throws {AuthenticationError} when credentials are rejected.
    */
   public async authenticate(credentials: LoginCredentials): Promise<void> {
+    const epoch = this.#logOutEpoch
     this.applyCredentials(credentials.username, credentials.password)
     // Explicit login starts from a clean slate — enforced here so no
     // subclass can forget it (mirrors the post-auth sync below).
@@ -354,8 +363,7 @@ export abstract class BaseAPI implements Disposable {
       this.#armLoginBackoff(error)
       throw error
     }
-    this.#setLoginBackoffUntil(null)
-    await this.syncRegistry()
+    await this.#finishLogin(epoch)
   }
 
   /** Cancels any pending auto-sync timer; subsequent `setSyncInterval` or `fetch` calls re-arm it. */
@@ -403,6 +411,7 @@ export abstract class BaseAPI implements Disposable {
    * {@link authenticate} is the only way back in.
    */
   public logOut(): void {
+    this.#logOutEpoch += 1
     this.clearPersistedSession()
     this.username = ''
     this.password = ''
@@ -628,6 +637,7 @@ export abstract class BaseAPI implements Disposable {
    * @returns The fetched entries, or an empty array on failure.
    */
   protected async runSyncCycle<T>(work: () => Promise<T[]>): Promise<T[]> {
+    const epoch = this.#logOutEpoch
     this.clearSync()
     try {
       return await work()
@@ -635,19 +645,7 @@ export abstract class BaseAPI implements Disposable {
       this.logger.error('Failed to fetch devices:', error)
       return []
     } finally {
-      if (this.isAuthenticated()) {
-        // A live session marks any earlier loss episode as recovered.
-        this.#hasEmittedAuthenticationLost = false
-        this.syncManager.planNext()
-      } else if (this.#hasRecoverableState()) {
-        // Rescheduling would hammer the account with a doomed sign-in
-        // every cycle: stay disarmed and surface the loss instead — a
-        // successful authenticate() re-arms the sync through its
-        // enforced post-auth registry sync.
-        this.#emitAuthenticationLostOnce()
-      }
-      // Unauthenticated with nothing to recover from (e.g. the settings
-      // page probing a never-configured API) stays silent AND disarmed.
+      this.#settleSyncCycle(epoch)
     }
   }
 
@@ -778,6 +776,22 @@ export abstract class BaseAPI implements Disposable {
     this.events.emitAuthenticationLost()
   }
 
+  // Post-`doAuthenticate` epilogue, split on the logOut epoch: a
+  // logOut that landed while the sign-in round-trip was in flight
+  // (e.g. the user signed out during a background resume) wins —
+  // discard what the login just stored and stay signed out. Otherwise
+  // clear the backoff gate and run the enforced post-auth sync.
+  async #finishLogin(epoch: number): Promise<void> {
+    if (this.#logOutEpoch !== epoch) {
+      this.clearPersistedSession()
+      this.username = ''
+      this.password = ''
+      return
+    }
+    this.#setLoginBackoffUntil(null)
+    await this.syncRegistry()
+  }
+
   // A loss is only a loss when there was something to restore — a
   // persisted session or persisted credentials. Probing an API that was
   // never configured must neither notify nor look like an expiry.
@@ -787,21 +801,17 @@ export abstract class BaseAPI implements Disposable {
     )
   }
 
+  // A corrupt persisted value reads as "no pause" — never lock the
+  // user out on bad data.
   #isLoginBackedOff(): boolean {
-    const until = this.#loginBackoffUntil ?? this.#persistedLoginBackoffUntil()
-    return until !== null && Temporal.Now.instant().epochMilliseconds < until
-  }
-
-  // The persisted deadline covers instances created after a host
-  // restart; the in-memory field wins once this instance armed or
-  // cleared the gate itself.
-  #persistedLoginBackoffUntil(): number | null {
-    const raw = this.settingManager?.get(LOGIN_BACKOFF_SETTING_KEY) ?? ''
+    const raw = this.loginBackoffUntil
     if (raw === '') {
-      return null
+      return false
     }
     const until = Number(raw)
-    return Number.isFinite(until) ? until : null
+    return (
+      Number.isFinite(until) && Temporal.Now.instant().epochMilliseconds < until
+    )
   }
 
   async #runWithEvents<T>(
@@ -828,23 +838,38 @@ export abstract class BaseAPI implements Disposable {
     }
   }
 
-  // Clearing the gate deletes the key when the host delegates `unset`,
-  // else stores `''` — `#persistedLoginBackoffUntil` reads both as "no
-  // pause".
+  // `''` is the cleared sentinel: the `@setting` accessor persists the
+  // value and deletes the key outright when the host delegates `unset`.
   #setLoginBackoffUntil(until: number | null): void {
-    this.#loginBackoffUntil = until
-    const { settingManager } = this
-    if (settingManager === undefined) {
+    this.loginBackoffUntil = until === null ? '' : String(until)
+  }
+
+  // Sync-cycle epilogue, split on the logOut epoch. A logOut that
+  // landed while the cycle was in flight: its request completed with
+  // the pre-sign-out session and repopulated the registry (and, on
+  // Home, the user/context) — re-run the wipe so the sign-out sticks,
+  // and leave the timer disarmed. Unauthenticated with nothing to
+  // recover from (e.g. the settings page probing a never-configured
+  // API) stays silent AND disarmed.
+  #settleSyncCycle(epoch: number): void {
+    if (this.#logOutEpoch !== epoch) {
+      this.clearPersistedSession()
+      this.clearRegistry()
       return
     }
-    if (until === null && settingManager.unset !== undefined) {
-      settingManager.unset(LOGIN_BACKOFF_SETTING_KEY)
+    if (this.isAuthenticated()) {
+      // A live session marks any earlier loss episode as recovered.
+      this.#hasEmittedAuthenticationLost = false
+      this.syncManager.planNext()
       return
     }
-    settingManager.set(
-      LOGIN_BACKOFF_SETTING_KEY,
-      until === null ? '' : String(until),
-    )
+    if (this.#hasRecoverableState()) {
+      // Rescheduling would hammer the account with a doomed sign-in
+      // every cycle: stay disarmed and surface the loss instead — a
+      // successful authenticate() re-arms the sync through its
+      // enforced post-auth registry sync.
+      this.#emitAuthenticationLostOnce()
+    }
   }
 
   private resolvePersistedCredentials(): LoginCredentials | null {

--- a/src/api/classic.ts
+++ b/src/api/classic.ts
@@ -679,8 +679,8 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
           )
         : new AuthenticationError('MELCloud Classic rejected the credentials')
     }
-    this.username = username
-    this.password = password
+    // Credentials are already persisted by `authenticate` before this
+    // hook runs; only the session artifacts are stored here.
     this.contextKey = loginData.ContextKey
     this.expiry = loginData.Expiry
   }

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -19,7 +19,7 @@ import {
   HomeRegistry,
 } from '../entities/home-registry.ts'
 import { AuthenticationThrottledError } from '../errors/index.ts'
-import { isHttpError } from '../http/index.ts'
+import { HttpStatus, isHttpError } from '../http/index.ts'
 import { isSessionExpired } from '../resilience/index.ts'
 import { Temporal } from '../temporal.ts'
 import { SESSION_REFRESH_AHEAD_MS } from '../time-units.ts'
@@ -38,7 +38,6 @@ import { performTokenAuth, refreshAccessToken } from './token-auth.ts'
 
 const API_BASE_URL = 'https://mobile.bff.melcloudhome.com'
 const ATA_UNIT_PATH = '/monitor/ataunit'
-const HTTP_TOO_MANY_REQUESTS = 429
 const ATW_UNIT_PATH = '/monitor/atwunit'
 
 /**
@@ -498,6 +497,10 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
 
   protected override clearPersistedSession(): void {
     this.#user = null
+    // The context getter promises "cleared on session invalidation":
+    // without this, a logged-out client keeps exposing the previous
+    // account's buildings and devices.
+    this.#context = null
     this.accessToken = ''
     this.refreshToken = ''
     this.expiry = ''
@@ -529,7 +532,7 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
       // propagate unchanged.
       if (
         isHttpError(error) &&
-        error.response.status === HTTP_TOO_MANY_REQUESTS
+        error.response.status === HttpStatus.TooManyRequests
       ) {
         // The BFF/Cognito login throttle — the Home mirror of Classic's
         // ErrorId 6. Valid credentials, blocked endpoint: back off.
@@ -543,7 +546,6 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
       }
       throw error
     }
-    this.applyCredentials(username, password)
   }
 
   protected getAuthHeaders(): Record<string, string> {

--- a/src/api/token-auth.ts
+++ b/src/api/token-auth.ts
@@ -4,6 +4,7 @@ import { CookieJar } from 'tough-cookie'
 
 import type { HomeTokenResponse } from '../types/index.ts'
 import { AuthenticationError } from '../errors/index.ts'
+import { HttpError } from '../http/index.ts'
 import {
   HomeParResponseSchema,
   HomeTokenResponseSchema,
@@ -102,7 +103,9 @@ const readResponseHeaders = (
 // targets (PAR, token exchange) always return JSON; parse
 // unconditionally and throw on non-2xx. Each caller is responsible
 // for narrowing the returned `unknown` (PAR via a local guard, token
-// exchange via a Zod schema).
+// exchange via a Zod schema). Non-2xx throws HttpError — not a plain
+// Error — so doAuthenticate's status classification (429 throttle,
+// 401 normalization) sees real server refusals from these endpoints.
 const fetchPostForm = async ({
   abortSignal,
   body,
@@ -118,8 +121,16 @@ const fetchPostForm = async ({
   const responseHeaders = readResponseHeaders(response.headers)
   const text = await response.text()
   if (!response.ok) {
-    throw new Error(
+    throw new HttpError(
       `Request to ${url} failed with status ${String(response.status)}`,
+      {
+        config: { method: 'POST', url },
+        response: {
+          data: text,
+          headers: responseHeaders,
+          status: response.status,
+        },
+      },
     )
   }
   return {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -66,11 +66,6 @@ export interface BaseAPIConfig extends UndefinedTolerant<LoginCredentials> {
  */
 export interface LifecycleEvents {
   /**
-   * Invoked after each sync trigger (auto-timer or
-   * `@syncDevices`-decorated mutation). Receives the device-type
-   * filter and any IDs the cascade was scoped to.
-   */
-  /**
    * Fires when a previously-available session is definitively lost:
    * the boot-time restore found persisted state but could not sign
    * in, or a sync cycle ended unauthenticated after the 401-recovery
@@ -89,6 +84,11 @@ export interface LifecycleEvents {
   readonly onRequestRetry?: ((event: RequestRetryEvent) => void) | undefined
   /** Invoked when a request is dispatched for the first time. */
   readonly onRequestStart?: ((event: RequestStartEvent) => void) | undefined
+  /**
+   * Invoked after each sync trigger (auto-timer or
+   * `@syncDevices`-decorated mutation). Receives the device-type
+   * filter and any IDs the cascade was scoped to.
+   */
   readonly onSyncComplete?: SyncCallback | undefined
 }
 

--- a/src/facades/classic-base-device.ts
+++ b/src/facades/classic-base-device.ts
@@ -133,6 +133,23 @@ const getDuration = ({ from, to }: Resolved<ReportQuery>): number =>
     smallestUnit: 'day',
   }).days
 
+// Query dates carrying an offset (`Z`, `+02:00`) pin an absolute
+// instant, lowered here to wall-clock in the display timezone — the
+// only dialect the Classic wire and the Temporal Plain types accept.
+// Zoneless strings pass through as the literal local datetimes callers
+// already feed. Mirrors the Home facades' query tolerance so the same
+// `new Date().toISOString()` output works against both APIs.
+const toWallClock = (iso: string, timezone = 'UTC'): string => {
+  try {
+    return Temporal.Instant.from(iso)
+      .toZonedDateTimeISO(timezone)
+      .toPlainDateTime()
+      .toString()
+  } catch {
+    return iso
+  }
+}
+
 /**
  * Abstract base for device-specific facades. Handles device data access, report generation,
  * value updates with effective flags, and ATA key conversion between set/list formats.
@@ -424,11 +441,16 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
     shouldUseExactRange = false,
   ): ClassicReportPostData {
     const { from = DEFAULT_YEAR, to = now(this.api.timezone) } = query
+    const fromDate = toWallClock(from, this.api.timezone)
+    const toDate = toWallClock(to, this.api.timezone)
     return {
       DeviceID: this.id,
-      Duration: shouldUseExactRange ? getDuration({ from, to }) : undefined,
-      FromDate: from,
-      ToDate: to,
+      Duration:
+        shouldUseExactRange ?
+          getDuration({ from: fromDate, to: toDate })
+        : undefined,
+      FromDate: fromDate,
+      ToDate: toDate,
     }
   }
 

--- a/src/facades/classic-device-ata.ts
+++ b/src/facades/classic-device-ata.ts
@@ -4,7 +4,6 @@ import {
   ClassicFanSpeed,
   ClassicOperationMode,
 } from '../constants.ts'
-import { NoChangesError } from '../errors/index.ts'
 import {
   type ClassicEnergyDataAta,
   type ClassicFailureData,
@@ -18,6 +17,7 @@ import { clampToRange } from '../utils.ts'
 import type { ClassicEnergyReportExtract } from './classic-types.ts'
 import { BaseDeviceFacade } from './classic-base-device.ts'
 import { classicAtaFlags } from './classic-flags.ts'
+import { tolerateNoChanges } from './home-ata-group.ts'
 
 const isSet = <T>(value: T | null | undefined): value is T =>
   value !== null && value !== undefined
@@ -117,7 +117,7 @@ export class ClassicDeviceAtaFacade extends BaseDeviceFacade<
    * path; null fields are the group "leave unchanged" sentinel and are
    * dropped from the write. Group writes are no-op tolerant: an all-null
    * state resolves without a wire call, and a device already matching the
-   * state (a {@link NoChangesError} from its update) counts as success.
+   * state counts as success ({@link tolerateNoChanges}).
    * @param state - Group state to push to the device.
    * @returns The zone-shaped success outcome once the write completes.
    */
@@ -126,15 +126,7 @@ export class ClassicDeviceAtaFacade extends BaseDeviceFacade<
   ): Promise<ClassicFailureData | ClassicSuccessData> {
     const values = toUpdateData(state)
     if (Object.keys(values).length > 0) {
-      try {
-        await this.updateValues(values)
-      } catch (error) {
-        // A device already matching the group state is fine by definition —
-        // zone group writes are no-op tolerant, so the group-of-one is too.
-        if (!(error instanceof NoChangesError)) {
-          throw error
-        }
-      }
+      await tolerateNoChanges(async () => this.updateValues(values))
     }
     return { AttributeErrors: null, Success: true }
   }

--- a/src/facades/classic-device-ata.ts
+++ b/src/facades/classic-device-ata.ts
@@ -117,7 +117,8 @@ export class ClassicDeviceAtaFacade extends BaseDeviceFacade<
    * path; null fields are the group "leave unchanged" sentinel and are
    * dropped from the write. Group writes are no-op tolerant: an all-null
    * state resolves without a wire call, and a device already matching the
-   * state counts as success ({@link tolerateNoChanges}).
+   * state (a tolerated `NoChangesError` from its update) counts as
+   * success.
    * @param state - Group state to push to the device.
    * @returns The zone-shaped success outcome once the write completes.
    */

--- a/src/facades/home-ata-group.ts
+++ b/src/facades/home-ata-group.ts
@@ -18,6 +18,7 @@ import {
   verticalFromClassic,
   verticalToClassic,
 } from '../enum-mappings.ts'
+import { NoChangesError } from '../errors/index.ts'
 
 /**
  * The facade slice the Classic group-state projection reads. Structural so
@@ -135,3 +136,22 @@ export const toHomeAtaValues = (state: ClassicGroupState): HomeAtaValues => ({
     vaneVerticalDirection: verticalFromClassic[state.VaneVerticalDirection],
   }),
 })
+
+/**
+ * Run a group-member update, counting a {@link NoChangesError} as
+ * success: a device already matching the group state is fine by
+ * definition, so zone group writes — and the group-of-one emulation —
+ * are no-op tolerant.
+ * @param update - The member update to run.
+ */
+export const tolerateNoChanges = async (
+  update: () => Promise<unknown>,
+): Promise<void> => {
+  try {
+    await update()
+  } catch (error) {
+    if (!(error instanceof NoChangesError)) {
+      throw error
+    }
+  }
+}

--- a/src/facades/home-building-ata.ts
+++ b/src/facades/home-building-ata.ts
@@ -113,8 +113,8 @@ export class HomeBuildingAtaFacade {
   /**
    * Apply a Classic group state to every member device. The delta is
    * translated to the Home vocabulary once, then fanned out; members
-   * already matching it are fine by definition and do not fail the
-   * group write ({@link tolerateNoChanges}).
+   * already matching it (a tolerated `NoChangesError` from their
+   * update) are fine by definition and do not fail the group write.
    * @param state - Partial Classic group state to push to the members.
    * @returns The zone-shaped success outcome once every write settled.
    */

--- a/src/facades/home-building-ata.ts
+++ b/src/facades/home-building-ata.ts
@@ -1,7 +1,6 @@
 import type { HomeAPIAdapter } from '../api/index.ts'
 import type { HomeDevice } from '../entities/home-device.ts'
 import { HomeDeviceType } from '../constants.ts'
-import { NoChangesError } from '../errors/index.ts'
 import {
   type ClassicFailureData,
   type ClassicGroupState,
@@ -15,6 +14,7 @@ import {
   aggregateClassicAtaGroupStates,
   toClassicAtaGroupState,
   toHomeAtaValues,
+  tolerateNoChanges,
 } from './home-ata-group.ts'
 
 /**
@@ -113,8 +113,8 @@ export class HomeBuildingAtaFacade {
   /**
    * Apply a Classic group state to every member device. The delta is
    * translated to the Home vocabulary once, then fanned out; members
-   * already matching it (a {@link NoChangesError} from their update) are
-   * fine by definition and do not fail the group write.
+   * already matching it are fine by definition and do not fail the
+   * group write ({@link tolerateNoChanges}).
    * @param state - Partial Classic group state to push to the members.
    * @returns The zone-shaped success outcome once every write settled.
    */
@@ -124,15 +124,11 @@ export class HomeBuildingAtaFacade {
     const values = toHomeAtaValues(state)
     if (Object.keys(values).length > 0) {
       await Promise.all(
-        this.devices.map(async (device) => {
-          try {
-            await this.#getFacade(device).updateValues(values)
-          } catch (error) {
-            if (!(error instanceof NoChangesError)) {
-              throw error
-            }
-          }
-        }),
+        this.devices.map(async (device) =>
+          tolerateNoChanges(async () =>
+            this.#getFacade(device).updateValues(values),
+          ),
+        ),
       )
     }
     return { AttributeErrors: null, Success: true }

--- a/src/facades/home-device-ata.ts
+++ b/src/facades/home-device-ata.ts
@@ -26,21 +26,21 @@ import {
 } from '../types/index.ts'
 import { clampToRange, omitUndefined } from '../utils.ts'
 import type { ReportChartLineOptions, ReportQuery } from './report-types.ts'
-import { toClassicAtaGroupState, toHomeAtaValues } from './home-ata-group.ts'
+import {
+  toClassicAtaGroupState,
+  toHomeAtaValues,
+  tolerateNoChanges,
+} from './home-ata-group.ts'
 import { HomeBaseDeviceFacade } from './home-base-device.ts'
 import {
   fetchHomeReportChunks,
   resolveHomeReportWindow,
   toHomeEnergyBucketUnit,
+  toHomeEnergyInterval,
   toHomeEnergyOptions,
   toHomeLineOptions,
   toHomeWireWindow,
 } from './home-report.ts'
-
-// Telemetry intervals per display bucket granularity: local-day
-// buckets aggregate hourly wire buckets client-side (the wire's own
-// day buckets are UTC days).
-const ENERGY_INTERVALS = { day: 'Day', hour: 'Hour', localDay: 'Hour' } as const
 
 // The ATA cumulative energy measure reports watt-hours (100 Wh pulses,
 // live-probed 2026-07-18: a daily bucket of `571.0` for ~0.57 kWh).
@@ -212,7 +212,7 @@ export class HomeDeviceAtaFacade extends HomeBaseDeviceFacade<HomeAtaDeviceData>
     return mapResult(
       await this.api.getAtaEnergy(this.id, {
         ...toHomeWireWindow(window),
-        interval: ENERGY_INTERVALS[bucketUnit],
+        interval: toHomeEnergyInterval(bucketUnit),
       }),
       (data) =>
         toHomeEnergyOptions({
@@ -288,15 +288,7 @@ export class HomeDeviceAtaFacade extends HomeBaseDeviceFacade<HomeAtaDeviceData>
   ): Promise<ClassicFailureData | ClassicSuccessData> {
     const values = toHomeAtaValues(state)
     if (Object.keys(values).length > 0) {
-      try {
-        await this.updateValues(values)
-      } catch (error) {
-        // A device already matching the group state is fine by definition —
-        // zone group writes are no-op tolerant, so the group-of-one is too.
-        if (!(error instanceof NoChangesError)) {
-          throw error
-        }
-      }
+      await tolerateNoChanges(async () => this.updateValues(values))
     }
     return { AttributeErrors: null, Success: true }
   }

--- a/src/facades/home-device-atw.ts
+++ b/src/facades/home-device-atw.ts
@@ -36,6 +36,7 @@ import {
   resolveHomeReportWindow,
   shouldChartHomeBands,
   toHomeEnergyBucketUnit,
+  toHomeEnergyInterval,
   toHomeEnergyOptions,
   toHomeLineOptions,
   toHomeOperationModeOptions,
@@ -46,8 +47,6 @@ import {
 // buckets aggregate hourly wire buckets client-side (the wire's own
 // day buckets are UTC days); the ATW interval measures already report
 // kWh per bucket.
-const ENERGY_INTERVALS = { day: 'Day', hour: 'Hour', localDay: 'Hour' } as const
-
 const IDENTITY_SCALE = 1
 
 const TEMPERATURE_UNIT = '°C'
@@ -365,7 +364,7 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
     const bucketUnit = toHomeEnergyBucketUnit(window)
     const params = {
       ...toHomeWireWindow(window),
-      interval: ENERGY_INTERVALS[bucketUnit],
+      interval: toHomeEnergyInterval(bucketUnit),
     }
     const [consumed, produced] = await Promise.all([
       this.api.getAtwEnergy(this.id, { ...params, measure: 'consumed' }),

--- a/src/facades/home-report.ts
+++ b/src/facades/home-report.ts
@@ -1,4 +1,5 @@
 import { Intl, Temporal } from '../temporal.ts'
+import { MS_PER_DAY } from '../time-units.ts'
 import {
   type HomeEnergyData,
   type HomeReportAnnotation,
@@ -38,7 +39,7 @@ export interface HomeChartWindow {
 // LESS hot water than its own 30-day subwindow), and minute-grained
 // payloads blow the client timeout past ~7 days. Facades therefore
 // split wide windows into chunks and merge the reports.
-export const MAX_REPORT_CHUNK_DAYS = 30
+const MAX_REPORT_CHUNK_DAYS = 30
 
 // Worse for the labeled mode annotations: at period `Weekly` the BFF
 // truncates them to roughly the first two weeks of the window
@@ -57,7 +58,7 @@ export const MAX_ANNOTATION_CHUNK_DAYS = 7
 // 2026-07-19, `scripts/probe-report-load.ts`), so a band-bearing
 // window stays a single chunk. Wider temperature charts fetch fast
 // Weekly samples without annotations instead.
-export const MAX_BAND_WINDOW_DAYS = 7
+const MAX_BAND_WINDOW_DAYS = 7
 
 const windowDaysOf = (window: HomeChartWindow): number =>
   window.from.until(window.to).total({ relativeTo: window.from, unit: 'days' })
@@ -246,8 +247,6 @@ const MAX_HOURLY_GRID_DAYS = 7
 // Classic-style epoch default cannot produce a multi-year grid.
 const MAX_REPORT_SPAN_DAYS = 92
 
-const MILLISECONDS_PER_DAY = 86_400_000
-
 // A "one day" query resolves a hair over 1.0 days (the caller stamps
 // `from` a few milliseconds before the library stamps `to`), so the
 // hourly-bucket cutoff sits halfway to the next whole-day option.
@@ -413,6 +412,21 @@ export const toHomeEnergyBucketUnit = (
   return days <= MAX_LOCAL_DAY_ENERGY_DAYS ? 'localDay' : 'day'
 }
 
+// Local-day buckets are aggregated client-side from hourly wire
+// buckets, so they request `Hour` too.
+const ENERGY_INTERVALS = { day: 'Day', hour: 'Hour', localDay: 'Hour' } as const
+
+/**
+ * Wire `interval` value for a display bucket unit — the request-side
+ * companion of {@link toHomeEnergyBucketUnit}.
+ * @param bucketUnit - Display bucket unit.
+ * @returns The telemetry `interval` to request.
+ */
+export const toHomeEnergyInterval = (
+  bucketUnit: HomeEnergyBucketUnit,
+): (typeof ENERGY_INTERVALS)[HomeEnergyBucketUnit] =>
+  ENERGY_INTERVALS[bucketUnit]
+
 /**
  * Resolve today's full-day window in the display timezone — what the
  * "today" charts (fine temperatures, signal) cover — plus the "now"
@@ -444,13 +458,7 @@ export const toHomeWireWindow = (
 })
 
 const chooseGridUnit = (window: HomeChartWindow): HomeChartGridUnit =>
-  (
-    window.from
-      .until(window.to)
-      .total({ relativeTo: window.from, unit: 'days' }) > MAX_HOURLY_GRID_DAYS
-  ) ?
-    'day'
-  : 'hour'
+  windowDaysOf(window) > MAX_HOURLY_GRID_DAYS ? 'day' : 'hour'
 
 const buildGrid = (
   window: HomeChartWindow,
@@ -485,12 +493,7 @@ const gridLabelOptions = (
     return { hour: '2-digit', minute: '2-digit' }
   }
   // Only the hourly unit reaches this point.
-  const isMultiDay =
-    window.from.until(window.to).total({
-      relativeTo: window.from,
-      unit: 'days',
-    }) > 1
-  return isMultiDay ?
+  return windowDaysOf(window) > 1 ?
       { day: 'numeric', hour: '2-digit', minute: '2-digit', month: 'short' }
     : { hour: '2-digit', minute: '2-digit' }
 }
@@ -715,10 +718,7 @@ const sumModeDurations = (
     )
     if (max > min) {
       const mode = toModeName(annotation.label)
-      durations.set(
-        mode,
-        (durations.get(mode) ?? 0) + (max - min) / MILLISECONDS_PER_DAY,
-      )
+      durations.set(mode, (durations.get(mode) ?? 0) + (max - min) / MS_PER_DAY)
     }
   }
   return durations
@@ -738,8 +738,7 @@ export const toHomeOperationModeOptions = (
 ): ReportChartPieOptions => {
   const durations = sumModeDurations(reports, window)
   const windowDays =
-    (window.to.epochMilliseconds - window.from.epochMilliseconds) /
-    MILLISECONDS_PER_DAY
+    (window.to.epochMilliseconds - window.from.epochMilliseconds) / MS_PER_DAY
   const active = durations.values().reduce((sum, value) => sum + value, 0)
   durations.set(IDLE_MODE_NAME, Math.max(0, windowDays - active))
   const labels = [
@@ -754,36 +753,36 @@ export const toHomeOperationModeOptions = (
   }
 }
 
-// Energy buckets are UTC calendar days (or hours) on the wire:
-// enumerate them by their literal timestamps instead of shifting them
-// into the display timezone.
-const buildUtcDayGrid = (window: HomeChartWindow): string[] => {
-  const last = window.to.withTimeZone(WIRE_TIME_ZONE).toPlainDate()
-  const days: string[] = []
+const enumerateDays = (
+  first: Temporal.PlainDate,
+  last: Temporal.PlainDate,
+): Temporal.PlainDate[] => {
+  const days: Temporal.PlainDate[] = []
   for (
-    let day = window.from.withTimeZone(WIRE_TIME_ZONE).toPlainDate();
+    let day = first;
     Temporal.PlainDate.compare(day, last) <= 0;
     day = day.add({ days: 1 })
   ) {
-    days.push(day.toPlainDateTime().toString())
+    days.push(day)
   }
   return days
 }
 
+// Energy buckets are UTC calendar days (or hours) on the wire:
+// enumerate them by their literal timestamps instead of shifting them
+// into the display timezone.
+const buildUtcDayGrid = (window: HomeChartWindow): string[] =>
+  enumerateDays(
+    window.from.withTimeZone(WIRE_TIME_ZONE).toPlainDate(),
+    window.to.withTimeZone(WIRE_TIME_ZONE).toPlainDate(),
+  ).map((day) => day.toPlainDateTime().toString())
+
 // Local-day buckets enumerate the calendar days of the display
 // timezone the window spans (its bounds already live in that zone).
-const buildLocalDayGrid = (window: HomeChartWindow): string[] => {
-  const last = window.to.toPlainDate()
-  const days: string[] = []
-  for (
-    let day = window.from.toPlainDate();
-    Temporal.PlainDate.compare(day, last) <= 0;
-    day = day.add({ days: 1 })
-  ) {
-    days.push(day.toString())
-  }
-  return days
-}
+const buildLocalDayGrid = (window: HomeChartWindow): string[] =>
+  enumerateDays(window.from.toPlainDate(), window.to.toPlainDate()).map((day) =>
+    day.toString(),
+  )
 
 const toWireHour = (bound: Temporal.ZonedDateTime): Temporal.PlainDateTime =>
   bound

--- a/src/time-units.ts
+++ b/src/time-units.ts
@@ -10,6 +10,8 @@ export const MS_PER_SECOND = 1000
 export const MS_PER_MINUTE = 60_000
 /** Number of milliseconds in one hour. */
 export const MS_PER_HOUR = 3_600_000
+/** Number of milliseconds in one day. */
+export const MS_PER_DAY = 86_400_000
 
 const SESSION_REFRESH_AHEAD_MINUTES = 5
 

--- a/tests/unit/base-api.test.ts
+++ b/tests/unit/base-api.test.ts
@@ -1162,4 +1162,32 @@ describe('logOut', () => {
     expect(unsetSpy).toHaveBeenCalledWith('username')
     expect(unsetSpy).toHaveBeenCalledWith('loginBackoffUntil')
   })
+
+  it('discards a sign-in that was in flight when logOut ran', async () => {
+    const { settingManager } = createSettingStore()
+    const api = new TestAPI({ settingManager })
+    // The sign-in round-trip resolves only after the user signed out.
+    const loginGate: PromiseWithResolvers<void> = Promise.withResolvers()
+    api.doAuthenticateMock.mockImplementationOnce(async () => loginGate.promise)
+    const login = api.authenticate({ password: 'p', username: 'u' })
+    api.logOut()
+    loginGate.resolve()
+    await login
+
+    // The explicit sign-out wins: the login's stored credentials are
+    // discarded and the post-auth registry sync never runs.
+    expect(settingManager.get('username') ?? '').toBe('')
+    expect(settingManager.get('password') ?? '').toBe('')
+    expect(api.syncRegistryMock).not.toHaveBeenCalled()
+  })
+
+  it('runs the post-auth sync when no logOut intervened', async () => {
+    const { settingManager } = createSettingStore()
+    const api = new TestAPI({ settingManager })
+
+    await api.authenticate({ password: 'p', username: 'u' })
+
+    expect(settingManager.get('username')).toBe('u')
+    expect(api.syncRegistryMock).toHaveBeenCalledTimes(1)
+  })
 })

--- a/tests/unit/classic-facades.test.ts
+++ b/tests/unit/classic-facades.test.ts
@@ -51,7 +51,7 @@ import {
   classicReportData,
   createMockClassicApi,
 } from '../classic-fixtures.ts'
-import { cast, defined, mock, okValue } from '../helpers.ts'
+import { cast, defined, matchObject, mock, okValue } from '../helpers.ts'
 
 type DeviceModelAta = ClassicDevice<typeof ClassicDeviceType.Ata>
 
@@ -890,6 +890,49 @@ describe('ata device facade', () => {
       '13 janv.',
       '14 janv.',
     ])
+  })
+
+  it('lowers Z-suffixed report bounds to wall-clock in the display timezone', async () => {
+    const getEnergy = vi.fn<ClassicAPIAdapter['getEnergy']>().mockResolvedValue(
+      ok(
+        cast({
+          Auto: [0, 0],
+          Cooling: [0.5, 1],
+          Dry: [0, 0],
+          Fan: [0, 0],
+          Heating: [0, 0],
+          Labels: [0, 1],
+          LabelType: 0,
+          Other: [0, 0],
+          TotalAutoConsumed: 0,
+          TotalCoolingConsumed: 1.5,
+          TotalDryConsumed: 0,
+          TotalFanConsumed: 0,
+          TotalHeatingConsumed: 0,
+          TotalOtherConsumed: 0,
+          UsageDisclaimerPercentages: '100',
+        }),
+      ),
+    )
+    const { facade } = createAtaFacade({
+      getEnergy,
+      timezone: 'Europe/Paris',
+    })
+
+    // `new Date().toISOString()` output must not crash the Temporal
+    // Plain parsing — the instants lower to Paris wall-clock instead.
+    const result = await facade.getEnergyReport({
+      from: '2024-01-07T23:30:00.000Z',
+      to: '2024-01-08T23:30:00.000Z',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(getEnergy).toHaveBeenCalledWith({
+      postData: matchObject({
+        FromDate: '2024-01-08T00:30:00',
+        ToDate: '2024-01-09T00:30:00',
+      }),
+    })
   })
 
   it('formats a one-day energy report with clock labels', async () => {

--- a/tests/unit/decorators.test.ts
+++ b/tests/unit/decorators.test.ts
@@ -26,7 +26,7 @@ import {
 } from '../../src/errors/index.ts'
 import { HttpError } from '../../src/http/index.ts'
 import { Temporal } from '../../src/temporal.ts'
-import { cast, mock } from '../helpers.ts'
+import { cast, defined, mock } from '../helpers.ts'
 
 const createMockFacade = (
   devices: { type: ClassicDeviceType; update: ReturnType<typeof vi.fn> }[] = [],
@@ -149,74 +149,62 @@ const resolvePowerData = async (): Promise<{ Alpha: null; Power: true }> => {
 
 const setupFetchDevices = (
   options?: Parameters<typeof fetchDevices>[0],
-): { callOrder: string[]; invoke: () => Promise<void> } => {
-  const callOrder: string[] = []
-  const fetchMock = vi.fn<ClassicAPIAdapter['fetch']>().mockImplementation(
-    // eslint-disable-next-line @typescript-eslint/require-await -- ClassicAPIAdapter['fetch'] is async
-    async () => {
-      callOrder.push('fetch')
-      return cast([])
-    },
-  )
+): {
+  fetchMock: ReturnType<typeof vi.fn<ClassicAPIAdapter['fetch']>>
+  target: ReturnType<typeof vi.fn<(...args: unknown[]) => Promise<never>>>
+  invoke: () => Promise<void>
+} => {
+  const fetchMock = vi
+    .fn<ClassicAPIAdapter['fetch']>()
+    .mockResolvedValue(cast([]))
   const target = vi
     .fn<(...args: unknown[]) => Promise<never>>()
-    .mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/require-await -- target signature is async
-      async () => {
-        callOrder.push('target')
-        return cast('result')
-      },
-    )
+    .mockResolvedValue(cast('result'))
   const decorated = fetchDevices(options)(
     target,
     mock<ClassMethodDecoratorContext>(),
   )
   const context = { api: mock<ClassicAPIAdapter>({ fetch: fetchMock }) }
-  return { callOrder, invoke: async () => decorated.call(context) }
+  return { fetchMock, target, invoke: async () => decorated.call(context) }
 }
 
 describe(fetchDevices, () => {
   it.each([
     {
-      expected: ['fetch', 'target'],
+      first: 'fetch' as const,
       label: 'default (before)',
       options: undefined,
     },
     {
-      expected: ['fetch', 'target'],
+      first: 'fetch' as const,
       label: 'when=before',
       options: { when: 'before' as const },
     },
     {
-      expected: ['target', 'fetch'],
+      first: 'target' as const,
       label: 'when=after',
       options: { when: 'after' as const },
     },
   ])(
     'invokes api.fetch and target in the correct order: $label',
-    async ({ expected, options }) => {
-      const { callOrder, invoke } = setupFetchDevices(options)
+    async ({ first, options }) => {
+      const { fetchMock, invoke, target } = setupFetchDevices(options)
       await invoke()
 
-      expect(callOrder).toStrictEqual(expected)
+      const orders = {
+        fetch: defined(fetchMock.mock.invocationCallOrder[0]),
+        target: defined(target.mock.invocationCallOrder[0]),
+      }
+
+      expect(Math.min(orders.fetch, orders.target)).toBe(orders[first])
     },
   )
 
   it('prefers syncRegistry() over api.fetch() when both are exposed', async () => {
-    const callOrder: string[] = []
-    const syncRegistry = vi.fn<() => Promise<void>>().mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/require-await -- signature is async
-      async () => {
-        callOrder.push('syncRegistry')
-      },
-    )
-    const fetchMock = vi.fn<ClassicAPIAdapter['fetch']>().mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/require-await -- signature is async
-      async () => {
-        callOrder.push('fetch')
-        return cast([])
-      },
-    )
+    const syncRegistry = vi.fn<() => Promise<void>>().mockResolvedValue()
+    const fetchMock = vi
+      .fn<ClassicAPIAdapter['fetch']>()
+      .mockResolvedValue(cast([]))
     const target = vi
       .fn<(...args: unknown[]) => Promise<never>>()
       .mockResolvedValue(cast('result'))
@@ -230,7 +218,7 @@ describe(fetchDevices, () => {
     }
     await decorated.call(context)
 
-    expect(callOrder).toStrictEqual(['syncRegistry'])
+    expect(syncRegistry).toHaveBeenCalledTimes(1)
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
@@ -505,16 +493,8 @@ describe(classifyError, () => {
 // the notify — worth pinning.
 describe('decorator stacking order', () => {
   it('runs outer syncDevices after inner classicUpdateDevices', async () => {
-    const callOrder: string[] = []
-    const update = vi.fn<(data: unknown) => void>().mockImplementation(() => {
-      callOrder.push('update')
-    })
-    const notifySync = vi.fn<SyncCallback>().mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/require-await -- signature is async
-      async () => {
-        callOrder.push('notifySync')
-      },
-    )
+    const update = vi.fn<(data: unknown) => void>()
+    const notifySync = vi.fn<SyncCallback>().mockResolvedValue()
     const innerTarget = vi
       .fn<(isOn: boolean) => Promise<boolean>>()
       .mockResolvedValue(true)
@@ -531,7 +511,10 @@ describe('decorator stacking order', () => {
 
     await outer.call(facade, true)
 
-    expect(callOrder).toStrictEqual(['update', 'notifySync'])
+    const [updateOrder] = update.mock.invocationCallOrder
+    const [notifyOrder] = notifySync.mock.invocationCallOrder
+
+    expect(defined(updateOrder)).toBeLessThan(defined(notifyOrder))
   })
 })
 
@@ -543,8 +526,7 @@ describe('decorator type-filter forwarding', () => {
   it('@syncDevices forwards the configured type to notifySync', async () => {
     const notifySync = vi.fn<SyncCallback>().mockResolvedValue()
     const decorated = syncDevices({ type: ClassicDeviceType.Atw })(
-      // eslint-disable-next-line @typescript-eslint/require-await -- target is async
-      async () => 'ok',
+      vi.fn<() => Promise<string>>().mockResolvedValue('ok'),
       mock<ClassMethodDecoratorContext>(),
     )
 

--- a/tests/unit/home-api.test.ts
+++ b/tests/unit/home-api.test.ts
@@ -9,7 +9,7 @@ import type {
   HomeErrorLogEntry,
   HomeReportData,
 } from '../../src/types/index.ts'
-import { HttpError } from '../../src/http/index.ts'
+import { type HttpResponse, HttpError } from '../../src/http/index.ts'
 import { Temporal } from '../../src/temporal.ts'
 import { MS_PER_SECOND } from '../../src/time-units.ts'
 import {
@@ -22,6 +22,7 @@ import {
   mockFetchResponse,
   mockResponse,
 } from '../helpers.ts'
+import { homeReportPoint } from '../home-fixtures.ts'
 
 const BASE_URL = 'https://melcloudhome.com'
 const COGNITO = 'https://live-melcloudhome.auth.eu-west-1.amazoncognito.com'
@@ -186,10 +187,8 @@ const mockReportData: HomeReportData[] = [
     datasets: [
       {
         data: [
-          /* eslint-disable id-length -- match the wire format produced by the BFF */
-          { x: '2026-03-01T00:00:00', y: 20.5 },
-          { x: '2026-03-01T01:00:00', y: 21 },
-          /* eslint-enable id-length */
+          homeReportPoint('2026-03-01T00:00:00', 20.5),
+          homeReportPoint('2026-03-01T01:00:00', 21),
         ],
         id: 'room_temperature',
         label: 'Room ClassicTemperature',
@@ -610,11 +609,40 @@ describe('melcloud home API', () => {
 
       expect(api.registry.getById('device-1')).toBeDefined()
       expect(api.isAuthenticated()).toBe(true)
+      expect(api.context).not.toBeNull()
 
       api.logOut()
 
       expect(api.registry.getAll()).toHaveLength(0)
       expect(api.isAuthenticated()).toBe(false)
+      // The previous account's buildings/devices must not linger.
+      expect(api.context).toBeNull()
+    })
+
+    it('discards a sync cycle that was in flight when logOut ran', async () => {
+      setupSuccessfulLogin()
+      const api = await createApi()
+      // The /context fetch resolves only after the user signed out; the
+      // in-flight gate guarantees the request really started before the
+      // sign-out runs.
+      const contextGate: PromiseWithResolvers<HttpResponse> =
+        Promise.withResolvers()
+      const inFlightGate: PromiseWithResolvers<void> = Promise.withResolvers()
+      mockRequest.mockImplementationOnce(async () => {
+        inFlightGate.resolve()
+        return contextGate.promise
+      })
+      const listPromise = api.list()
+      await inFlightGate.promise
+      api.logOut()
+      contextGate.resolve(mockResponse(mockContext, {}, 200))
+      await listPromise
+
+      // The completing cycle repopulated user/context/registry with the
+      // pre-sign-out session; the epoch guard re-runs the wipe.
+      expect(api.isAuthenticated()).toBe(false)
+      expect(api.context).toBeNull()
+      expect(api.registry.getAll()).toHaveLength(0)
     })
 
     it('should return empty array on failure', async () => {
@@ -2731,12 +2759,9 @@ describe('melcloud home API', () => {
           200,
         ),
       )
-      .mockRejectedValueOnce(
-        new HttpError('Too Many Requests', {
-          config: { url: '/connect/token' },
-          response: { data: undefined, headers: {}, status: 429 },
-        }),
-      )
+      // The token exchange answers a real 429 — fetchPostForm raises it
+      // as an HttpError, the shape doAuthenticate classifies.
+      .mockResolvedValueOnce(mockFetchResponse('rate limited', {}, 429))
     const api = await melCloudHomeApi.create({
       baseURL: BASE_URL,
       transport: mockHttpClient,


### PR DESCRIPTION
Applies the melcloud-api findings of the cross-repo post-churn audit (multi-agent sweep over the recent auth/logout/energy/charts work, every finding re-verified against source before landing).

## Real bugs fixed
- **Home 429/401 classification was unreachable** — the OIDC flow (`token-auth.ts`) threw plain `Error`s, never `HttpError`, so `doAuthenticate`'s `isHttpError` gate could never match in production: a real MELCloud Home 429 armed no login backoff and sign-ins kept hammering the throttled endpoint (the exact field failure the persisted backoff was built to stop). `fetchPostForm` now raises `HttpError` on non-2xx; the throttle test mocks a real 429 `Response` instead of a hand-built production-impossible rejection. The local `429` constant folds into `HttpStatus.TooManyRequests`.
- **`logOut()` left the Home context exposed** — `clearPersistedSession` never nulled `#context`, contradicting the getter's documented "cleared on session invalidation": a signed-out client still served the previous account's buildings/devices. Now cleared.
- **`logOut()` could be resurrected by in-flight work** — a background resume or sync cycle completing after the sign-out re-persisted tokens, re-set `#user`/context, repopulated the registry and re-armed the timer. A logOut epoch counter now makes the explicit sign-out win: stale completions discard their state (`#finishLogin` / `#settleSyncCycle`), covered by race tests on both paths.
- **Classic report queries crashed on `Z`-suffixed timestamps** — the natural `new Date().toISOString()` output (accepted by the Home facades) threw an uncaught `RangeError` in the Temporal `Plain` parsing instead of the promised typed failure. Bounds now lower instants to wall-clock in the display timezone (`toWallClock`, mirroring home-report's `parseQueryDate`).

## Simplifications (audit dimension B/C)
- Login backoff persists through the `@setting` accessor (same key, data-compatible) — the hand-rolled get-with-fallback/unset-on-empty trio is gone.
- `tolerateNoChanges` extracted (was triplicated verbatim across the three group-write sites), `enumerateDays` (twin 12-line grid loops), `toHomeEnergyInterval` (character-identical table in both Home facades), `MS_PER_DAY` in `time-units.ts` (its declared single source of truth), `windowDaysOf` reused at its two inline re-implementations, redundant credential re-stores in both `doAuthenticate` hooks removed (base `authenticate` already persists them first), dead `export` modifiers dropped, orphaned `onSyncComplete` doc block reattached (typedoc published it undocumented).

## Lint debt (dimension D)
- **8 disables removed**: the `id-length` pair in `home-api.test.ts` (last replicated copy — `homeReportPoint` fixture now used), 6 `require-await` in `decorators.test.ts` (`mockResolvedValue` + `invocationCallOrder` ordering asserts), and the inert undocumented `no-await-in-loop` in `scripts/`.
- Ledger completed: the `scripts/` lint exemption now records its verdict, and every reason-less config `'off'` got its one-line rationale (`unicorn/no-null` wire domain, decorator `this`, config default exports, temporal entry point, test literals/length caps).
- CLAUDE.md's bitwise gotcha reworded to match reality (`classic-flags.ts` holds hex magic numbers only; the two operators live behind their documented inline disables).

Suite: 920 tests (+5), 100 % statements/branches/functions/lines, lint 0, typecheck/build clean. Behavior additions → minor bump **42.3.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)