### PR TITLE
feat: type LastTimeStamp on Classic list device data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [43.4.0] - 2026-07-28
+
+### Added
+
+- Classic list device data now types `LastTimeStamp` (already on the wire) — the only trustworthy reachability signal: the list `Offline` flag flaps minute-to-minute on healthy units (live-probed 2026-07-28). The value is building-local wall clock, not UTC, so worldwide skew reaches ±14 h: compare it with day-scale thresholds only.
+
+## [43.3.0] - 2026-07-28
+
+### Added
+
+- `isConnected` getter on the Home device facades, exposing the `/context` connectivity flag.
+
+## [43.2.0] - 2026-07-27
+
+### Added
+
+- Home overheat-protection write path (Home ATA only, mirroring frost protection): `HomeAPI.updateOverheatProtection` (`POST /monitor/protection/overheat`) and `HomeManager.updateOverheatProtection` (bulk by device ids, non-ATA ids filtered out, no-op without at least one ATA).
+- Generic `clampProtection` with `OVERHEAT_PROTECTION_RANGE` (31–40 °C) alongside the frost range, sharing the 2 °C min–max gap; `clampFrostProtection` is now a wrapper. The module moved from `frost-protection.ts` to `protection.ts`.
+
 ## [43.1.0] - 2026-07-23
 
 ### Added
@@ -364,6 +383,9 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[43.4.0]: https://github.com/OlivierZal/melcloud-api/compare/43.3.0...43.4.0
+[43.3.0]: https://github.com/OlivierZal/melcloud-api/compare/43.2.0...43.3.0
+[43.2.0]: https://github.com/OlivierZal/melcloud-api/compare/43.1.0...43.2.0
 [43.1.0]: https://github.com/OlivierZal/melcloud-api/compare/43.0.1...43.1.0
 [43.0.1]: https://github.com/OlivierZal/melcloud-api/compare/43.0.0...43.0.1
 [43.0.0]: https://github.com/OlivierZal/melcloud-api/compare/42.6.0...43.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,14 @@ is on: no runtime enums, no parameter properties, no runtime namespaces.
   (`LEGIONELLA` ↔ `LegionellaPrevention`) — while annotations WITHOUT
   a label (internal-temperatures) mark missing-data ranges. Dataset
   `label` fields are i18n keys, useless for display.
+- Classic reachability: the list `Offline` flag is garbage — live-probed
+  2026-07-28, it flaps minute-to-minute on healthy units (9 of 13 alive
+  devices flagged offline, membership changing between two runs one
+  minute apart). The trustworthy signal is `LastTimeStamp` staleness,
+  but it speaks building-local wall clock, not UTC (09:33 read at
+  07:35 UTC in a UTC+2 building): worldwide skew reaches ±14 h, so only
+  day-scale thresholds are safe. Never map either signal to anything
+  blocking (com.melcloud #1479/#1481).
 - Classic `/EnergyCost/Report` returns per-bucket arrays for BOTH types
   (ATA per-mode consumption; ATW consumed + produced per category) with
   numeric `Labels`/`LabelType` — day-of-week labels are .NET 0-based

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "43.3.0",
+  "version": "43.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "43.3.0",
+      "version": "43.4.0",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "43.3.0",
+  "version": "43.4.0",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/types/classic-bases.ts
+++ b/src/types/classic-bases.ts
@@ -92,6 +92,7 @@ export interface ClassicBaseListDeviceData extends Omit<
   ClassicBaseGetDeviceData,
   keyof ClassicTransientDeviceData
 > {
+  readonly LastTimeStamp: string
   readonly WifiSignalStrength: number
 }
 


### PR DESCRIPTION
Types `LastTimeStamp` on `ClassicBaseListDeviceData` — the field is already on the wire and is the only trustworthy Classic reachability signal: the `Offline` flag flaps minute-to-minute on healthy units (live-probed 2026-07-28, 9 of 13 alive devices flagged offline with membership changing between runs one minute apart).

Also:
- CLAUDE.md domain gotcha: the value is building-local wall clock (±14 h worldwide skew) — day-scale thresholds only; never map reachability to anything blocking (com.melcloud #1479/#1481).
- Changelog backfill for 43.2.0/43.3.0 + the 43.4.0 entry; version bumped to 43.4.0.

Downstream: com.melcloud will map staleness >24 h (Classic) and `isConnected` (Home) to a non-blocking `setWarning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)