### PR TITLE
docs: SonarCloud spotless required for any merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,11 @@ is on: no runtime enums, no parameter properties, no runtime namespaces.
   change when the point holds, or with a reasoned reply when it does
   not — verify claims against sources before acting either way. Resolve
   the thread once settled; none left dangling.
+- SonarCloud must be spotless for a PR to merge: quality gate green,
+  zero open issues on its analysis, and 100 % coverage (within the
+  exclusions `sonar-project.properties` declares). A Sonar finding is
+  handled like a lint error — the code adapts, or the divergence is
+  settled as a documented verdict — never merged over.
 - GitHub merge queue is impossible here: the repo is user-owned and the
   feature is org-only (verified via API — no ruleset payload enables it).
   Dependabot PRs auto-merge via `gh pr merge --auto`; the `merge_group`


### PR DESCRIPTION
Doctrine addition on Olivier's call: a PR merges only with SonarCloud fully clean — quality gate green, zero open issues, 100 % coverage within the declared exclusions. Doc-only, no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)