### PR TITLE
style: drop the experimentalTernaries flag

### DIFF
--- a/prettier.config.ts
+++ b/prettier.config.ts
@@ -1,7 +1,6 @@
 import type { Config } from 'prettier'
 
 const config: Config = {
-  experimentalTernaries: true,
   plugins: ['prettier-plugin-packagejson'],
   semi: false,
   singleQuote: true,

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -72,14 +72,14 @@ export const classifyError = (error: unknown): ApiRequestError => {
     return {
       kind: 'rate-limited',
       retryAfterMs:
-        error.retryAfter === null ?
-          null
-        : error.retryAfter.total({ unit: 'millisecond' }),
+        error.retryAfter === null
+          ? null
+          : error.retryAfter.total({ unit: 'millisecond' }),
     }
   }
   if (isHttpError(error)) {
-    return error.response.status === HttpStatus.Unauthorized ?
-        { cause: error, kind: 'unauthorized' }
+    return error.response.status === HttpStatus.Unauthorized
+      ? { cause: error, kind: 'unauthorized' }
       : { cause: error, kind: 'server', status: error.response.status }
   }
   return { cause: error, kind: 'network' }
@@ -99,11 +99,11 @@ export const classifyError = (error: unknown): ApiRequestError => {
 export const normalizeUnauthorized = (
   error: unknown,
 ): AuthenticationError | null =>
-  isHttpError(error) && error.response.status === HttpStatus.Unauthorized ?
-    new AuthenticationError('MELCloud rejected the credentials', {
-      cause: error,
-    })
-  : null
+  isHttpError(error) && error.response.status === HttpStatus.Unauthorized
+    ? new AuthenticationError('MELCloud rejected the credentials', {
+        cause: error,
+      })
+    : null
 
 const DEFAULT_TIMEOUT_MS = 30_000
 
@@ -261,12 +261,12 @@ export abstract class BaseAPI implements Disposable {
     this.rateLimitGate = new RateLimitGate({ hours: rateLimitHours })
     this.retryGuard = new RetryGuard(DEFAULT_AUTH_RETRY_COOLDOWN_MS)
     this.api =
-      transport instanceof HttpClient ? transport : (
-        new HttpClient({
-          ...httpConfig,
-          timeout: transport?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-        })
-      )
+      transport instanceof HttpClient
+        ? transport
+        : new HttpClient({
+            ...httpConfig,
+            timeout: transport?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+          })
     this.#syncManager = new SyncManager(
       syncCallback,
       logger,
@@ -638,9 +638,9 @@ export abstract class BaseAPI implements Disposable {
   ): Promise<T> {
     const { schema, ...config } = options
     const { data } = await this.request<T>(method, url, config)
-    return schema === undefined ? data : (
-        parseOrThrow(schema, data, `${method.toUpperCase()} ${url}`)
-      )
+    return schema === undefined
+      ? data
+      : parseOrThrow(schema, data, `${method.toUpperCase()} ${url}`)
   }
 
   /**
@@ -723,9 +723,9 @@ export abstract class BaseAPI implements Disposable {
       return
     }
     const backoffMs =
-      error instanceof AuthenticationThrottledError ?
-        LOGIN_BACKOFF_THROTTLE_MS
-      : LOGIN_BACKOFF_FAILURE_MS
+      error instanceof AuthenticationThrottledError
+        ? LOGIN_BACKOFF_THROTTLE_MS
+        : LOGIN_BACKOFF_FAILURE_MS
     this.#setLoginBackoffUntil(
       Temporal.Now.instant().epochMilliseconds + backoffMs,
     )

--- a/src/api/classic.ts
+++ b/src/api/classic.ts
@@ -137,9 +137,9 @@ const parseErrorLogQuery = (
   const fromDateOverride =
     from !== undefined && from !== '' ? parsePlainDate(from) : null
   const toDate =
-    to !== undefined && to !== '' ?
-      parsePlainDate(to)
-    : Temporal.Now.plainDateISO(timeZone)
+    to !== undefined && to !== ''
+      ? parsePlainDate(to)
+      : Temporal.Now.plainDateISO(timeZone)
   // A page covers `period` days; consecutive pages are separated by a
   // one-day boundary so day N is never returned twice. Each step back
   // therefore moves `period + 1` days, hence the `* (period + 1)`.
@@ -347,8 +347,8 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
                 return []
               }
               const error = errorMessage?.trim() ?? ''
-              return error === '' ?
-                  []
+              return error === ''
+                ? []
                 : [{ date: startDate, deviceId: errorDeviceId, error }]
             },
           )
@@ -674,8 +674,8 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
       // ErrorId 6 is MELCloud's login throttle (LoginStatus 6, high
       // LoginAttempts): the credentials may be perfectly valid — asking
       // the user to re-log would keep the lockout alive.
-      throw errorId === LOGIN_THROTTLE_ERROR_ID ?
-          new AuthenticationThrottledError(
+      throw errorId === LOGIN_THROTTLE_ERROR_ID
+        ? new AuthenticationThrottledError(
             'MELCloud is temporarily blocking sign-ins (too many attempts)',
           )
         : new AuthenticationError('MELCloud Classic rejected the credentials')

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -580,8 +580,8 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
   }
 
   protected getAuthHeaders(): Record<string, string> {
-    return this.accessToken === '' ?
-        {}
+    return this.accessToken === ''
+      ? {}
       : { Authorization: `Bearer ${this.accessToken}` }
   }
 
@@ -722,9 +722,8 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
         strict.error,
       )
     }
-    const data =
-      strict.success ?
-        strict.data
+    const data = strict.success
+      ? strict.data
       : parseOrThrow(HomeResilientContextSchema, raw, 'GET /context (salvage)')
     this.#context = data
     return data

--- a/src/api/token-auth.ts
+++ b/src/api/token-auth.ts
@@ -332,9 +332,9 @@ const extractRedirectTarget = (
     return resolveUrl({ base: currentUrl, location })
   }
   const jsRedirect = extractPageRedirect(response.data)
-  return jsRedirect === null ? null : (
-      resolveUrl({ base: currentUrl, location: jsRedirect })
-    )
+  return jsRedirect === null
+    ? null
+    : resolveUrl({ base: currentUrl, location: jsRedirect })
 }
 
 /**
@@ -426,8 +426,8 @@ const refusedSubmissionMessage = (html: string): string => {
   const match =
     /(?:id|class)="errorMessage[^"]*"[^>]*>(?<message>[^<]*)</v.exec(html)
   const reason = match?.groups?.message?.trim() ?? ''
-  return reason === '' ?
-      'Credential submission was not redirected'
+  return reason === ''
+    ? 'Credential submission was not redirected'
     : `MELCloud Home rejected the sign-in: ${reason}`
 }
 

--- a/src/decorators/classic-update-devices.ts
+++ b/src/decorators/classic-update-devices.ts
@@ -75,17 +75,17 @@ export const classicUpdateDevices =
       }
       const data = await target.call(this, ...args)
       const newData =
-        kind === 'power' ?
-          { Power: arg }
-        : Object.fromEntries(
-            Object.entries(arg ?? data).filter(
-              ([, value]) => value !== undefined && value !== null,
-            ),
-          )
+        kind === 'power'
+          ? { Power: arg }
+          : Object.fromEntries(
+              Object.entries(arg ?? data).filter(
+                ([, value]) => value !== undefined && value !== null,
+              ),
+            )
       const targetDevices =
-        type === undefined ?
-          this.devices
-        : this.devices.filter(({ type: deviceType }) => deviceType === type)
+        type === undefined
+          ? this.devices
+          : this.devices.filter(({ type: deviceType }) => deviceType === type)
       for (const device of targetDevices) {
         device.update(newData)
       }
@@ -113,22 +113,22 @@ export const convertToListDeviceData = <T extends ClassicDeviceType>(
   const effectiveFlagsBigInt =
     effectiveFlags === CLASSIC_FLAG_UNCHANGED ? null : BigInt(effectiveFlags)
   const entries =
-    effectiveFlagsBigInt === null ? allEntries : (
-      allEntries.filter(
-        ([key]) =>
-          isUpdateDeviceData(flags, key) &&
-          // eslint-disable-next-line no-bitwise -- `EffectiveFlags` is a bitfield; `&` tests flag membership
-          Boolean(BigInt(flags[key]) & effectiveFlagsBigInt),
-      )
-    )
+    effectiveFlagsBigInt === null
+      ? allEntries
+      : allEntries.filter(
+          ([key]) =>
+            isUpdateDeviceData(flags, key) &&
+            // eslint-disable-next-line no-bitwise -- `EffectiveFlags` is a bitfield; `&` tests flag membership
+            Boolean(BigInt(flags[key]) & effectiveFlagsBigInt),
+        )
   return typedFromEntries<Partial<ClassicListDeviceData<T>>>(
-    type === ClassicDeviceType.Ata ?
-      entries.map(([key, value]) =>
-        isSetDeviceDataAtaNotInList(key) ?
-          [fromSetToListAta[key], value]
-        : [key, value],
-      )
-    : entries,
+    type === ClassicDeviceType.Ata
+      ? entries.map(([key, value]) =>
+          isSetDeviceDataAtaNotInList(key)
+            ? [fromSetToListAta[key], value]
+            : [key, value],
+        )
+      : entries,
   )
 }
 

--- a/src/entities/classic-registry.ts
+++ b/src/entities/classic-registry.ts
@@ -140,9 +140,9 @@ const buildDeviceZones = (
   type?: ClassicDeviceType,
 ): ClassicDeviceZone[] => {
   const filtered =
-    type === undefined ? devices : (
-      devices.filter(({ type: deviceType }) => deviceType === type)
-    )
+    type === undefined
+      ? devices
+      : devices.filter(({ type: deviceType }) => deviceType === type)
   return filtered
     .map(({ areaId, floorId, id, name }) => ({
       id,
@@ -491,8 +491,8 @@ export class ClassicRegistry {
     if (zone === 'area') {
       return this.getDevicesByAreaId(toClassicAreaId(id))
     }
-    return zone === 'building' ?
-        this.getDevicesByBuildingId(toClassicBuildingId(id))
+    return zone === 'building'
+      ? this.getDevicesByBuildingId(toClassicBuildingId(id))
       : this.getDevicesByFloorId(toClassicFloorId(id))
   }
 
@@ -502,8 +502,8 @@ export class ClassicRegistry {
     type?: ClassicDeviceType,
   ): boolean {
     const devices = this.#getDevicesByZone(id, zone)
-    return type === undefined ?
-        devices.length > 0
+    return type === undefined
+      ? devices.length > 0
       : devices.some(({ type: deviceType }) => deviceType === type)
   }
 }

--- a/src/facades/classic-base-device.ts
+++ b/src/facades/classic-base-device.ts
@@ -115,9 +115,9 @@ const toEnergyReportLabels = (
   return {
     labels: labels.map((label) =>
       String(
-        label === 0 && labelType === ClassicLabelType.day_of_week ?
-          ISO_SUNDAY
-        : label,
+        label === 0 && labelType === ClassicLabelType.day_of_week
+          ? ISO_SUNDAY
+          : label,
       ),
     ),
     labelType,
@@ -227,12 +227,13 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
   protected get setData(): Required<ClassicUpdateDeviceData<T>> {
     const dataEntries = Object.entries(this.data)
     const entries = (
-      this.type === ClassicDeviceType.Ata ?
-        dataEntries.map(([key, value]): [string, unknown] => [
-          isSetDeviceDataAtaInList(key) ? fromListToSetAta[key] : key,
-          value,
-        ])
-      : dataEntries).filter(([key]) => Object.hasOwn(this.flags, key))
+      this.type === ClassicDeviceType.Ata
+        ? dataEntries.map(([key, value]): [string, unknown] => [
+            isSetDeviceDataAtaInList(key) ? fromListToSetAta[key] : key,
+            value,
+          ])
+        : dataEntries
+    ).filter(([key]) => Object.hasOwn(this.flags, key))
     return typedFromEntries<Required<ClassicUpdateDeviceData<T>>>(entries)
   }
 
@@ -445,9 +446,8 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
     const toDate = toWallClock(to, this.api.timezone)
     return {
       DeviceID: this.id,
-      Duration:
-        shouldUseExactRange ?
-          getDuration({ from: fromDate, to: toDate })
+      Duration: shouldUseExactRange
+        ? getDuration({ from: fromDate, to: toDate })
         : undefined,
       FromDate: fromDate,
       ToDate: toDate,

--- a/src/facades/classic-base.ts
+++ b/src/facades/classic-base.ts
@@ -83,16 +83,16 @@ const throwLocationError = (error: ApiRequestError): never => {
 const getDateTimeComponents = (
   date: Temporal.PlainDateTime | null,
 ): ClassicDateTimeComponents =>
-  date === null ? null : (
-    {
-      Day: date.day,
-      Hour: date.hour,
-      Minute: date.minute,
-      Month: date.month,
-      Second: date.second,
-      Year: date.year,
-    }
-  )
+  date === null
+    ? null
+    : {
+        Day: date.day,
+        Hour: date.hour,
+        Minute: date.minute,
+        Month: date.month,
+        Second: date.second,
+        Year: date.year,
+      }
 
 /**
  * Abstract base for all facades. Provides common functionality for frost protection,
@@ -405,8 +405,8 @@ export abstract class ClassicBaseFacade<
         throwLocationError(result.error)
       }
     }
-    return this.isFrostProtectionAtZoneLevel === true ?
-        { [this.frostProtectionLocation]: [this.id] }
+    return this.isFrostProtectionAtZoneLevel === true
+      ? { [this.frostProtectionLocation]: [this.id] }
       : { DeviceIds: this.#deviceIds }
   }
 
@@ -417,8 +417,8 @@ export abstract class ClassicBaseFacade<
         throwLocationError(result.error)
       }
     }
-    return this.isHolidayModeAtZoneLevel === true ?
-        [{ [this.holidayModeLocation]: [this.id] }]
+    return this.isHolidayModeAtZoneLevel === true
+      ? [{ [this.holidayModeLocation]: [this.id] }]
       : [{ Devices: this.#deviceIds }]
   }
 

--- a/src/facades/classic-device-ata.ts
+++ b/src/facades/classic-device-ata.ts
@@ -28,9 +28,9 @@ const isSet = <T>(value: T | null | undefined): value is T =>
 const toGroupFanSpeed = (
   fanSpeed: ClassicFanSpeed | undefined,
 ): ClassicNonSilentFanSpeed | null =>
-  fanSpeed === undefined || fanSpeed === ClassicFanSpeed.silent ?
-    null
-  : fanSpeed
+  fanSpeed === undefined || fanSpeed === ClassicFanSpeed.silent
+    ? null
+    : fanSpeed
 
 // Group-state keys map onto the per-device update tags (`FanSpeed` →
 // `SetFanSpeed`, the vane directions lose their `Direction` suffix); the

--- a/src/facades/classic-device-atw-dual-zone.ts
+++ b/src/facades/classic-device-atw-dual-zone.ts
@@ -92,9 +92,9 @@ export class ClassicDeviceAtwHasZone2Facade extends ClassicDeviceAtwFacade {
     // Whichever zone was explicitly changed becomes the primary; the other
     // is automatically adjusted to maintain consistency
     const [primaryOperationMode, secondaryOperationMode] =
-      operationModeZone1?.value === undefined ?
-        [operationModeZone2, operationModeZone1]
-      : [operationModeZone1, operationModeZone2]
+      operationModeZone1?.value === undefined
+        ? [operationModeZone2, operationModeZone1]
+        : [operationModeZone1, operationModeZone2]
 
     if (
       secondaryOperationMode === undefined ||
@@ -123,9 +123,9 @@ export class ClassicDeviceAtwHasZone2Facade extends ClassicDeviceAtwFacade {
     if (this.data.CanCool) {
       if (primaryValue > ClassicOperationModeZone.curve) {
         secondaryValue =
-          secondaryValue === ClassicOperationModeZone.curve ?
-            ClassicOperationModeZone.room_cool
-          : secondaryValue + HEAT_COOL_GAP
+          secondaryValue === ClassicOperationModeZone.curve
+            ? ClassicOperationModeZone.room_cool
+            : secondaryValue + HEAT_COOL_GAP
       } else if (secondaryValue > ClassicOperationModeZone.curve) {
         secondaryValue -= HEAT_COOL_GAP
       }

--- a/src/facades/classic-device-atw.ts
+++ b/src/facades/classic-device-atw.ts
@@ -69,8 +69,8 @@ const getHotWaterOperationalState = (
   if (data.ForcedHotWaterMode) {
     return ClassicOperationModeStateHotWater.dhw
   }
-  return data.ProhibitHotWater ?
-      ClassicOperationModeStateHotWater.prohibited
+  return data.ProhibitHotWater
+    ? ClassicOperationModeStateHotWater.prohibited
     : (hotWaterStateMap[data.OperationMode] ??
         ClassicOperationModeStateHotWater.idle)
 }
@@ -85,8 +85,8 @@ const getZoneOperationalState = (
   ) {
     return ClassicOperationModeStateZone.prohibited
   }
-  return data[`Idle${zone}`] ?
-      ClassicOperationModeStateZone.idle
+  return data[`Idle${zone}`]
+    ? ClassicOperationModeStateZone.idle
     : (zoneStateMap[data.OperationMode] ?? ClassicOperationModeStateZone.idle)
 }
 

--- a/src/facades/classic-factory.ts
+++ b/src/facades/classic-factory.ts
@@ -36,8 +36,8 @@ const createDeviceFacade = (
     return new ClassicDeviceAtaFacade(api, registry, device)
   }
   if (isClassicDeviceOfType(device, ClassicDeviceType.Atw)) {
-    return device.data.HasZone2 ?
-        new ClassicDeviceAtwHasZone2Facade(api, registry, device)
+    return device.data.HasZone2
+      ? new ClassicDeviceAtwHasZone2Facade(api, registry, device)
       : new ClassicDeviceAtwFacade(api, registry, device)
   }
   return new ClassicDeviceErvFacade(api, registry, device)

--- a/src/facades/home-base-device.ts
+++ b/src/facades/home-base-device.ts
@@ -146,12 +146,12 @@ export abstract class HomeBaseDeviceFacade<TData extends HomeDeviceData> {
     hour?: Hour,
   ): Promise<Result<ReportChartLineOptions>> {
     const { cutoff, window } =
-      hour === undefined ?
-        resolveHomeDayWindow(this.chartTimezone)
-      : {
-          cutoff: undefined,
-          window: resolveHomeHourWindow(hour, this.chartTimezone),
-        }
+      hour === undefined
+        ? resolveHomeDayWindow(this.chartTimezone)
+        : {
+            cutoff: undefined,
+            window: resolveHomeHourWindow(hour, this.chartTimezone),
+          }
     return mapResult(
       await this.api.getSignal(this.id, toHomeWireWindow(window)),
       (data) =>

--- a/src/facades/home-device-ata.ts
+++ b/src/facades/home-device-ata.ts
@@ -321,8 +321,8 @@ export class HomeDeviceAtaFacade extends HomeBaseDeviceFacade<HomeAtaDeviceData>
     }
     const mode = operationMode ?? this.operationMode
     const getRange = temperatureRanges.get(mode)
-    return getRange === undefined ?
-        { setTemperature: value }
+    return getRange === undefined
+      ? { setTemperature: value }
       : { setTemperature: clampToRange(value, getRange(this.capabilities)) }
   }
 

--- a/src/facades/home-device-atw.ts
+++ b/src/facades/home-device-atw.ts
@@ -160,8 +160,8 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
     if (this.forcedHotWaterMode) {
       return ClassicOperationModeStateHotWater.dhw
     }
-    return this.prohibitHotWater ?
-        ClassicOperationModeStateHotWater.prohibited
+    return this.prohibitHotWater
+      ? ClassicOperationModeStateHotWater.prohibited
       : (hotWaterStateFromOperationMode[this.operationMode] ??
           ClassicOperationModeStateHotWater.idle)
   }
@@ -411,12 +411,12 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
     hour?: Hour,
   ): Promise<Result<ReportChartLineOptions>> {
     const { cutoff, window } =
-      hour === undefined ?
-        resolveHomeDayWindow(this.chartTimezone)
-      : {
-          cutoff: undefined,
-          window: resolveHomeHourWindow(hour, this.chartTimezone),
-        }
+      hour === undefined
+        ? resolveHomeDayWindow(this.chartTimezone)
+        : {
+            cutoff: undefined,
+            window: resolveHomeHourWindow(hour, this.chartTimezone),
+          }
     return this.#fetchTemperatureChart(
       window,
       hour === undefined ? 'fiveMinutes' : 'minute',
@@ -583,10 +583,9 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
         ...(gridUnit !== undefined && { gridUnit }),
         cutoff,
         locale: this.api.locale,
-        reports:
-          shouldChartBands ? reports : (
-            reports.map((report) => ({ ...report, annotations: [] }))
-          ),
+        reports: shouldChartBands
+          ? reports
+          : reports.map((report) => ({ ...report, annotations: [] })),
         unit: TEMPERATURE_UNIT,
         window,
       }),

--- a/src/facades/home-manager.ts
+++ b/src/facades/home-manager.ts
@@ -60,9 +60,8 @@ export class HomeFacadeManager {
     if (cached !== undefined) {
       return cached
     }
-    const facade =
-      instance.isAta() ?
-        new HomeDeviceAtaFacade(this.#api, instance)
+    const facade = instance.isAta()
+      ? new HomeDeviceAtaFacade(this.#api, instance)
       : new HomeDeviceAtwFacade(this.#api, instance)
     this.#facades.set(instance, facade)
     return facade

--- a/src/facades/home-report.ts
+++ b/src/facades/home-report.ts
@@ -352,9 +352,9 @@ export const resolveHomeReportWindow = (
   timezone: string,
 ): HomeChartWindow => {
   const to =
-    query?.to === undefined ?
-      Temporal.Now.zonedDateTimeISO(timezone)
-    : parseQueryDate(query.to, timezone)
+    query?.to === undefined
+      ? Temporal.Now.zonedDateTimeISO(timezone)
+      : parseQueryDate(query.to, timezone)
   const earliest = to.subtract({ days: MAX_REPORT_SPAN_DAYS })
   const from =
     query?.from === undefined ? earliest : parseQueryDate(query.from, timezone)
@@ -493,8 +493,8 @@ const gridLabelOptions = (
     return { hour: '2-digit', minute: '2-digit' }
   }
   // Only the hourly unit reaches this point.
-  return windowDaysOf(window) > 1 ?
-      { day: 'numeric', hour: '2-digit', minute: '2-digit', month: 'short' }
+  return windowDaysOf(window) > 1
+    ? { day: 'numeric', hour: '2-digit', minute: '2-digit', month: 'short' }
     : { hour: '2-digit', minute: '2-digit' }
 }
 
@@ -862,9 +862,8 @@ const toEnergySlotLabel = (
       .toPlainDateTime()
   }
   return (
-    bucketUnit === 'localDay' ?
-      Temporal.PlainDate
-    : Temporal.PlainDateTime).from(slot)
+    bucketUnit === 'localDay' ? Temporal.PlainDate : Temporal.PlainDateTime
+  ).from(slot)
 }
 
 const energyGridBuilders: Record<
@@ -908,9 +907,9 @@ export const toHomeEnergyOptions = ({
   const slots = energyGridBuilders[bucketUnit](window)
   const formatter = new Intl.DateTimeFormat(
     locale,
-    bucketUnit === 'hour' ?
-      { hour: '2-digit', minute: '2-digit' }
-    : { day: 'numeric', month: 'short' },
+    bucketUnit === 'hour'
+      ? { hour: '2-digit', minute: '2-digit' }
+      : { day: 'numeric', month: 'short' },
   )
   return {
     from: window.from.toPlainDateTime().toString(),

--- a/src/frost-protection.ts
+++ b/src/frost-protection.ts
@@ -32,9 +32,9 @@ export const clampFrostProtection = (
   )
   return {
     max:
-      clampedMax - clampedMin < FROST_PROTECTION_GAP ?
-        clampedMin + FROST_PROTECTION_GAP
-      : clampedMax,
+      clampedMax - clampedMin < FROST_PROTECTION_GAP
+        ? clampedMin + FROST_PROTECTION_GAP
+        : clampedMax,
     min: clampedMin,
   }
 }

--- a/src/http/client.ts
+++ b/src/http/client.ts
@@ -106,8 +106,8 @@ const buildUrl = (
   if (queryString === '') {
     return fullUrl
   }
-  return fullUrl.includes('?') ?
-      `${fullUrl}&${queryString}`
+  return fullUrl.includes('?')
+    ? `${fullUrl}&${queryString}`
     : `${fullUrl}?${queryString}`
 }
 

--- a/src/resilience/rate-limit-gate.ts
+++ b/src/resilience/rate-limit-gate.ts
@@ -16,9 +16,9 @@ const pluralize = (count: number, unit: string): string =>
   count === 1 ? unit : `${unit}s`
 
 const parseDeltaSeconds = (seconds: number): Temporal.Duration | null =>
-  Number.isFinite(seconds) && seconds > 0 ?
-    Temporal.Duration.from({ seconds })
-  : null
+  Number.isFinite(seconds) && seconds > 0
+    ? Temporal.Duration.from({ seconds })
+    : null
 
 const parseHttpDate = (
   value: string,
@@ -112,8 +112,8 @@ export class RateLimitGate {
    */
   public get remaining(): Temporal.Duration | null {
     const now = Temporal.Now.instant()
-    return Temporal.Instant.compare(this.#pausedUntil, now) > 0 ?
-        this.#pausedUntil.since(now)
+    return Temporal.Instant.compare(this.#pausedUntil, now) > 0
+      ? this.#pausedUntil.since(now)
       : null
   }
 

--- a/src/resilience/retry-backoff.ts
+++ b/src/resilience/retry-backoff.ts
@@ -89,9 +89,9 @@ export interface RetryBackoffOptions {
 // to an Error so Promise rejections always satisfy
 // `prefer-promise-reject-errors` and downstream `instanceof Error` checks.
 const toAbortReason = (signal: AbortSignal): Error =>
-  signal.reason instanceof Error ?
-    signal.reason
-  : new Error(String(signal.reason))
+  signal.reason instanceof Error
+    ? signal.reason
+    : new Error(String(signal.reason))
 
 // Wrapper over `setTimeout` that surfaces the caller's `signal` as a
 // rejection mid-wait. We use the global `setTimeout` (rather than

--- a/src/types/classic-generic.ts
+++ b/src/types/classic-generic.ts
@@ -535,8 +535,9 @@ export interface ClassicTemperatureLogPostData extends ClassicReportPostData {
  * @category Types
  */
 export interface ClassicTilesData<T extends ClassicDeviceType | null> {
-  readonly SelectedDevice: T extends ClassicDeviceType ? ClassicGetDeviceData<T>
-  : null
+  readonly SelectedDevice: T extends ClassicDeviceType
+    ? ClassicGetDeviceData<T>
+    : null
   readonly Tiles: readonly {
     readonly Device: number
     readonly Offline: boolean
@@ -555,9 +556,9 @@ export interface ClassicTilesData<T extends ClassicDeviceType | null> {
  */
 export type ClassicTilesPostData<T extends ClassicDeviceType | null> = {
   readonly DeviceIDs: number | readonly number[]
-} & (T extends ClassicDeviceType ?
-  { readonly SelectedBuilding: number; readonly SelectedDevice: number }
-: { readonly SelectedBuilding?: null; readonly SelectedDevice?: null })
+} & (T extends ClassicDeviceType
+  ? { readonly SelectedBuilding: number; readonly SelectedDevice: number }
+  : { readonly SelectedBuilding?: null; readonly SelectedDevice?: null })
 
 /**
  * Mutable fields for a `Device/Set{Ata,Atw,Erv}` payload, narrowed by device type.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -397,12 +397,10 @@ export const withMinuteClockLabels = (
     ...options,
     labels: options.labels.map((label) => {
       const minute = Number(label)
-      return (
-          Number.isSafeInteger(minute) &&
-            minute >= 0 &&
-            minute <= MAX_MINUTE_LABEL
-        ) ?
-          formatter.format(new Temporal.PlainTime(hour, minute))
+      return Number.isSafeInteger(minute) &&
+        minute >= 0 &&
+        minute <= MAX_MINUTE_LABEL
+        ? formatter.format(new Temporal.PlainTime(hour, minute))
         : label
     }),
   }

--- a/tests/integration/api-lifecycle.test.ts
+++ b/tests/integration/api-lifecycle.test.ts
@@ -311,9 +311,9 @@ describe('api lifecycle', () => {
     mockRequest.mockImplementation(async (config) =>
       cast({
         data:
-          config.url === '/FrostProtection/Update' ?
-            { AttributeErrors: null, Success: true }
-          : buildingResponse,
+          config.url === '/FrostProtection/Update'
+            ? { AttributeErrors: null, Success: true }
+            : buildingResponse,
         headers: {},
         status: 200,
       }),
@@ -462,13 +462,11 @@ describe('api lifecycle', () => {
 
       expect(abortResult.ok).toBe(false)
       expect(
-        (
-          !abortResult.ok &&
-            'cause' in abortResult.error &&
-            abortResult.error.cause instanceof Error
-        ) ?
-          abortResult.error.cause.message
-        : '<unexpected success>',
+        !abortResult.ok &&
+          'cause' in abortResult.error &&
+          abortResult.error.cause instanceof Error
+          ? abortResult.error.cause.message
+          : '<unexpected success>',
       ).toMatch(/abort/iv)
     })
   })

--- a/tests/unit/base-api.test.ts
+++ b/tests/unit/base-api.test.ts
@@ -87,9 +87,9 @@ class TestAPI extends BaseAPI {
     }: { shouldUseDefaultTransport?: boolean } = {},
   ) {
     super(
-      shouldUseDefaultTransport ? config : (
-        { transport: mockHttpClient, ...config }
-      ),
+      shouldUseDefaultTransport
+        ? config
+        : { transport: mockHttpClient, ...config },
       {
         defaultSyncIntervalMinutes: false,
         httpConfig: { baseURL: 'https://test.api' },

--- a/tests/unit/classic-api.test.ts
+++ b/tests/unit/classic-api.test.ts
@@ -360,10 +360,16 @@ describe('mELCloud Classic API', () => {
       const api = await createApi({ password: 'pass', username: 'user' })
       mockRequest.mockResolvedValue(
         wrap(
-          method === 'login' ?
-            { LoginData: { ContextKey: 'ctx', Expiry: '2099-01-01T00:00:00Z' } }
-          : method === 'getEnergy' ? ataEnergyResponse
-          : {},
+          method === 'login'
+            ? {
+                LoginData: {
+                  ContextKey: 'ctx',
+                  Expiry: '2099-01-01T00:00:00Z',
+                },
+              }
+            : method === 'getEnergy'
+              ? ataEnergyResponse
+              : {},
         ),
       )
       await api[method](cast(args))

--- a/tests/unit/retry-backoff.test.ts
+++ b/tests/unit/retry-backoff.test.ts
@@ -10,11 +10,11 @@ const ALWAYS_RETRYABLE = (): boolean => true
 const NEVER_RETRYABLE = (): boolean => false
 
 const httpError = (status?: number): unknown =>
-  status === undefined ?
-    new Error('network failure')
-  : new HttpError(`Status ${String(status)}`, {
-      response: { data: {}, headers: {}, status },
-    })
+  status === undefined
+    ? new Error('network failure')
+    : new HttpError(`Status ${String(status)}`, {
+        response: { data: {}, headers: {}, status },
+      })
 
 describe(isTransientServerError, () => {
   it.each([502, 503, 504])('returns true for HTTP %i', (status) => {


### PR DESCRIPTION
Removes `experimentalTernaries: true` from `prettier.config.ts` and reformats (28 files). Family-wide change — rationale in OlivierZal/com.melcloud#1471. Formatting-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)