### PR TITLE
feat: label every log line with the emitting client, export AuthenticationThrottledError (42.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [42.4.0] - 2026-07-20
+
+### Added
+
+- Every log line is now prefixed with the emitting client's label (`[Classic]` / `[Home]`): the two clients emit identically-worded lifecycle logs ("Session resume failed", "Automatic sign-ins paused"), so a host running both could not tell which account a diagnostics report was about.
+- `AuthenticationThrottledError` is re-exported from the package root (it was only reachable through the internal errors module), so consumers can `instanceof` the login throttle instead of matching the error name.
+
 ## [42.3.0] - 2026-07-20
 
 ### Fixed
@@ -327,6 +334,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[42.4.0]: https://github.com/OlivierZal/melcloud-api/compare/42.3.0...42.4.0
 [42.3.0]: https://github.com/OlivierZal/melcloud-api/compare/42.2.0...42.3.0
 [42.2.0]: https://github.com/OlivierZal/melcloud-api/compare/42.1.0...42.2.0
 [42.1.0]: https://github.com/OlivierZal/melcloud-api/compare/42.0.6...42.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.3.0",
+  "version": "42.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "42.3.0",
+      "version": "42.4.0",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.3.0",
+  "version": "42.4.0",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -138,11 +138,27 @@ interface BaseAPIConstructorOptions {
   defaultSyncIntervalMinutes: number | false
   /** Subclass-fixed HTTP defaults (baseURL, optional dispatcher). */
   httpConfig: Omit<HttpClientConfig, 'timeout'>
+  /**
+   * Label prefixed to every log line (e.g. `[Classic]`): the two
+   * clients emit identically-worded lifecycle logs ("Session resume
+   * failed", "Automatic sign-ins paused"), so a host running both
+   * could not tell which account a diagnostics report was about.
+   */
+  logLabel: string
   /** Sliding-window length the rate-limit gate observes. */
   rateLimitHours: number
   /** Sync runner the auto-timer drives. */
   syncCallback: () => Promise<unknown>
 }
+
+const labelLogger = (logger: Logger, label: string): Logger => ({
+  error: (...data: unknown[]): void => {
+    logger.error(label, ...data)
+  },
+  log: (...data: unknown[]): void => {
+    logger.log(label, ...data)
+  },
+})
 
 /**
  * Shared infrastructure for MELCloud API clients.
@@ -233,14 +249,15 @@ export abstract class BaseAPI implements Disposable {
     {
       defaultSyncIntervalMinutes,
       httpConfig,
+      logLabel,
       rateLimitHours,
       syncCallback,
     }: BaseAPIConstructorOptions,
   ) {
     this.abortSignal = abortSignal
-    this.logger = logger
+    this.logger = labelLogger(logger, logLabel)
     this.settingManager = settingManager
-    this.events = new LifecycleEmitter(events, logger)
+    this.events = new LifecycleEmitter(events, this.logger)
     this.rateLimitGate = new RateLimitGate({ hours: rateLimitHours })
     this.retryGuard = new RetryGuard(DEFAULT_AUTH_RETRY_COOLDOWN_MS)
     this.api =

--- a/src/api/classic.ts
+++ b/src/api/classic.ts
@@ -253,6 +253,7 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
           dispatcher: new Agent({ connect: { rejectUnauthorized: false } }),
         }),
       },
+      logLabel: '[Classic]',
       rateLimitHours: DEFAULT_RETRY_HOURS,
       syncCallback: async () => this.fetch(),
     })

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -240,6 +240,7 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
     super(config, {
       defaultSyncIntervalMinutes: DEFAULT_SYNC_INTERVAL_MINUTES,
       httpConfig: { baseURL },
+      logLabel: '[Home]',
       rateLimitHours: DEFAULT_RATE_LIMIT_FALLBACK_HOURS,
       syncCallback: async () => this.list(),
     })

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,6 +202,7 @@ export {
 export {
   APIError,
   AuthenticationError,
+  AuthenticationThrottledError,
   EntityNotFoundError,
   isAPIError,
   NetworkError,

--- a/tests/unit/base-api.test.ts
+++ b/tests/unit/base-api.test.ts
@@ -90,6 +90,7 @@ class TestAPI extends BaseAPI {
       {
         defaultSyncIntervalMinutes: false,
         httpConfig: { baseURL: 'https://test.api' },
+        logLabel: '[Test]',
         rateLimitHours: 2,
         syncCallback: syncCallbackMock,
       },
@@ -503,7 +504,7 @@ describe('baseAPI shared request pipeline', () => {
         'Status 500',
       )
 
-      expect(logger.error).toHaveBeenCalledWith(expect.any(String))
+      expect(logger.error).toHaveBeenCalledWith('[Test]', expect.any(String))
     })
 
     it('does not log non-HTTP errors via logError', async () => {
@@ -635,6 +636,7 @@ describe('baseAPI shared request pipeline', () => {
 
       expect(isResumed).toBe(false)
       expect(logger.error).toHaveBeenCalledWith(
+        '[Test]',
         'Session resume failed:',
         expect.any(Error),
       )
@@ -735,6 +737,7 @@ describe('baseAPI shared request pipeline', () => {
 
       await expect(api.notifySync({ type: undefined })).resolves.toBeUndefined()
       expect(logger.error).toHaveBeenCalledWith(
+        '[Test]',
         expect.stringContaining('onSyncComplete'),
         expect.any(Error),
       )
@@ -758,6 +761,7 @@ describe('baseAPI shared request pipeline', () => {
       await Promise.resolve()
 
       expect(logger.error).toHaveBeenCalledWith(
+        '[Test]',
         expect.stringContaining('onSyncComplete'),
         expect.any(Error),
       )

--- a/tests/unit/classic-api.test.ts
+++ b/tests/unit/classic-api.test.ts
@@ -232,6 +232,7 @@ describe('mELCloud Classic API', () => {
     await vi.advanceTimersByTimeAsync(60_000)
 
     expect(logger.error).toHaveBeenCalledWith(
+      '[Classic]',
       'LifecycleEvents.onSyncComplete callback threw — ignoring',
       expect.any(Error),
     )
@@ -497,6 +498,7 @@ describe('mELCloud Classic API', () => {
       expect(isResumed).toBe(false)
       expect(api.isAuthenticated()).toBe(false)
       expect(logger.error).toHaveBeenCalledWith(
+        '[Classic]',
         'Session resume failed:',
         expect.any(AuthenticationError),
       )

--- a/tests/unit/home-api.test.ts
+++ b/tests/unit/home-api.test.ts
@@ -534,6 +534,7 @@ describe('melcloud home API', () => {
 
       expect(isResumed).toBe(false)
       expect(logger.error).toHaveBeenCalledWith(
+        '[Home]',
         'Session resume failed:',
         expect.any(Error),
       )
@@ -817,6 +818,7 @@ describe('melcloud home API', () => {
       await api.updateAtaValues('device-1', { power: false })
 
       expect(logger.error).toHaveBeenCalledWith(
+        '[Home]',
         'LifecycleEvents.onSyncComplete callback threw — ignoring',
         expect.any(Error),
       )
@@ -1366,6 +1368,7 @@ describe('melcloud home API', () => {
 
       expect(api.isAuthenticated()).toBe(false)
       expect(logger.error).toHaveBeenCalledWith(
+        '[Home]',
         'Session resume failed:',
         expect.any(Error),
       )
@@ -1449,6 +1452,7 @@ describe('melcloud home API', () => {
 
       expect(api.isAuthenticated()).toBe(false)
       expect(logger.error).toHaveBeenCalledWith(
+        '[Home]',
         'Session resume failed:',
         matchObject({
           message: cast(expect.stringContaining('Too many redirects')),
@@ -1664,6 +1668,7 @@ describe('melcloud home API', () => {
       })
 
       expect(logger.error).toHaveBeenCalledWith(
+        '[Home]',
         'Background session resume failed:',
         expect.objectContaining({ message: 'boom' }),
       )
@@ -1695,6 +1700,7 @@ describe('melcloud home API', () => {
 
       expect(api.isAuthenticated()).toBe(false)
       expect(logger.error).toHaveBeenCalledWith(
+        '[Home]',
         'Session resume failed:',
         expect.objectContaining({
           message:
@@ -1738,6 +1744,7 @@ describe('melcloud home API', () => {
 
       expect(api.isAuthenticated()).toBe(false)
       expect(logger.error).toHaveBeenCalledWith(
+        '[Home]',
         'Session resume failed:',
         expect.objectContaining({
           message:
@@ -1767,6 +1774,7 @@ describe('melcloud home API', () => {
 
       expect(api.isAuthenticated()).toBe(false)
       expect(logger.error).toHaveBeenCalledWith(
+        '[Home]',
         'Session resume failed:',
         expect.any(Error),
       )
@@ -1920,6 +1928,7 @@ describe('melcloud home API', () => {
 
       expect(api.isAuthenticated()).toBe(false)
       expect(logger.error).toHaveBeenCalledWith(
+        '[Home]',
         'Session resume failed:',
         expect.any(Error),
       )
@@ -1948,6 +1957,7 @@ describe('melcloud home API', () => {
 
       expect(api.isAuthenticated()).toBe(false)
       expect(logger.error).toHaveBeenCalledWith(
+        '[Home]',
         'Session resume failed:',
         expect.any(Error),
       )
@@ -2292,6 +2302,7 @@ describe('melcloud home API', () => {
 
       expect(api.isAuthenticated()).toBe(true)
       expect(logger.error).toHaveBeenCalledWith(
+        '[Home]',
         'Home context drifted from the strict schema; salvaging device entries:',
         expect.anything(),
       )
@@ -2523,6 +2534,7 @@ describe('melcloud home API', () => {
 
       expect(api.isAuthenticated()).toBe(false)
       expect(logger.error).toHaveBeenCalledWith(
+        '[Home]',
         'Session resume failed:',
         expect.any(Error),
       )
@@ -2566,6 +2578,7 @@ describe('melcloud home API', () => {
 
       expect(api.isAuthenticated()).toBe(false)
       expect(logger.error).toHaveBeenCalledWith(
+        '[Home]',
         'Session resume failed:',
         expect.any(Error),
       )
@@ -2676,7 +2689,9 @@ describe('melcloud home API', () => {
         mock: { calls },
       } = vi.mocked(logger.log)
 
-      const messages = calls.map(([message]) => String(message))
+      // The API label rides as the first argument; the structured
+      // payload follows.
+      const messages = calls.map((call) => call.map(String).join(' '))
 
       expect(messages.length).toBeGreaterThan(0)
       expect(messages.some((message) => message.includes('API request'))).toBe(
@@ -2699,6 +2714,7 @@ describe('melcloud home API', () => {
       await api.list()
 
       expect(logger.error).toHaveBeenCalledWith(
+        '[Home]',
         expect.stringContaining('Request failed'),
       )
     })


### PR DESCRIPTION
On Olivier's call, the diagnostics labeling moves lib-side where it belongs (the client knows its own identity; every consumer benefits):

- `BaseAPIConstructorOptions` gains `logLabel` (subclass-fixed: `[Classic]` / `[Home]`); the constructor wraps the injected logger once so **every** line — lifecycle, sync, structured request logs, LifecycleEmitter — carries the label. Field motivation: a diagnostics report showed "Automatic sign-ins paused for 15 minutes after a rejected login" with no way to tell which account.
- `AuthenticationThrottledError` re-exported from the package root — it was only reachable through the internal errors module, forcing consumers to discriminate the login throttle by error name (com.melcloud's next release switches to a real `instanceof`).

Suite: 920 tests, 100 % everywhere, lint 0, docs/typecheck/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)