### PR TITLE
refactor: settle the Number.NaN convention (SonarCloud S7773 alignment)

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -776,6 +776,10 @@ const config = defineConfig([
       'unicorn/prefer-dispose': 'error',
       // Requires Node.js 24 (`Error.isError`).
       'unicorn/prefer-error-is-error': 'off',
+      // Mutually exclusive twin of `prefer-number-properties`'
+      // `checkNaN`: the repos pick `Number.NaN` (SonarCloud S7773 is a
+      // required gate, and it pairs with the mandated `Number.isNaN`).
+      'unicorn/prefer-global-number-constants': 'off',
       'unicorn/prefer-import-meta-properties': 'error',
       // Requires Node.js 24 (`Iterator.concat`).
       'unicorn/prefer-iterator-concat': 'off',
@@ -785,6 +789,14 @@ const config = defineConfig([
         'error',
         {
           checkVaryingBase: true,
+        },
+      ],
+      // Stricter than the v72 default (see
+      // `prefer-global-number-constants` above).
+      'unicorn/prefer-number-properties': [
+        'error',
+        {
+          checkNaN: true,
         },
       ],
       // Requires Node.js 24 (`RegExp.escape`).

--- a/tests/unit/rate-limit-gate.test.ts
+++ b/tests/unit/rate-limit-gate.test.ts
@@ -111,7 +111,7 @@ describe(RateLimitGate, () => {
   it('falls back when Retry-After is a non-finite number', () => {
     const gate = new RateLimitGate({ hours: 2 })
 
-    gate.recordRateLimit(NaN)
+    gate.recordRateLimit(Number.NaN)
 
     expect(gate.remaining?.total({ unit: 'hours' })).toBeGreaterThan(1.9)
   })

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -377,7 +377,7 @@ describe('validation/schemas', () => {
       { label: 'null', value: null },
       { label: 'a string', value: '1.5' },
       { label: 'Infinity', value: Infinity },
-      { label: 'NaN', value: NaN },
+      { label: 'NaN', value: Number.NaN },
     ])('rejects an ATA payload whose total is $label', ({ value }) => {
       expect(() =>
         ClassicEnergyDataAtaSchema.parse({
@@ -391,7 +391,7 @@ describe('validation/schemas', () => {
       expect(() =>
         ClassicEnergyDataAtaSchema.parse({
           ...validClassicEnergyAta,
-          Heating: [0, NaN, 1],
+          Heating: [0, Number.NaN, 1],
         }),
       ).toThrow(/Heating/v)
     })
@@ -409,7 +409,7 @@ describe('validation/schemas', () => {
       { label: 'null', value: null },
       { label: 'a string', value: '1.5' },
       { label: 'Infinity', value: Infinity },
-      { label: 'NaN', value: NaN },
+      { label: 'NaN', value: Number.NaN },
     ])('rejects an ATW payload whose total is $label', ({ value }) => {
       expect(() =>
         ClassicEnergyDataAtwSchema.parse({
@@ -432,7 +432,7 @@ describe('validation/schemas', () => {
       expect(() =>
         ClassicEnergyDataAtwSchema.parse({
           ...validClassicEnergyAtw,
-          CoP: [2.5, NaN],
+          CoP: [2.5, Number.NaN],
         }),
       ).toThrow(/CoP/v)
     })


### PR DESCRIPTION
Same verdict as com.melcloud #1450, applied before Sonar raises the matching S7773s here: the repo picks `Number.NaN` — `prefer-number-properties` gains `checkNaN: true`, its mutually exclusive twin `prefer-global-number-constants` goes to the config ledger with the rationale, and the five bare test `NaN`s migrate via the rule's autofix. Quality-only, rides the next release. Suite: lint 0, tsc 0, 100 % coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)