### PR TITLE
docs: prune comments to the doctrine (intent and constraint only)

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -49,9 +49,8 @@ const typeLikeSortOptions = {
 
 const config = defineConfig([
   {
-    // `scripts/` holds one-shot wire probes committed as dated evidence
-    // artifacts (cited from CLAUDE.md), not shipped code — they stay
-    // outside the lint scope by decision, like the build outputs.
+    // `scripts/` holds gitignored one-shot wire probes, not shipped
+    // code — outside the lint scope by decision, like the build outputs.
     ignores: ['coverage/', 'dist/', 'docs/', 'scripts/'],
   },
   {
@@ -851,7 +850,7 @@ const config = defineConfig([
   {
     files: ['*.config.ts'],
     rules: {
-      // Config loaders (eslint, vitest, typedoc) consume default exports.
+      // Config loaders (eslint, vitest, prettier) consume default exports.
       'import-x/no-default-export': 'off',
       'import-x/prefer-default-export': [
         'error',
@@ -938,10 +937,8 @@ const config = defineConfig([
     },
   },
   {
-    // TC39 decorator protocol: the replacement method receives the
-    // instance through `this` (no class body to put it in), and the
-    // `context` parameter is what pins the decorator kind at type level
-    // even when unused.
+    // TC39 decorator protocol: the `context` parameter pins the
+    // decorator kind at type level even when unused.
     files: ['src/decorators/**/*.ts'],
     rules: {
       '@typescript-eslint/no-unused-vars': [

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -108,9 +108,8 @@ export const normalizeUnauthorized = (
 const DEFAULT_TIMEOUT_MS = 30_000
 
 // Cool-down between consecutive auth-retry consumptions on the same
-// RetryGuard. Hardcoded because no caller has ever needed to tune it
-// — every Classic + Home flow uses the same 1 s value, and adjusting
-// it is more likely to mask bugs than reflect a real product need.
+// RetryGuard. Deliberately not configurable: adjusting it is more
+// likely to mask bugs than reflect a real product need.
 const DEFAULT_AUTH_RETRY_COOLDOWN_MS = 1000
 
 // Automatic re-login backoff after a REJECTED sign-in: MELCloud

--- a/src/api/classic-types.ts
+++ b/src/api/classic-types.ts
@@ -45,9 +45,8 @@ import type { BaseAPIConfig, SyncCallback } from './types.ts'
  *
  * Every method returns the unwrapped payload (no `{ data }` wrapper).
  * Transport metadata (status, headers) lives inside the SDK on
- * `request<T>()`; consumers don't see it. This is the resource-focused
- * convention (Stripe, Linear) — applied uniformly across both Classic
- * and Home so the public surface is symmetric.
+ * `request<T>()`; consumers don't see it. Applied uniformly across
+ * both Classic and Home so the public surface is symmetric.
  * @category Configuration
  */
 export interface ClassicAPIAdapter {

--- a/src/api/classic.ts
+++ b/src/api/classic.ts
@@ -82,7 +82,7 @@ const INVALID_YEAR = 1
 
 // Re-thrown with the historical "Invalid DateTime" prefix so the
 // public failure surface for `getErrorLog({ to: 'not-a-date' })` stays
-// stable across the Luxon → Temporal migration.
+// stable.
 const parsePlainDate = (iso: string): Temporal.PlainDate => {
   try {
     return Temporal.PlainDate.from(iso)
@@ -109,8 +109,7 @@ const plainDateYear = (iso: string): number | null => {
 
 // Year extraction across both MELCloud date dialects — the sentinel
 // arrives as an instant too (`0001-01-01T00:00:00Z`, live payload
-// 2026-07-18), which `PlainDate.from` rejects. Parse-failure behavior
-// still mirrors the original Luxon semantics: a bad input does NOT
+// 2026-07-18), which `PlainDate.from` rejects. A bad input does NOT
 // short-circuit as "invalid year 1" — it falls through and the entry
 // is kept. Only the year-1 sentinel gets filtered.
 const safePlainDateYear = (iso: string): number =>

--- a/src/api/token-auth.ts
+++ b/src/api/token-auth.ts
@@ -11,10 +11,6 @@ import {
   parseOrThrow,
 } from '../validation/index.ts'
 
-// ------------------------------------------------------------------
-//  Constants
-// ------------------------------------------------------------------
-
 const CLIENT_ID = 'homemobile'
 const REDIRECT_URI = 'melcloudhome://'
 const SCOPES = 'openid profile email offline_access IdentityServerApi'
@@ -30,10 +26,6 @@ const PKCE_RANDOM_BYTES = 32
 const STATE_RANDOM_BYTES = 16
 const REDIRECT_STATUS_MIN = 300
 const REDIRECT_STATUS_MAX = 400
-
-// ------------------------------------------------------------------
-//  Types
-// ------------------------------------------------------------------
 
 /** Options for {@link authRequest}. */
 interface AuthRequestOptions {
@@ -81,10 +73,6 @@ interface SubmitCredentialsOptions {
   jar: CookieJar
   abortSignal?: AbortSignal
 }
-
-// ------------------------------------------------------------------
-//  HTTP transport (fetch-based)
-// ------------------------------------------------------------------
 
 const readResponseHeaders = (
   headers: Headers,
@@ -218,10 +206,6 @@ const authRequest = async ({
   return response
 }
 
-// ------------------------------------------------------------------
-//  Helpers
-// ------------------------------------------------------------------
-
 /**
  * Extract the `action` attribute from the first `<form>` element in an HTML string.
  * @param html - Raw HTML string from the login page.
@@ -310,10 +294,6 @@ const generatePKCE = (): { challenge: string; verifier: string } => {
   return { challenge, verifier }
 }
 
-// ------------------------------------------------------------------
-//  Redirect-following
-// ------------------------------------------------------------------
-
 /**
  * Extract the redirect target from an HTTP or JS redirect response.
  * @param response - The raw HTTP response.
@@ -379,10 +359,6 @@ const authFollowRedirects = async ({
   }
   return { data: response.data, url }
 }
-
-// ------------------------------------------------------------------
-//  Auth flow steps
-// ------------------------------------------------------------------
 
 /**
  * Push Authorization Request — returns the opaque `request_uri`.
@@ -547,10 +523,6 @@ const tokenRequest = async ({
   return parseOrThrow(HomeTokenResponseSchema, tokens, 'OIDC token endpoint')
 }
 
-// ------------------------------------------------------------------
-//  Public surface
-// ------------------------------------------------------------------
-
 /**
  * Full headless OIDC login: PAR → Cognito → token exchange.
  * @param options - Credentials plus abort plumbing for the full login flow.
@@ -601,8 +573,7 @@ export const performTokenAuth = async ({
  * on **any** failure so the caller can fall through to a full re-auth
  * without threading an exception up the stack — but logs the error
  * reason via the optional logger so the failure mode (expired refresh
- * token vs. transient network flake vs. 5xx) stays observable. Prior
- * behaviour silently discarded all diagnostic context.
+ * token vs. transient network flake vs. 5xx) stays observable.
  * @param options - Refresh token plus logging and abort plumbing.
  * @param options.refreshToken - The user's refresh token.
  * @param options.abortSignal - Optional signal to abort the refresh.

--- a/src/decorators/classic-update-devices.ts
+++ b/src/decorators/classic-update-devices.ts
@@ -27,9 +27,6 @@ import {
  * - `'power'`: specialisation for power-toggle methods whose argument
  *   is a bare `boolean` rather than an object. The boolean is wrapped
  *   into `{ Power: bool }` before the propagation step.
- *
- * Replacing the former `String(context.name) === 'updatePower'`
- * heuristic: a silent rename is no longer a latent bug.
  * @internal
  */
 type UpdatePatchKind = 'payload' | 'power'

--- a/src/enum-mappings.ts
+++ b/src/enum-mappings.ts
@@ -10,10 +10,6 @@ import { isKeyOf } from './utils.ts'
 
 // Bidirectional mapping tables between classic API numeric enums
 // and Home API string values.
-//
-// Classic → Home: used by ClassicAtaAdapter to normalize output.
-// Home → Classic: used by ClassicAtaAdapter to convert normalized input
-// back to the classic API format.
 
 /**
  * Home API fan speed string values.

--- a/src/facades/classic-base.ts
+++ b/src/facades/classic-base.ts
@@ -52,9 +52,6 @@ import type { ReportChartLineOptions } from './report-types.ts'
 
 // Settings can be defined at zone or device level. Try zone first;
 // if unsupported, fall back to device level and cache the result.
-// Result-aware fallback: a `!ok` zone result triggers the device-level
-// retry, mirroring the previous try/catch semantic without losing the
-// typed-failure surface for the final outcome.
 const getWithZoneFallback = async <TResult>(
   isAtZoneLevel: boolean | null,
   zoneGetter: () => Promise<Result<TResult>>,

--- a/src/facades/classic-flags.ts
+++ b/src/facades/classic-flags.ts
@@ -4,10 +4,8 @@ import type { ClassicUpdateDeviceData } from '../types/index.ts'
 // MELCloud EffectiveFlags bitfield values — each bit tells the Classic
 // API which fields in an update payload should actually be applied.
 //
-// Centralised here (not on each facade) so:
-//   - all magic hex constants live in a single table,
-//   - comparing bit assignments across device types is possible at a glance,
-//   - new device types or new fields are added by extending one map.
+// Centralised here (not on each facade): the single sanctioned home of
+// the flag hex constants, comparable across device types at a glance.
 //
 // Each map carries a literal-typed annotation so callers see the exact
 // bit value at type level (e.g. `classicAtaFlags.Power: 0x1`, not

--- a/src/facades/home-base-device.ts
+++ b/src/facades/home-base-device.ts
@@ -203,8 +203,7 @@ export abstract class HomeBaseDeviceFacade<TData extends HomeDeviceData> {
 
   /**
    * Reads a numeric device setting (the BFF serializes numbers as
-   * strings). An absent setting reads `0` (`Number('')`), matching the
-   * pre-helper behavior of every call site.
+   * strings). An absent setting reads `0` (`Number('')`).
    * @param name - Setting name (e.g. `'RoomTemperatureZone1'`).
    * @returns The wire string parsed as a number, `0` when absent.
    */

--- a/src/http/client.ts
+++ b/src/http/client.ts
@@ -1,10 +1,6 @@
 import { HttpError } from './errors.ts'
 
-// `fetch()` in Node 22+ accepts `dispatcher` (undici-specific). We import
-// the type from undici-types (the copy bundled with @types/node that
-// Node's `fetch()` declaration uses) so passing a dispatcher
-// instantiated from the `undici` runtime package remains structurally
-// compatible with what fetch expects.
+// `fetch()` in Node 22+ accepts `dispatcher` (undici-specific).
 type FetchBody = NonNullable<FetchInit['body']>
 
 // `Dispatcher` is defined both in the `undici` npm package and in
@@ -36,9 +32,6 @@ export interface HttpClientConfig {
 
 /**
  * Configuration accepted by {@link HttpClient.request}.
- *
- * Intentionally mirrors the subset of the Axios request config that the
- * library relied on, so call sites migrate verbatim.
  * @category HTTP
  */
 export interface HttpRequestConfig {
@@ -140,11 +133,11 @@ const readHeaders = (headers: Headers): Record<string, string | string[]> => {
   return result
 }
 
-// Try JSON first, fall back to text. Axios auto-parses bodies by default —
-// content-type from upstream can be absent or a JSON variant the strict
-// `application/json` substring misses (e.g. `text/json`, `application/problem+json`).
-// Matching on parseability keeps those callers working without a content-type
-// allowlist that drifts with every new server flavour.
+// Try JSON first, fall back to text: content-type from upstream can be
+// absent or a JSON variant a strict `application/json` substring check
+// misses (e.g. `text/json`, `application/problem+json`). Matching on
+// parseability avoids a content-type allowlist that drifts with every
+// new server flavour.
 const parseBody = async (response: Response): Promise<unknown> => {
   if (
     response.status === NULL_BODY_STATUS ||

--- a/src/http/errors.ts
+++ b/src/http/errors.ts
@@ -13,9 +13,7 @@ export interface HttpErrorRequestConfig {
 /**
  * Thrown by {@link HttpClient} whenever an upstream response has a non-2xx
  * status. The shape mirrors what downstream code needs: `response.status`,
- * `response.headers`, and `response.data` — identical to the relevant
- * surface of the previous `AxiosError` contract so retry/rate-limit logic
- * does not need to branch on the error's origin.
+ * `response.headers`, and `response.data`.
  * @template T - Type of the parsed body of the failed response, exposed as
  * `response.data`.
  * @category HTTP

--- a/src/resilience/policy.ts
+++ b/src/resilience/policy.ts
@@ -4,9 +4,7 @@
  * Each policy owns exactly one concern (rate-limiting, auth retry,
  * transient-error retry…) and wraps the caller's `attempt` with its
  * own semantics. Policies are **composed** via {@link CompositePolicy}
- * to build the request pipeline declaratively, replacing the prior
- * inline `makeRequestAttempt` chain whose stages were tangled across
- * `BaseAPI.request`, `makeRequestAttempt`, and `runWithEvents`.
+ * to build the request pipeline declaratively.
  *
  * Implementations MUST:
  * - run the caller's `attempt` at most once per `run` invocation per

--- a/src/resilience/retry-backoff.ts
+++ b/src/resilience/retry-backoff.ts
@@ -152,8 +152,6 @@ export const withRetryBackoff = async <T>(
   // Recursive shape (over a loop) makes the sequential nature of each
   // attempt structural: every retry strictly awaits the previous
   // attempt's settlement and the backoff delay before the next call.
-  // Also gives the function a single, type-checked exit — no need for
-  // an unreachable post-loop throw.
   const attempt = async (number: number): Promise<T> => {
     try {
       return await operation()

--- a/src/temporal.ts
+++ b/src/temporal.ts
@@ -3,9 +3,9 @@
 // does not yet ship native `Temporal`; the polyfill stays bundled
 // until Node 22 reaches EOL (April 2027), at which point this module
 // and the dependency can be replaced with `globalThis.Temporal`.
-// Since v1, the polyfill's default entrypoint delegates to the native
-// `Temporal` when the runtime provides one (0.x never did), so newer
-// runtimes get the native implementation through this same import.
+// The polyfill's default entrypoint delegates to the native `Temporal`
+// when the runtime provides one, so newer runtimes get the native
+// implementation through this same import.
 //
 // The polyfill's `Intl` export is re-exported too: it is the
 // Temporal-aware `Intl.DateTimeFormat` that formats Temporal objects

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -17,9 +17,7 @@ export interface Failure {
  * The error type is fixed to {@link ApiRequestError} rather than
  * generic: every call site in the SDK fails through the same
  * classification pipeline, so a `<TError>` parameter would be a
- * degree of freedom nothing exercises. General-purpose Result
- * libraries (neverthrow, ts-results) keep it generic because they
- * cannot assume a single domain; domain-specific SDKs lock it.
+ * degree of freedom nothing exercises.
  * @template T - Type of the parsed value carried by the success branch.
  * @category Types
  */
@@ -56,8 +54,7 @@ export const err = (error: ApiRequestError): Failure => ({
 
 /**
  * Transform the success branch of a {@link Result} while passing the
- * failure branch through unchanged. The standard "functor map" operation
- * from neverthrow / ts-results / oxide; lets callers compose
+ * failure branch through unchanged. Lets callers compose
  * Result-returning calls with synchronous transforms (e.g.
  * `mapResult(await api.getEnergy(...), getChartLineOptions)`) without
  * unwrapping then re-wrapping by hand.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,11 +33,10 @@ interface LabelFormatterCache {
 // Per-locale `Intl.DateTimeFormat` cache. Keyed on the locale string
 // (or `''` for the runtime default) so repeat calls with the same
 // locale reuse the same formatter pair without re-allocating on each
-// chart-options call. Modern best practice: the locale is carried as
-// an explicit argument by each call site, never via a mutable global.
-// The formatters come from the polyfill's Temporal-aware `Intl` and
-// consume `Temporal.PlainDate` values directly; plain types format
-// their own calendar fields, so no `timeZone` option is involved.
+// chart-options call. The formatters come from the polyfill's
+// Temporal-aware `Intl` and consume `Temporal.PlainDate` values
+// directly; plain types format their own calendar fields, so no
+// `timeZone` option is involved.
 const formatterCacheByLocale = new Map<string, LabelFormatterCache>()
 
 const getLabelFormatters = (
@@ -291,9 +290,6 @@ export interface ChartLineFormatOptions {
 /**
  * Transform raw API report data into structured line chart options
  * with formatted labels.
- *
- * Per modern library conventions, this function carries no mutable
- * locale global — the caller decides via `options.locale`.
  * @param root0 - The raw report data from the Classic API.
  * @param root0.Data - The data series arrays.
  * @param root0.FromDate - The start date of the report period.

--- a/tests/classic-fixtures.ts
+++ b/tests/classic-fixtures.ts
@@ -185,9 +185,7 @@ export const classicErvDeviceData = (
   })
 
 // ---------------------------------------------------------------------------
-// Default fixture IDs — named constants so the numeric literals don't
-// trigger `@typescript-eslint/no-magic-numbers` outside the vitest
-// override (this file is a helper, not a `.test.ts`).
+// Default fixture IDs
 // ---------------------------------------------------------------------------
 
 const DEFAULT_AREA_ID = toClassicAreaId(100)

--- a/tests/integration/api-lifecycle.test.ts
+++ b/tests/integration/api-lifecycle.test.ts
@@ -198,7 +198,6 @@ describe('api lifecycle', () => {
 
     expect(api.registry.getDevices()).toHaveLength(0)
 
-    // Simulate authentication returning login data, then fetch returns buildings
     mockRequest.mockImplementation(async (config) => {
       await Promise.resolve()
       if (config.url === '/Login/ClientLogin3') {
@@ -251,7 +250,6 @@ describe('api lifecycle', () => {
 
     await api.authenticate({ password: 'secret', username: 'me@test.com' })
 
-    // Verify credentials were persisted
     expect(setSpy).toHaveBeenCalledWith('username', 'me@test.com')
     expect(setSpy).toHaveBeenCalledWith('password', 'secret')
     expect(setSpy).toHaveBeenCalledWith('contextKey', 'ctx-abc')

--- a/tests/unit/base-api.test.ts
+++ b/tests/unit/base-api.test.ts
@@ -405,7 +405,6 @@ describe('baseAPI shared request pipeline', () => {
         'Status 500',
       )
 
-      // Only one call, no retry
       expect(mockRequest).toHaveBeenCalledTimes(1)
     })
 
@@ -532,7 +531,8 @@ describe('baseAPI shared request pipeline', () => {
         status: 200,
       })
 
-      // Pass a non-object headers value (e.g. a string) to cover line 160
+      // Pass a non-object headers value (e.g. a string) to cover the
+      // non-object branch of dispatch's headers merge
       await api.callDispatch('get', '/data', {
         headers: cast('not-an-object'),
       })
@@ -602,10 +602,7 @@ describe('baseAPI shared request pipeline', () => {
   // the best-effort restore entry — it logs and swallows. This
   // describe block pins the observable difference between the two
   // so future refactors cannot collapse them back into a dual-mode
-  // function. Subsumes the former `initialize() → runs doAuthenticate
-  // + syncRegistry when credentials are persisted` test: the
-  // persisted-credentials path is now exercised at its natural unit
-  // (resumeSession) rather than through initialize's indirection.
+  // function.
   describe('authenticate() vs resumeSession() contract', () => {
     it('authenticate() throws when doAuthenticate rejects', async () => {
       api.doAuthenticateMock.mockRejectedValueOnce(new Error('rejected'))

--- a/tests/unit/classic-api.test.ts
+++ b/tests/unit/classic-api.test.ts
@@ -955,7 +955,6 @@ describe('mELCloud Classic API', () => {
       mockRequest.mockResolvedValue({ data: {}, headers: {}, status: 200 })
       await api.getValues({ params: { buildingId: 1, id: 1 } })
 
-      // Should NOT have called login
       expect(mockRequest).not.toHaveBeenCalledWith(
         expect.objectContaining({ url: '/Login/ClientLogin3' }),
       )

--- a/tests/unit/classic-factory.test.ts
+++ b/tests/unit/classic-factory.test.ts
@@ -104,5 +104,5 @@ describe(createFacade, () => {
     )
   })
 
-  // Unsupported model types are now a compile-time error via exhaustive modelKind switch
+  // Unsupported model types are a compile-time error via exhaustive modelKind switch
 })


### PR DESCRIPTION
Family-wide comment pass (adversarially reviewed proposal by proposal): drops reviewer narration, debate relics, version/library provenance and restatements of adjacent code; trims verbose blocks to their load-bearing constraint; fixes (partially) obsolete comments. On-device evidence, config triage-ledger reasons and lint-required JSDoc untouched. **No code changes** — 22 files changed, 37 insertions(+), 113 deletions(-). Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)