### PR TITLE
feat: onAuthenticationRestored lifecycle event (42.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -340,6 +340,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[42.5.0]: https://github.com/OlivierZal/melcloud-api/compare/42.4.0...42.5.0
 [42.4.0]: https://github.com/OlivierZal/melcloud-api/compare/42.3.0...42.4.0
 [42.3.0]: https://github.com/OlivierZal/melcloud-api/compare/42.2.0...42.3.0
 [42.2.0]: https://github.com/OlivierZal/melcloud-api/compare/42.1.0...42.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [42.5.0] - 2026-07-20
+
+### Added
+
+- New `LifecycleEvents.onAuthenticationRestored` callback: fires when a sync cycle ends authenticated after an `onAuthenticationLost` episode — the user logged back in or a retry recovered the session. Fires once per loss episode, so the two events always alternate; hosts can surface a "signed in again" confirmation to mirror the loss notification.
+
 ## [42.4.0] - 2026-07-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.4.0",
+  "version": "42.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "42.4.0",
+      "version": "42.5.0",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.4.0",
+  "version": "42.5.0",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -831,6 +831,17 @@ export abstract class BaseAPI implements Disposable {
     )
   }
 
+  // A live session marks any earlier loss episode as recovered —
+  // announced once per episode, so the two events always alternate.
+  #markLossRecovered(): void {
+    if (!this.#hasEmittedAuthenticationLost) {
+      return
+    }
+
+    this.#hasEmittedAuthenticationLost = false
+    this.events.emitAuthenticationRestored()
+  }
+
   async #runWithEvents<T>(
     context: { correlationId: string; method: string; url: string },
     runner: () => Promise<HttpResponse<T>>,
@@ -875,8 +886,7 @@ export abstract class BaseAPI implements Disposable {
       return
     }
     if (this.isAuthenticated()) {
-      // A live session marks any earlier loss episode as recovered.
-      this.#hasEmittedAuthenticationLost = false
+      this.#markLossRecovered()
       this.syncManager.planNext()
       return
     }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -75,6 +75,13 @@ export interface LifecycleEvents {
    * logging back in — re-arms it. Fires once per loss episode.
    */
   readonly onAuthenticationLost?: (() => void) | undefined
+  /**
+   * Fires when a sync cycle ends authenticated after an
+   * `onAuthenticationLost` episode — the user logged back in or a
+   * retry recovered the session. Fires once per loss episode, so the
+   * two events always alternate.
+   */
+  readonly onAuthenticationRestored?: (() => void) | undefined
   /** Invoked after a successful HTTP response is received. */
   readonly onRequestComplete?:
     ((event: RequestCompleteEvent) => void) | undefined

--- a/src/observability/events-emitter.ts
+++ b/src/observability/events-emitter.ts
@@ -32,6 +32,12 @@ export class LifecycleEmitter {
     )
   }
 
+  public emitAuthenticationRestored(): void {
+    this.#safeInvoke('onAuthenticationRestored', () =>
+      this.#events?.onAuthenticationRestored?.(),
+    )
+  }
+
   public emitComplete(event: RequestCompleteEvent): void {
     this.#safeInvoke('onRequestComplete', () =>
       this.#events?.onRequestComplete?.(event),

--- a/tests/unit/base-api.test.ts
+++ b/tests/unit/base-api.test.ts
@@ -44,6 +44,9 @@ const successfulWork = vi.fn<() => Promise<never[]>>().mockResolvedValue([])
 const createLostSpy = (): ReturnType<
   typeof vi.fn<NonNullable<LifecycleEvents['onAuthenticationLost']>>
 > => vi.fn<NonNullable<LifecycleEvents['onAuthenticationLost']>>()
+const createRestoredSpy = (): ReturnType<
+  typeof vi.fn<NonNullable<LifecycleEvents['onAuthenticationRestored']>>
+> => vi.fn<NonNullable<LifecycleEvents['onAuthenticationRestored']>>()
 
 const { client: mockHttpClient, requestSpy: mockRequest } =
   createMockHttpClient('https://test.api')
@@ -885,6 +888,37 @@ describe('authentication-lost lifecycle', () => {
       await api.callRunSyncCycle(failingWork)
 
       expect(onAuthenticationLost).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('announces the recovery once per loss episode, never without one', async () => {
+    vi.useFakeTimers()
+    try {
+      const onAuthenticationRestored = createRestoredSpy()
+      const api = new TestAPI({
+        events: {
+          onAuthenticationLost: createLostSpy(),
+          onAuthenticationRestored,
+        },
+        settingManager: createSettingStore({ password: 'p', username: 'u' })
+          .settingManager,
+        syncIntervalMinutes: 1,
+      })
+
+      // Authenticated settles without a preceding loss stay silent.
+      await api.callRunSyncCycle(successfulWork)
+
+      expect(onAuthenticationRestored).not.toHaveBeenCalled()
+
+      api.isAuthenticatedMock.mockReturnValue(false)
+      await api.callRunSyncCycle(failingWork)
+      api.isAuthenticatedMock.mockReturnValue(true)
+      await api.callRunSyncCycle(successfulWork)
+      await api.callRunSyncCycle(successfulWork)
+
+      expect(onAuthenticationRestored).toHaveBeenCalledTimes(1)
     } finally {
       vi.useRealTimers()
     }

--- a/tests/unit/events-emitter.test.ts
+++ b/tests/unit/events-emitter.test.ts
@@ -125,6 +125,23 @@ describe(LifecycleEmitter, () => {
     expect(logger.error).not.toHaveBeenCalled()
   })
 
+  it('forwards onAuthenticationRestored and tolerates its absence', () => {
+    const logger = createLogger()
+    const onAuthenticationRestored =
+      vi.fn<NonNullable<LifecycleEvents['onAuthenticationRestored']>>()
+
+    const emitter = new LifecycleEmitter({ onAuthenticationRestored }, logger)
+    const emptyEmitter = new LifecycleEmitter({}, logger)
+
+    emitter.emitAuthenticationRestored()
+
+    expect(onAuthenticationRestored).toHaveBeenCalledTimes(1)
+    expect(() => {
+      emptyEmitter.emitAuthenticationRestored()
+    }).not.toThrow()
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
   it('logs and swallows a throwing onAuthenticationLost callback', () => {
     const logger = createLogger()
     const emitter = new LifecycleEmitter(


### PR DESCRIPTION
Adds the recovery counterpart of `onAuthenticationLost`: `#settleSyncCycle` announces the transition back to an authenticated cycle once per loss episode (extracted `#markLossRecovered`, keeping the statement cap), `LifecycleEmitter.emitAuthenticationRestored` routes it through the same swallow-and-log observer contract, and `LifecycleEvents` documents the alternation guarantee.

Motivated by a field report: after a session-expired timeline notification and a re-login, users get no confirmation that background syncing resumed. com.melcloud 45.7.6 consumes this to post the mirroring "signed in again" notification.

- Tests: emitter forwarding/absence, settle transition (no episode → silent; episode → once; repeated authenticated settles → still once).
- Suite: lint 0, tsc 0, coverage 100%, docs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)