### PR TITLE
fix: tolerate Home protection/holiday entries without the active flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [43.0.1] - 2026-07-23
+
+### Fixed
+
+- Home `/context` no longer drifts from the strict schema when a unit reports frost/overheat protection or holiday mode without the runtime `active` flag (observed on live guest ATW units). `active` is now optional on `HomeFrostProtection`, `HomeOverheatProtection`, and `HomeHolidayMode`; previously the strict parse failed on every sync and fell back to the salvage schema, dropping that unit's protection data and logging a `ZodError` each cycle.
+
 ## [43.0.0] - 2026-07-23
 
 ### Changed
@@ -352,6 +358,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[43.0.1]: https://github.com/OlivierZal/melcloud-api/compare/43.0.0...43.0.1
 [43.0.0]: https://github.com/OlivierZal/melcloud-api/compare/42.6.0...43.0.0
 [42.6.0]: https://github.com/OlivierZal/melcloud-api/compare/42.5.0...42.6.0
 [42.5.0]: https://github.com/OlivierZal/melcloud-api/compare/42.4.0...42.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "43.0.0",
+  "version": "43.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "43.0.0",
+      "version": "43.0.1",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "43.0.0",
+  "version": "43.0.1",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/types/home.ts
+++ b/src/types/home.ts
@@ -332,10 +332,10 @@ export interface HomeErrorLogEntry {
  * @category Types
  */
 export interface HomeFrostProtection {
-  readonly active: boolean
   readonly enabled: boolean
   readonly max: number
   readonly min: number
+  readonly active?: boolean | undefined
 }
 
 /**
@@ -358,10 +358,10 @@ export interface HomeFrostProtectionPostData {
  * @category Types
  */
 export interface HomeHolidayMode {
-  readonly active: boolean
   readonly enabled: boolean
   readonly endDate: string
   readonly startDate: string
+  readonly active?: boolean | undefined
 }
 
 /**
@@ -383,10 +383,10 @@ export interface HomeHolidayModePostData {
  * @category Types
  */
 export interface HomeOverheatProtection {
-  readonly active: boolean
   readonly enabled: boolean
   readonly max: number
   readonly min: number
+  readonly active?: boolean | undefined
 }
 
 /**

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -127,14 +127,17 @@ const HomeAtwCapabilitiesSchema: z.ZodType<HomeAtwDeviceCapabilities> =
 // + min/max); `holidayMode` carries active/enabled plus a start/end
 // window. Both are consumed by the SDK now, so both are validated.
 const HomeProtectionSchema = z.looseObject({
-  active: z.boolean(),
+  // `active` (is it currently kicking in) is absent on some units — live
+  // ATW guests omit it — so it is optional; `enabled`/`min`/`max` are the
+  // configuration and are always present.
+  active: z.boolean().optional(),
   enabled: z.boolean(),
   max: z.number(),
   min: z.number(),
 })
 
 const HomeHolidayModeSchema = z.looseObject({
-  active: z.boolean(),
+  active: z.boolean().optional(),
   enabled: z.boolean(),
   endDate: z.string(),
   startDate: z.string(),

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -270,6 +270,34 @@ describe('validation/schemas', () => {
       ).not.toThrow()
     })
 
+    it('accepts a unit whose frostProtection/holidayMode omit the optional active flag', () => {
+      // Live guest ATW units report the protection config without the
+      // runtime `active` flag; the strict schema must not drift on that.
+      expect(() =>
+        HomeContextSchema.parse(
+          buildHomeContext({
+            guestBuildings: [
+              {
+                ...baseHomeBuilding,
+                airToWaterUnits: [
+                  {
+                    ...baseHomeAtwDevice,
+                    capabilities: defaultHomeAtwCapabilities,
+                    frostProtection: { enabled: false, max: 12, min: 6 },
+                    holidayMode: {
+                      enabled: false,
+                      endDate: '2026-08-05T00:00:00',
+                      startDate: '2026-08-01T00:00:00',
+                    },
+                  },
+                ],
+              },
+            ],
+          }),
+        ),
+      ).not.toThrow()
+    })
+
     it('rejects ATA capabilities missing a required field', () => {
       const incomplete = {
         ...defaultHomeAtaCapabilities,


### PR DESCRIPTION
## What

Makes the runtime `active` flag optional on `HomeFrostProtection`, `HomeOverheatProtection` and `HomeHolidayMode` (type + schema).

## Why (found on-device)

Running the downstream app against a live account surfaced this every sync:

```
Home context drifted from the strict schema; salvaging device entries: ZodError:
  guestBuildings[2].airToWaterUnits[0].frostProtection.active
  Invalid input: expected boolean, received undefined
```

A **guest ATW unit** reports its protection config (`enabled`/`min`/`max`) and holiday window without the `active` ("currently kicking in") flag. Since 43.0.0 both are SDK-consumed and strictly validated, so the strict `/context` parse failed on every cycle, fell back to the salvage schema, dropped that unit's protection data, and logged a `ZodError` each minute. Unit tests missed it (fixtures always set `active`); a regression test now covers the `active`-absent shape.

## Verification

`format` · `lint` · `typecheck` · `test:coverage` (**100%**, 929 tests) · `build` · `docs` green. → **43.0.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)