### PR TITLE
feat!: cross-dialect isAvailable contract on device facades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [43.4.0] - 2026-07-28
+## [44.0.0] - 2026-07-28
+
+### Changed
+
+- **Breaking:** the Home facade getter `isConnected` (introduced in 43.3.0) is replaced by a cross-dialect availability contract: every device facade — Classic and Home — now exposes `isAvailable` (the `AvailabilityAware` interface), `true` while MELCloud can still deliver writes to the unit. Home derives it from the `/context` `isConnected` flag; Classic from `LastTimeStamp` staleness with a 24-hour threshold — the `Offline` flag flaps minute-to-minute on healthy units (live-probed 2026-07-28), and the timestamp is building-local wall clock (±14 h of worldwide skew), so only day-scale staleness is trustworthy. An unparsable or future-skewed timestamp reads available.
 
 ### Added
 
-- Classic list device data now types `LastTimeStamp` (already on the wire) — the only trustworthy reachability signal: the list `Offline` flag flaps minute-to-minute on healthy units (live-probed 2026-07-28). The value is building-local wall clock, not UTC, so worldwide skew reaches ±14 h: compare it with day-scale thresholds only.
+- Classic list device data now types `LastTimeStamp` (already on the wire), the signal behind Classic `isAvailable`.
 
 ## [43.3.0] - 2026-07-28
 
@@ -383,7 +387,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
-[43.4.0]: https://github.com/OlivierZal/melcloud-api/compare/43.3.0...43.4.0
+[44.0.0]: https://github.com/OlivierZal/melcloud-api/compare/43.3.0...44.0.0
 [43.3.0]: https://github.com/OlivierZal/melcloud-api/compare/43.2.0...43.3.0
 [43.2.0]: https://github.com/OlivierZal/melcloud-api/compare/43.1.0...43.2.0
 [43.1.0]: https://github.com/OlivierZal/melcloud-api/compare/43.0.1...43.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **Breaking:** the Home facade getter `isConnected` (introduced in 43.3.0) is replaced by a cross-dialect availability contract: every device facade — Classic and Home — now exposes `isAvailable` (the `AvailabilityAware` interface), `true` while MELCloud can still deliver writes to the unit. Home derives it from the `/context` `isConnected` flag; Classic from `LastTimeStamp` staleness with a 24-hour threshold — the `Offline` flag flaps minute-to-minute on healthy units (live-probed 2026-07-28), and the timestamp is building-local wall clock (±14 h of worldwide skew), so only day-scale staleness is trustworthy. An unparsable or future-skewed timestamp reads available.
 
+### Fixed
+
+- **Breaking:** Home device facades now resolve their model by id through the registry on every access, mirroring the Classic facades, instead of pinning the wrapper captured at construction. A pinned wrapper froze its data forever once the registry was rebuilt (logout/login, transient prune) — a cached facade could then report a healed unit unavailable until app restart. Accessors throw `EntityNotFoundError` (whose `entityId`/`tableName` widen to accept Home GUID strings and `'Device'`) when the id is gone, and the new `exists` getter offers the same non-throwing staleness probe as Classic.
+
 ### Added
 
 - Classic list device data now types `LastTimeStamp` (already on the wire), the signal behind Classic `isAvailable`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,8 +93,10 @@ is on: no runtime enums, no parameter properties, no runtime namespaces.
   minute apart). The trustworthy signal is `LastTimeStamp` staleness,
   but it speaks building-local wall clock, not UTC (09:33 read at
   07:35 UTC in a UTC+2 building): worldwide skew reaches ±14 h, so only
-  day-scale thresholds are safe. Never map either signal to anything
-  blocking (com.melcloud #1479/#1481).
+  day-scale thresholds are safe. The device facades encapsulate this as
+  the cross-dialect `isAvailable` contract (Classic: 24 h staleness;
+  Home: the `/context` `isConnected` flag) — consumers must never map
+  the raw `Offline` flag to anything (com.melcloud #1479/#1481).
 - Classic `/EnergyCost/Report` returns per-bucket arrays for BOTH types
   (ATA per-mode consumption; ATW consumed + produced per category) with
   numeric `Labels`/`LabelType` — day-of-week labels are .NET 0-based

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -527,6 +527,18 @@ const config = defineConfig([
           ],
         },
       ],
+      // `consistent-type-exports` tolerates inline specifiers on all-type
+      // exports; no shipped rule hoists them, so the constraint is spelled
+      // out here (imports get the same via `consistent-type-imports`).
+      'no-restricted-syntax': [
+        'error',
+        {
+          message:
+            'An all-type export hoists the keyword: `export type { … }`.',
+          selector:
+            "ExportNamedDeclaration[exportKind='value']:has(ExportSpecifier[exportKind='type']):not(:has(ExportSpecifier[exportKind='value']))",
+        },
+      ],
       'no-return-assign': ['error', 'always'],
       'no-self-compare': 'error',
       'no-sequences': [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "43.4.0",
+  "version": "44.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "43.4.0",
+      "version": "44.0.0",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "43.4.0",
+  "version": "44.0.0",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -1,3 +1,4 @@
+export type { AvailabilityAware, Identifiable } from './types.ts'
 export { ClassicArea } from './area.ts'
 export { ClassicBuilding } from './building.ts'
 export { ClassicDevice } from './classic-device.ts'
@@ -13,4 +14,3 @@ export {
 export { ClassicFloor } from './floor.ts'
 export { HomeDevice } from './home-device.ts'
 export { type HomeBuildingDevices, HomeRegistry } from './home-registry.ts'
-export type { AvailabilityAware, Identifiable } from './types.ts'

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -1,4 +1,5 @@
 export type { AvailabilityAware, Identifiable } from './types.ts'
+
 export { ClassicArea } from './area.ts'
 export { ClassicBuilding } from './building.ts'
 export { ClassicDevice } from './classic-device.ts'

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -13,4 +13,4 @@ export {
 export { ClassicFloor } from './floor.ts'
 export { HomeDevice } from './home-device.ts'
 export { type HomeBuildingDevices, HomeRegistry } from './home-registry.ts'
-export { type Identifiable } from './types.ts'
+export { type AvailabilityAware, type Identifiable } from './types.ts'

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -13,4 +13,4 @@ export {
 export { ClassicFloor } from './floor.ts'
 export { HomeDevice } from './home-device.ts'
 export { type HomeBuildingDevices, HomeRegistry } from './home-registry.ts'
-export { type AvailabilityAware, type Identifiable } from './types.ts'
+export type { AvailabilityAware, Identifiable } from './types.ts'

--- a/src/entities/types.ts
+++ b/src/entities/types.ts
@@ -1,3 +1,8 @@
+/** Cross-dialect reachability contract: `true` while MELCloud can deliver writes to the unit. */
+export interface AvailabilityAware {
+  readonly isAvailable: boolean
+}
+
 /** Base identifiable entity with numeric ID and display name. */
 export interface Identifiable {
   readonly id: number

--- a/src/errors/entity-not-found.ts
+++ b/src/errors/entity-not-found.ts
@@ -24,13 +24,13 @@ import { APIError } from './base.ts'
  * @category Errors
  */
 export class EntityNotFoundError extends APIError {
-  /** Id that could not be resolved in the registry. */
-  public readonly entityId: number
+  /** Id that could not be resolved in the registry — a number for Classic, a GUID string for Home. */
+  public readonly entityId: number | string
 
   public override readonly name = 'EntityNotFoundError'
 
-  /** Registry table the lookup was performed against (e.g. `'DeviceLocation'`). */
-  public readonly tableName: ClassicSettingsParams['tableName']
+  /** Registry table the lookup was performed against (e.g. `'DeviceLocation'`), or `'Device'` for the Home registry. */
+  public readonly tableName: 'Device' | ClassicSettingsParams['tableName']
 
   /**
    * Builds the error from the registry table and the unresolved entity id;
@@ -41,8 +41,8 @@ export class EntityNotFoundError extends APIError {
    * @param options.cause - Original error that triggered this one.
    */
   public constructor(
-    tableName: ClassicSettingsParams['tableName'],
-    options: { entityId: number; cause?: unknown },
+    tableName: 'Device' | ClassicSettingsParams['tableName'],
+    options: { entityId: number | string; cause?: unknown },
   ) {
     const { entityId } = options
     super(`${tableName} with id ${String(entityId)} not found`, options)

--- a/src/facades/classic-base-device.ts
+++ b/src/facades/classic-base-device.ts
@@ -67,6 +67,12 @@ const ISO_SUNDAY = 7
 // Day-scale by design: `LastTimeStamp` is building-local wall clock
 // (±14 h of worldwide skew) and the `Offline` flag flaps on healthy
 // units (live-probed 2026-07-28), so no finer threshold is trustworthy.
+// The staleness anchor is deliberately UTC, not `api.timezone`: UTC
+// bounds a healthy unit's apparent staleness at +14 h for ANY
+// Homey/building timezone pair, while a configured-zone anchor could
+// reach 26 h cross-zone (e.g. UTC+13 host, UTC-11 building) and wrongly
+// flag a live unit — accuracy of the "24 h" wording is traded for a
+// hard no-false-positive bound.
 const STALE_COMMUNICATION_HOURS = 24
 
 // `EnergyCost/Report` labels need repairs before the shared formatter:

--- a/src/facades/classic-base-device.ts
+++ b/src/facades/classic-base-device.ts
@@ -64,6 +64,11 @@ const ENERGY_REPORT_UNIT = 'kWh'
 // ISO 8601 weekday number for Sunday.
 const ISO_SUNDAY = 7
 
+// Day-scale by design: `LastTimeStamp` is building-local wall clock
+// (±14 h of worldwide skew) and the `Offline` flag flaps on healthy
+// units (live-probed 2026-07-28), so no finer threshold is trustworthy.
+const STALE_COMMUNICATION_HOURS = 24
+
 // `EnergyCost/Report` labels need repairs before the shared formatter:
 // one-day reports arrive as bare hour numbers (`LabelType.time`) that
 // format as clock labels, and multi-day buckets carry vendor-dependent
@@ -188,6 +193,26 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
    */
   public override get devices(): ClassicDeviceAny[] {
     return [this.instance]
+  }
+
+  /**
+   * Whether MELCloud can still deliver writes to the unit: it
+   * communicated within the last 24 hours. The `Offline` flag is not
+   * usable (it flaps on healthy units) and `LastTimeStamp` is
+   * building-local wall clock, so only day-scale staleness is
+   * trustworthy; an unparsable or future-skewed value reads available.
+   * @returns `false` after a day without communication.
+   */
+  public get isAvailable(): boolean {
+    try {
+      return (
+        Temporal.Now.plainDateTimeISO('UTC')
+          .since(Temporal.PlainDateTime.from(this.data.LastTimeStamp))
+          .total('hours') <= STALE_COMMUNICATION_HOURS
+      )
+    } catch {
+      return true
+    }
   }
 
   // `null` marks device types without an energy report (ERV):

--- a/src/facades/classic-types.ts
+++ b/src/facades/classic-types.ts
@@ -8,7 +8,7 @@ import type {
   ClassicBaseDevice,
   ClassicDeviceAny,
 } from '../entities/classic-types.ts'
-import type { Identifiable } from '../entities/types.ts'
+import type { AvailabilityAware, Identifiable } from '../entities/types.ts'
 import type { HolidayModeUpdate } from '../holiday-mode.ts'
 import type {
   ClassicEnergyData,
@@ -82,7 +82,7 @@ export interface ClassicDeviceAtwHasZone2Facade extends ClassicDeviceAtwFacade {
  * @category Facades
  */
 export interface ClassicDeviceFacade<T extends ClassicDeviceType>
-  extends ClassicBaseDevice<T>, ClassicFacade {
+  extends AvailabilityAware, ClassicBaseDevice<T>, ClassicFacade {
   /** Bitfield flags mapping each updatable property to its effective flag value. */
   readonly flags: Record<keyof ClassicUpdateDeviceData<T>, number>
   /** Fetch the latest device data after syncing. */

--- a/src/facades/home-base-device.ts
+++ b/src/facades/home-base-device.ts
@@ -1,5 +1,6 @@
 import type { HomeAPIAdapter } from '../api/index.ts'
 import type { HomeDevice } from '../entities/home-device.ts'
+import type { AvailabilityAware } from '../entities/types.ts'
 import {
   type HomeDeviceData,
   type HomeEnergyData,
@@ -35,7 +36,9 @@ import {
  * `model.data`, narrowed to the device-type-specific shape by each subclass.
  * @category Facades
  */
-export abstract class HomeBaseDeviceFacade<TData extends HomeDeviceData> {
+export abstract class HomeBaseDeviceFacade<
+  TData extends HomeDeviceData,
+> implements AvailabilityAware {
   /**
    * Current frost-protection settings, or `null` when not configured.
    * @returns The frost-protection descriptor from `/context`.
@@ -61,12 +64,12 @@ export abstract class HomeBaseDeviceFacade<TData extends HomeDeviceData> {
   }
 
   /**
-   * Whether MELCloud currently reports the unit as reachable. `false`
+   * Whether MELCloud can still deliver writes to the unit. `false`
    * means the wifi adapter lost its link to the cloud: writes are
    * accepted but never delivered, and readings go stale.
    * @returns The `/context` connectivity flag.
    */
-  public get isConnected(): boolean {
+  public get isAvailable(): boolean {
     return this.model.data.isConnected
   }
 

--- a/src/facades/home-base-device.ts
+++ b/src/facades/home-base-device.ts
@@ -1,6 +1,7 @@
 import type { HomeAPIAdapter } from '../api/index.ts'
 import type { HomeDevice } from '../entities/home-device.ts'
 import type { AvailabilityAware } from '../entities/types.ts'
+import { EntityNotFoundError } from '../errors/index.ts'
 import {
   type HomeDeviceData,
   type HomeEnergyData,
@@ -40,6 +41,17 @@ export abstract class HomeBaseDeviceFacade<
   TData extends HomeDeviceData,
 > implements AvailabilityAware {
   /**
+   * Whether the underlying device still exists in the registry.
+   * Non-throwing introspection mirroring the Classic facades' `exists`:
+   * a consumer holding a cached facade can detect staleness without a
+   * try/catch.
+   * @returns `true` while the registry still resolves the id.
+   */
+  public get exists(): boolean {
+    return this.api.registry.getById(this.#id) !== undefined
+  }
+
+  /**
    * Current frost-protection settings, or `null` when not configured.
    * @returns The frost-protection descriptor from `/context`.
    */
@@ -60,7 +72,7 @@ export abstract class HomeBaseDeviceFacade<
    * @returns The GUID string assigned by MELCloud Home.
    */
   public get id(): string {
-    return this.model.id
+    return this.#id
   }
 
   /**
@@ -102,8 +114,6 @@ export abstract class HomeBaseDeviceFacade<
 
   protected readonly api: HomeAPIAdapter
 
-  protected readonly model: HomeDevice<TData>
-
   /**
    * IANA timezone anchoring chart windows and labels, from the API
    * configuration; the Home wire itself always speaks UTC wall-clock.
@@ -114,14 +124,35 @@ export abstract class HomeBaseDeviceFacade<
   }
 
   /**
+   * Registry-resident model resolved by id on every access, so a
+   * long-lived facade never reads a pruned wrapper's frozen snapshot
+   * (a logout/login cycle rebuilds the registry with new wrappers —
+   * a pinned reference froze `isConnected` and kept a healed unit
+   * unavailable forever).
+   * @returns The current model for this facade's id.
+   * @throws EntityNotFoundError when the registry no longer holds the id.
+   */
+  protected get model(): HomeDevice<TData> {
+    const model = this.api.registry.getById(this.#id)
+    if (model === undefined) {
+      throw new EntityNotFoundError('Device', { entityId: this.#id })
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- the id was minted from a TData-shaped model and a physical device never changes type
+    return model as HomeDevice<TData>
+  }
+
+  readonly #id: string
+
+  /**
    * Builds a Home device facade backed by the given API client and
-   * registry-resident device model.
+   * registry-resident device model. Only the model's id is retained:
+   * every later access re-resolves through the registry.
    * @param api - Home API client.
    * @param model - Backing device model, narrowed to a specific variant.
    */
   protected constructor(api: HomeAPIAdapter, model: HomeDevice<TData>) {
     this.api = api
-    this.model = model
+    this.#id = model.id
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,6 +177,7 @@ export {
   syncDevices,
 } from './decorators/index.ts'
 export {
+  type AvailabilityAware,
   type ClassicDeviceAny,
   type ClassicModel,
   type HomeBuildingDevices,

--- a/tests/home-fixtures.ts
+++ b/tests/home-fixtures.ts
@@ -97,18 +97,37 @@ interface HomeDeviceFixtureOptions {
   isOwner?: boolean
 }
 
+// Facades resolve their model by id through `api.registry` on every
+// access, so device fixtures self-register here and test API mocks
+// plug this in as their registry (last-created wins per id, matching
+// the facade-under-test's own device).
+const registeredHomeDevices = new Map<string, HomeDevice>()
+
+export const homeTestRegistry = {
+  delete: (id: string): boolean => registeredHomeDevices.delete(id),
+  getById: (id: string): HomeDevice | undefined =>
+    registeredHomeDevices.get(id),
+}
+
+const registerHomeDevice = <T extends HomeDevice>(device: T): T => {
+  registeredHomeDevices.set(device.id, device)
+  return device
+}
+
 // ATA-shaped payloads carry the ATA type tag by construction; ATW entries
 // come from the dedicated creators below so fixtures stay representative.
 export const homeDevice = (
   overrides: HomeDeviceDataOverrides = {},
   options: HomeDeviceFixtureOptions = {},
 ): HomeDevice<HomeAtaDeviceData> =>
-  new HomeDevice({
-    building: options.building ?? homeBuildingRef(),
-    device: homeDeviceData(overrides),
-    isOwner: options.isOwner ?? true,
-    type: HomeDeviceType.Ata,
-  })
+  registerHomeDevice(
+    new HomeDevice({
+      building: options.building ?? homeBuildingRef(),
+      device: homeDeviceData(overrides),
+      isOwner: options.isOwner ?? true,
+      type: HomeDeviceType.Ata,
+    }),
+  )
 
 export const typedHomeDeviceData = (
   overrides: HomeDeviceDataOverrides = {},
@@ -174,12 +193,14 @@ export const homeAtwDevice = (
   isOwner = true,
   building: HomeBuildingRef = homeBuildingRef(),
 ): HomeDevice<HomeAtwDeviceData> =>
-  new HomeDevice({
-    building,
-    device: homeAtwDeviceData(overrides),
-    isOwner,
-    type: HomeDeviceType.Atw,
-  })
+  registerHomeDevice(
+    new HomeDevice({
+      building,
+      device: homeAtwDeviceData(overrides),
+      isOwner,
+      type: HomeDeviceType.Atw,
+    }),
+  )
 
 export const typedHomeAtwDeviceData = (
   overrides: HomeAtwDeviceDataOverrides = {},

--- a/tests/unit/classic-facades.test.ts
+++ b/tests/unit/classic-facades.test.ts
@@ -1473,6 +1473,38 @@ describe('atw device facade with zone 2', () => {
   })
 })
 
+describe('device facade availability', () => {
+  it('is available when the unit communicated recently', () => {
+    const facade = buildAtaFacade({
+      LastTimeStamp: Temporal.Now.plainDateTimeISO('UTC').toString(),
+    })
+
+    expect(facade.isAvailable).toBe(true)
+  })
+
+  it('is unavailable after a day without communication', () => {
+    const facade = buildAtaFacade({ LastTimeStamp: '2020-01-01T00:00:00' })
+
+    expect(facade.isAvailable).toBe(false)
+  })
+
+  it('errs on the available side for an unparsable timestamp', () => {
+    const facade = buildAtaFacade({ LastTimeStamp: 'garbage' })
+
+    expect(facade.isAvailable).toBe(true)
+  })
+
+  it('errs on the available side for a future-skewed timestamp', () => {
+    const facade = buildAtaFacade({
+      LastTimeStamp: Temporal.Now.plainDateTimeISO('UTC')
+        .add({ hours: 13 })
+        .toString(),
+    })
+
+    expect(facade.isAvailable).toBe(true)
+  })
+})
+
 describe('device type guards', () => {
   it.each([
     {

--- a/tests/unit/home-device-ata-facade.test.ts
+++ b/tests/unit/home-device-ata-facade.test.ts
@@ -64,13 +64,13 @@ describe('home device ata facade', () => {
       expect(facade.overheatProtection).toStrictEqual(overheatProtection)
     })
 
-    it('exposes the connectivity flag from context', () => {
+    it('exposes availability from the context connectivity flag', () => {
       const facade = new HomeDeviceAtaFacade(
         createApi(),
         homeDevice({ id: 'device-1', isConnected: false }),
       )
 
-      expect(facade.isConnected).toBe(false)
+      expect(facade.isAvailable).toBe(false)
     })
 
     it('returns null when protection is not configured', () => {

--- a/tests/unit/home-device-ata-facade.test.ts
+++ b/tests/unit/home-device-ata-facade.test.ts
@@ -1,12 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
-import { NoChangesError } from '../../src/errors/index.ts'
+import { EntityNotFoundError, NoChangesError } from '../../src/errors/index.ts'
 import { HomeDeviceAtaFacade } from '../../src/facades/home-device-ata.ts'
 import { Temporal } from '../../src/temporal.ts'
 import { type HomeAtaDeviceCapabilities, ok } from '../../src/types/index.ts'
 import { cast, mock, mockTemporalNowZoned, okValue } from '../helpers.ts'
-import { homeDevice, homeReportPoint } from '../home-fixtures.ts'
+import {
+  homeDevice,
+  homeReportPoint,
+  homeTestRegistry,
+} from '../home-fixtures.ts'
 
 const createModel = (
   settings: Record<string, string> = {},
@@ -28,6 +32,7 @@ const createApi = (overrides: Partial<HomeAPIAdapter> = {}): HomeAPIAdapter =>
     getAtaErrorLog: vi.fn<HomeAPIAdapter['getAtaErrorLog']>(),
     getAtaTemperatures: vi.fn<HomeAPIAdapter['getAtaTemperatures']>(),
     getSignal: vi.fn<HomeAPIAdapter['getSignal']>(),
+    registry: cast(homeTestRegistry),
     updateAtaValues: vi
       .fn<HomeAPIAdapter['updateAtaValues']>()
       .mockResolvedValue(),
@@ -71,6 +76,31 @@ describe('home device ata facade', () => {
       )
 
       expect(facade.isAvailable).toBe(false)
+    })
+
+    it('resolves the registry model by id, never a pinned snapshot', () => {
+      const facade = new HomeDeviceAtaFacade(
+        createApi(),
+        homeDevice({ id: 'device-1', isConnected: false }),
+      )
+      homeDevice({ id: 'device-1', isConnected: true })
+
+      expect(facade.isAvailable).toBe(true)
+    })
+
+    it('reports existence and throws once the registry drops the id', () => {
+      const facade = new HomeDeviceAtaFacade(
+        createApi(),
+        homeDevice({ id: 'device-gone' }),
+      )
+
+      expect(facade.exists).toBe(true)
+
+      homeTestRegistry.delete('device-gone')
+
+      expect(facade.exists).toBe(false)
+      expect(facade.id).toBe('device-gone')
+      expect(() => facade.isAvailable).toThrow(EntityNotFoundError)
     })
 
     it('returns null when protection is not configured', () => {

--- a/tests/unit/home-device-atw-facade.test.ts
+++ b/tests/unit/home-device-atw-facade.test.ts
@@ -6,7 +6,11 @@ import { HomeDeviceAtwFacade } from '../../src/facades/home-device-atw.ts'
 import { Temporal } from '../../src/temporal.ts'
 import { type HomeAtwDeviceCapabilities, ok } from '../../src/types/index.ts'
 import { cast, mock, mockTemporalNowZoned, okValue } from '../helpers.ts'
-import { homeAtwDevice, homeReportPoint } from '../home-fixtures.ts'
+import {
+  homeAtwDevice,
+  homeReportPoint,
+  homeTestRegistry,
+} from '../home-fixtures.ts'
 
 const createModel = (
   settings: Record<string, string> = {},
@@ -34,6 +38,7 @@ const createApi = (overrides: Partial<HomeAPIAdapter> = {}): HomeAPIAdapter =>
       vi.fn<HomeAPIAdapter['getAtwInternalTemperatures']>(),
     getAtwTemperatures: vi.fn<HomeAPIAdapter['getAtwTemperatures']>(),
     getSignal: vi.fn<HomeAPIAdapter['getSignal']>(),
+    registry: cast(homeTestRegistry),
     updateAtwValues: vi
       .fn<HomeAPIAdapter['updateAtwValues']>()
       .mockResolvedValue(),


### PR DESCRIPTION
Implements the common availability contract requested for com.melcloud's reachability feature: every device facade — Classic and Home — now exposes `isAvailable` (the `AvailabilityAware` interface), `true` while MELCloud can still deliver writes to the unit.

- **Home**: derives from the `/context` `isConnected` flag. **Breaking**: the `isConnected` getter (43.3.0) is renamed — one contract, no dialect-specific alias.
- **Classic**: derives from `LastTimeStamp` staleness (24 h threshold). The `Offline` flag is unusable — live-probed 2026-07-28, it flaps minute-to-minute on healthy units. The timestamp is building-local wall clock (±14 h worldwide skew), so only day-scale staleness is trustworthy; unparsable or future-skewed values err on the available side.
- Types `LastTimeStamp` on Classic list device data; CLAUDE.md gotcha; changelog backfill for 43.2.0/43.3.0; version 44.0.0 (supersedes the never-released 43.4.0).

Downstream: com.melcloud maps `facade.isAvailable` back to `setUnavailable`/`setAvailable` (the #1481 revert stands for the flap-prone signal only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)