### PR TITLE
feat: stamp flattened Classic zones with their building name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [43.1.0] - 2026-07-23
+
+### Added
+
+- `ClassicFacadeManager.getZones` / `ClassicRegistry.getZones` now stamp each flattened zone with its owning building's display name — the new `ClassicFlatZone` (`ClassicZone & { buildingName }`) return type — so a flat picker (e.g. a Flow autocomplete with no tree) can tell same-named zones on different buildings apart. `buildingName` equals the zone's own name for a building zone.
+
 ## [43.0.1] - 2026-07-23
 
 ### Fixed
@@ -358,6 +364,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[43.1.0]: https://github.com/OlivierZal/melcloud-api/compare/43.0.1...43.1.0
 [43.0.1]: https://github.com/OlivierZal/melcloud-api/compare/43.0.0...43.0.1
 [43.0.0]: https://github.com/OlivierZal/melcloud-api/compare/42.6.0...43.0.0
 [42.6.0]: https://github.com/OlivierZal/melcloud-api/compare/42.5.0...42.6.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "43.0.1",
+  "version": "43.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "43.0.1",
+      "version": "43.1.0",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "43.0.1",
+  "version": "43.1.0",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/classic.ts
+++ b/src/classic.ts
@@ -39,6 +39,7 @@ export {
   type ClassicErrorLogQuery as ErrorLogQuery,
   type ClassicFacade as Facade,
   type ClassicFailureData as FailureData,
+  type ClassicFlatZone as FlatZone,
   type ClassicFloorData as FloorData,
   type ClassicFloorID as FloorID,
   type ClassicFloorZone as FloorZone,

--- a/src/entities/classic-registry.ts
+++ b/src/entities/classic-registry.ts
@@ -7,11 +7,11 @@ import {
   type ClassicBuildingID,
   type ClassicBuildingZone,
   type ClassicDeviceZone,
+  type ClassicFlatZone,
   type ClassicFloorData,
   type ClassicFloorID,
   type ClassicFloorZone,
   type ClassicListDeviceAny,
-  type ClassicZone,
   toClassicAreaId,
   toClassicBuildingId,
   toClassicFloorId,
@@ -85,26 +85,37 @@ const level = {
   great_grandchild: 3,
 }
 
+const stampDevices = function* (
+  devices: readonly ClassicDeviceZone[],
+  buildingName: string,
+): Generator<ClassicFlatZone> {
+  for (const device of devices) {
+    yield { ...device, buildingName }
+  }
+}
+
 const flattenAreas = function* (
   areas: readonly ClassicAreaZone[],
-): Generator<ClassicZone> {
+  buildingName: string,
+): Generator<ClassicFlatZone> {
   for (const area of areas) {
-    yield area
-    yield* area.devices
+    yield { ...area, buildingName }
+    yield* stampDevices(area.devices, buildingName)
   }
 }
 
 const flattenBuildings = function* (
   buildings: readonly ClassicBuildingZone[],
-): Generator<ClassicZone> {
+): Generator<ClassicFlatZone> {
   for (const building of buildings) {
-    yield building
-    yield* building.devices
-    yield* flattenAreas(building.areas)
+    const { name: buildingName } = building
+    yield { ...building, buildingName }
+    yield* stampDevices(building.devices, buildingName)
+    yield* flattenAreas(building.areas, buildingName)
     for (const floor of building.floors) {
-      yield floor
-      yield* floor.devices
-      yield* flattenAreas(floor.areas)
+      yield { ...floor, buildingName }
+      yield* stampDevices(floor.devices, buildingName)
+      yield* flattenAreas(floor.areas, buildingName)
     }
   }
 }
@@ -331,7 +342,7 @@ export class ClassicRegistry {
    */
   public getZones({
     type,
-  }: { type?: ClassicDeviceType | undefined } = {}): ClassicZone[] {
+  }: { type?: ClassicDeviceType | undefined } = {}): ClassicFlatZone[] {
     return [...flattenBuildings(this.getBuildings({ type }))].toSorted(
       compareNames,
     )

--- a/src/facades/classic-manager.ts
+++ b/src/facades/classic-manager.ts
@@ -9,7 +9,7 @@ import type {
   ClassicModel,
   ClassicRegistry,
 } from '../entities/index.ts'
-import type { ClassicBuildingZone, ClassicZone } from '../types/index.ts'
+import type { ClassicBuildingZone, ClassicFlatZone } from '../types/index.ts'
 import type {
   ClassicBuildingFacade,
   ClassicDeviceFacade,
@@ -96,7 +96,7 @@ export class ClassicFacadeManager {
    */
   public getZones(params?: {
     type?: ClassicDeviceType | undefined
-  }): ClassicZone[] {
+  }): ClassicFlatZone[] {
     return this.#registry.getZones(params)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export type {
   ClassicErrorLogData,
   ClassicErrorLogPostData,
   ClassicFailureData,
+  ClassicFlatZone,
   ClassicFloorData,
   ClassicFloorID,
   ClassicFloorZone,

--- a/src/types/classic-generic.ts
+++ b/src/types/classic-generic.ts
@@ -249,6 +249,15 @@ export interface ClassicFailureData {
 }
 
 /**
+ * A flattened registry zone stamped with its owning building's display
+ * name, so a flat picker (e.g. a Flow autocomplete with no tree) can tell
+ * same-named zones on different buildings apart. `buildingName` equals the
+ * zone's own name for a building zone.
+ * @category Types
+ */
+export type ClassicFlatZone = ClassicZone & { readonly buildingName: string }
+
+/**
  * Wire-format floor entry from `ListDevices`.
  * @category Types
  */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -47,6 +47,7 @@ export type {
   ClassicErrorLogData,
   ClassicErrorLogPostData,
   ClassicFailureData,
+  ClassicFlatZone,
   ClassicFloorData,
   ClassicFloorZone,
   ClassicFrostProtectionData,

--- a/tests/unit/classic-get-zones.test.ts
+++ b/tests/unit/classic-get-zones.test.ts
@@ -221,6 +221,22 @@ describe('zone retrieval', () => {
     expect(models).toContainEqual({ model: 'devices', name: 'AC unit' })
   })
 
+  it('stamps each zone with its owning building name', () => {
+    const byName = new Map(
+      createSyncedRegistry()
+        .getZones()
+        .map((zone) => [zone.name, zone.buildingName]),
+    )
+
+    // A building zone carries its own name; its descendants carry the
+    // building's, so a flat picker can tell same-named zones apart.
+    expect(byName.get('Bravo')).toBe('Bravo')
+    expect(byName.get('Alpha')).toBe('Alpha')
+    expect(byName.get('AC unit')).toBe('Bravo')
+    expect(byName.get('Salon')).toBe('Bravo')
+    expect(byName.get('Studio')).toBe('Alpha')
+  })
+
   it('returns empty list when no devices match', () => {
     expect(
       createSyncedRegistry().getZones({ type: ClassicDeviceType.Erv }),


### PR DESCRIPTION
## What

`ClassicFacadeManager.getZones` / `ClassicRegistry.getZones` now return `ClassicFlatZone[]` — `ClassicZone & { buildingName }` — stamping each flattened zone with its owning building's display name (a building zone carries its own name). Threaded through `flattenBuildings`/`flattenAreas`; the tree `getBuildings` is untouched.

## Why

A flat picker with no tree (a Flow autocomplete) can't disambiguate same-named zones on different buildings from a bare `{ id, level, name }`. Exposing `buildingName` per flattened zone lets the downstream app suffix `(building)` uniformly — matching what the Home device list already does.

Additive field on the return type (`ClassicFlatZone` extends `ClassicZone`), so non-breaking → **43.1.0**.

## Verification

`format` · `lint` · `typecheck` · `test:coverage` (**100%**, 930 tests) · `build` · `docs` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)