### PR TITLE
feat!: unify holiday-mode write contract across Classic and Home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [43.0.0] - 2026-07-23
+
+### Changed
+
+- **Breaking:** unified the holiday-mode write contract across the Classic and Home APIs. `ClassicFacade.updateHolidayMode` and `HomeFacadeManager.updateHolidayMode` now both take the shared `HolidayModeUpdate` shape `{ isEnabled, startDate, endDate }` (ISO 8601 wall-clock), replacing the Classic-only `ClassicHolidayModeQuery` `{ from?, to? }` presence-encoding. `isEnabled` is now explicit rather than inferred from the presence of `to`; `startDate`/`endDate` are ignored when disabling. Callers pass the full window — the start is no longer defaulted to "now" (the Home API carries no timezone context to anchor such a default, and unifying the contract means one caller-supplied window drives both sides). `ClassicHolidayModeQuery` and its `/classic` alias `HolidayModeQuery` are removed; import `HolidayModeUpdate` from the package root.
+
 ## [42.6.0] - 2026-07-23
 
 ### Added
@@ -346,6 +352,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[43.0.0]: https://github.com/OlivierZal/melcloud-api/compare/42.6.0...43.0.0
 [42.6.0]: https://github.com/OlivierZal/melcloud-api/compare/42.5.0...42.6.0
 [42.5.0]: https://github.com/OlivierZal/melcloud-api/compare/42.4.0...42.5.0
 [42.4.0]: https://github.com/OlivierZal/melcloud-api/compare/42.3.0...42.4.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.6.0",
+  "version": "43.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "42.6.0",
+      "version": "43.0.0",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "42.6.0",
+  "version": "43.0.0",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/api/classic-types.ts
+++ b/src/api/classic-types.ts
@@ -68,9 +68,9 @@ export interface ClassicAPIAdapter {
   /**
    * IANA timezone identifier the Classic instance was configured with
    * (`ClassicAPIConfig.timezone`), or `undefined` when unset. Facades
-   * use this to anchor "now"-derived defaults (`updateHolidayMode`
-   * fallback, `getSignalStrength` / `getHourlyTemperatures` hour) to
-   * the Classic timezone instead of the host runtime timezone.
+   * use this to anchor "now"-derived defaults (`getSignalStrength` /
+   * `getHourlyTemperatures` hour) to the Classic timezone instead of the
+   * host runtime timezone.
    */
   readonly timezone: string | undefined
   /** Fetch all buildings and sync the model registry. */

--- a/src/classic.ts
+++ b/src/classic.ts
@@ -54,7 +54,6 @@ export {
   type ClassicHolidayModeData as HolidayModeData,
   type ClassicHolidayModeLocation as HolidayModeLocation,
   type ClassicHolidayModePostData as HolidayModePostData,
-  type ClassicHolidayModeQuery as HolidayModeQuery,
   type ClassicHolidayModeTimeZone as HolidayModeTimeZone,
   type ClassicHotWaterState as HotWaterState,
   type ClassicListDevice as ListDevice,

--- a/src/facades/classic-base.ts
+++ b/src/facades/classic-base.ts
@@ -10,6 +10,7 @@ import type {
   ClassicModel,
   ClassicRegistry,
 } from '../entities/index.ts'
+import type { HolidayModeUpdate } from '../holiday-mode.ts'
 import {
   classicUpdateDevices,
   fetchDevices,
@@ -46,7 +47,6 @@ import { HourSchema, parseOrThrow } from '../validation/index.ts'
 import type {
   ClassicFacade,
   ClassicFrostProtectionQuery,
-  ClassicHolidayModeQuery,
 } from './classic-types.ts'
 import type { ReportChartLineOptions } from './report-types.ts'
 
@@ -213,24 +213,20 @@ export abstract class ClassicBaseFacade<
 
   @fetchDevices({ when: 'after' })
   public async updateHolidayMode({
-    from,
-    to,
-  }: ClassicHolidayModeQuery = {}): Promise<
-    ClassicFailureData | ClassicSuccessData
-  > {
-    const isEnabled = to !== undefined
-    const resolveStartDate = (): Temporal.PlainDateTime =>
-      from === undefined ?
-        Temporal.Now.plainDateTimeISO(this.api.timezone)
-      : Temporal.PlainDateTime.from(from)
-    const startDate = isEnabled ? resolveStartDate() : null
-    const endDate = isEnabled ? Temporal.PlainDateTime.from(to) : null
+    endDate,
+    isEnabled,
+    startDate,
+  }: HolidayModeUpdate): Promise<ClassicFailureData | ClassicSuccessData> {
+    // Parse the window before the location fetch so malformed dates throw
+    // ahead of any I/O; dates are cleared when disabling.
+    const start = isEnabled ? Temporal.PlainDateTime.from(startDate) : null
+    const end = isEnabled ? Temporal.PlainDateTime.from(endDate) : null
     return this.api.updateHolidayMode({
       postData: {
         Enabled: isEnabled,
-        EndDate: getDateTimeComponents(endDate),
+        EndDate: getDateTimeComponents(end),
         HMTimeZones: await this.#getHolidayModeLocation(),
-        StartDate: getDateTimeComponents(startDate),
+        StartDate: getDateTimeComponents(start),
       },
     })
   }

--- a/src/facades/classic-types.ts
+++ b/src/facades/classic-types.ts
@@ -9,6 +9,7 @@ import type {
   ClassicDeviceAny,
 } from '../entities/classic-types.ts'
 import type { Identifiable } from '../entities/types.ts'
+import type { HolidayModeUpdate } from '../holiday-mode.ts'
 import type {
   ClassicEnergyData,
   ClassicFailureData,
@@ -193,7 +194,7 @@ export interface ClassicFacade extends Identifiable {
   ) => Promise<ClassicFailureData | ClassicSuccessData>
   /** Enable or disable holiday mode. */
   readonly updateHolidayMode: (
-    query: ClassicHolidayModeQuery,
+    query: HolidayModeUpdate,
   ) => Promise<ClassicFailureData | ClassicSuccessData>
   /** Turn all devices in this facade on or off. */
   readonly updatePower: (value?: boolean) => Promise<boolean>
@@ -210,17 +211,6 @@ export interface ClassicFrostProtectionQuery {
   readonly min: number
   /** Whether frost protection is enabled. Defaults to `true`. */
   readonly isEnabled?: boolean | undefined
-}
-
-/**
- * Parameters for enabling or disabling holiday mode.
- * @category Facades
- */
-export interface ClassicHolidayModeQuery {
-  /** Start date in ISO 8601 format. Defaults to now when `to` is provided. */
-  readonly from?: string | undefined
-  /** End date in ISO 8601 format. Omit to disable holiday mode. */
-  readonly to?: string | undefined
 }
 
 /**

--- a/src/facades/home-manager.ts
+++ b/src/facades/home-manager.ts
@@ -1,5 +1,6 @@
 import type { HomeAPIAdapter } from '../api/index.ts'
 import type { HomeDevice } from '../entities/home-device.ts'
+import type { HolidayModeUpdate } from '../holiday-mode.ts'
 import type {
   HomeAtaDeviceData,
   HomeAtwDeviceData,
@@ -123,17 +124,13 @@ export class HomeFacadeManager {
    * for the holiday window. All ids must belong to this manager's account.
    * @param deviceIds - Target device ids.
    * @param root0 - The new holiday-mode window.
-   * @param root0.endDate - Window end, ISO local date-time.
+   * @param root0.endDate - Window end, ISO 8601 wall-clock.
    * @param root0.isEnabled - Whether holiday mode is on.
-   * @param root0.startDate - Window start, ISO local date-time.
+   * @param root0.startDate - Window start, ISO 8601 wall-clock.
    */
   public async updateHolidayMode(
     deviceIds: readonly string[],
-    {
-      endDate,
-      isEnabled,
-      startDate,
-    }: { endDate: string; isEnabled: boolean; startDate: string },
+    { endDate, isEnabled, startDate }: HolidayModeUpdate,
   ): Promise<void> {
     await this.#api.updateHolidayMode({
       enabled: isEnabled,

--- a/src/facades/index.ts
+++ b/src/facades/index.ts
@@ -20,7 +20,6 @@ export {
   type ClassicEnergyReportExtract,
   type ClassicFacade,
   type ClassicFrostProtectionQuery,
-  type ClassicHolidayModeQuery,
   type ClassicZoneFacade,
   hasClassicZone2,
   isClassicAtaFacade,

--- a/src/holiday-mode.ts
+++ b/src/holiday-mode.ts
@@ -1,0 +1,21 @@
+/**
+ * Unified holiday-mode write contract, shared by the Classic and Home APIs
+ * so one window drives both without per-API translation.
+ * @module
+ */
+
+/**
+ * A holiday-mode window to apply. `startDate`/`endDate` are ISO 8601
+ * wall-clock strings; both are ignored when `isEnabled` is `false`. The
+ * start is always explicit (the Home API carries no timezone context to
+ * anchor a "now" default), so callers pass the full window.
+ * @category Facades
+ */
+export interface HolidayModeUpdate {
+  /** Window end (ISO 8601). Ignored when `isEnabled` is `false`. */
+  readonly endDate: string
+  /** Whether holiday mode is on. */
+  readonly isEnabled: boolean
+  /** Window start (ISO 8601). Ignored when `isEnabled` is `false`. */
+  readonly startDate: string
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export type { HolidayModeUpdate } from './holiday-mode.ts'
 export type {
   ApiRequestError,
   ClassicAreaData,
@@ -222,7 +223,6 @@ export {
   type ClassicDeviceFacadeAny,
   type ClassicFacade,
   type ClassicFrostProtectionQuery,
-  type ClassicHolidayModeQuery,
   type ClassicZoneFacade,
   type ReportChartBand,
   type ReportChartLineOptions,

--- a/tests/unit/classic-facades.test.ts
+++ b/tests/unit/classic-facades.test.ts
@@ -408,22 +408,30 @@ describe('building facade holiday mode', () => {
     const { facade } = createBuildingFacade()
     await facade.getHolidayMode()
     const result = await facade.updateHolidayMode({
-      from: '2024-06-01',
-      to: '2024-06-15',
+      endDate: '2024-06-15',
+      isEnabled: true,
+      startDate: '2024-06-01',
     })
 
     expect(result).toHaveProperty('Success')
   })
 
-  it('disables holiday mode when no to date', async () => {
+  it('disables holiday mode and ignores the window dates', async () => {
     const { api, facade } = createBuildingFacade()
     await facade.getHolidayMode()
-    await facade.updateHolidayMode({})
+    await facade.updateHolidayMode({
+      endDate: '2024-06-15',
+      isEnabled: false,
+      startDate: '2024-06-01',
+    })
     const call = vi.mocked(api.updateHolidayMode).mock.lastCall?.[0]
 
     expect(call).toBeDefined()
 
     expect(defined(call).postData.Enabled).toBe(false)
+    // Dates are cleared to null on the wire when disabling.
+    expect(defined(call).postData.StartDate).toBeNull()
+    expect(defined(call).postData.EndDate).toBeNull()
   })
 })
 
@@ -458,7 +466,11 @@ describe('facade write methods refresh registry', () => {
     const { api, facade } = createBuildingFacade()
     await facade.getHolidayMode()
     vi.mocked(api.fetch).mockClear()
-    await facade.updateHolidayMode({ from: '2024-06-01', to: '2024-06-15' })
+    await facade.updateHolidayMode({
+      endDate: '2024-06-15',
+      isEnabled: true,
+      startDate: '2024-06-01',
+    })
 
     expect(api.fetch).toHaveBeenCalledTimes(1)
   })
@@ -674,7 +686,11 @@ describe('base facade holiday mode with device fallback', () => {
       )
       .mockResolvedValue(ok(classicHolidayModeResponse()))
     const { api, facade } = createAreaFacade({ getHolidayMode: hmMock })
-    await facade.updateHolidayMode({ to: '2024-12-31' })
+    await facade.updateHolidayMode({
+      endDate: '2024-12-31',
+      isEnabled: true,
+      startDate: '2024-01-01',
+    })
     const call = vi.mocked(api.updateHolidayMode).mock.lastCall?.[0]
 
     expect(call).toBeDefined()
@@ -689,9 +705,13 @@ describe('base facade holiday mode with device fallback', () => {
       .mockResolvedValue(err({ cause, kind: 'network' as const }))
     const { facade } = createAreaFacade({ getHolidayMode: hmMock })
 
-    await expect(facade.updateHolidayMode({ to: '2024-12-31' })).rejects.toBe(
-      cause,
-    )
+    await expect(
+      facade.updateHolidayMode({
+        endDate: '2024-12-31',
+        isEnabled: true,
+        startDate: '2024-01-01',
+      }),
+    ).rejects.toBe(cause)
   })
 })
 


### PR DESCRIPTION
## What

Unifies the holiday-mode **write** contract across the Classic and Home APIs so a single window drives both without per-API translation.

- New shared `HolidayModeUpdate { isEnabled: boolean; startDate: string; endDate: string }` (ISO 8601 wall-clock), exported from the package root (`src/holiday-mode.ts`).
- `ClassicFacade.updateHolidayMode` and `HomeFacadeManager.updateHolidayMode` both accept it. Home behaviour is unchanged (it already spoke this shape); the Classic facade adapts internally to its `Enabled/StartDate/EndDate` wire.
- `isEnabled` is now explicit instead of inferred from the presence of `to`; `startDate`/`endDate` are ignored when disabling.
- Removes `ClassicHolidayModeQuery` and its `/classic` alias `HolidayModeQuery`.

## Why

The old contracts were only *analogous*: Classic used `{ from?, to? }` presence-encoding while Home used `{ isEnabled, startDate, endDate }`. That forced the downstream `com.melcloud` consumer to translate between them for every holiday write (a `toHomeHolidayIntent` bridge). One shape removes that adapter and makes the flow-card / settings paths call the same method shape regardless of side.

The start is no longer defaulted to "now": the Home API carries no timezone context to anchor such a default, and unifying the contract means one caller-supplied window drives both sides. The sole consumer already computes `startDate = now` for both.

## Breaking change

`ClassicFacade.updateHolidayMode` now takes `HolidayModeUpdate` instead of the removed `ClassicHolidayModeQuery`. Consumers import `HolidayModeUpdate` from the package root. → **43.0.0**.

## Verification

- Wire `postData` is byte-identical for equivalent valid inputs (enable and disable) — confirmed against the `main` baseline; malformed dates still throw before any I/O.
- `format` · `lint` · `typecheck` · `test:coverage` (**100%**, 928 tests) · `build` · `docs` all green.
- An adversarial multi-agent review (behaviour parity, completeness sweep, surface/semver/docs) surfaced two nits, both fixed: the error-path ordering above, and a JSDoc wording alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)