### PR TITLE
feat: day-scale persistence window on Home availability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "44.0.0",
+  "version": "44.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "44.0.0",
+      "version": "44.1.0",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "44.0.0",
+  "version": "44.1.0",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/entities/home-device.ts
+++ b/src/entities/home-device.ts
@@ -5,6 +5,7 @@ import type {
   HomeDeviceData,
 } from '../types/index.ts'
 import { HomeDeviceType } from '../constants.ts'
+import { Temporal } from '../temporal.ts'
 
 /**
  * Mutable wrapper around a {@link HomeDeviceData}, preserving object identity across syncs.
@@ -38,6 +39,18 @@ export class HomeDevice<TData extends HomeDeviceData = HomeDeviceData> {
   }
 
   /**
+   * First instant (UTC) since which every sync has reported the unit
+   * disconnected, or `null` while it reads connected. In-memory only: a
+   * fresh wrapper (new registry after a re-login, host restart)
+   * restarts the clock — deliberately conservative for the availability
+   * hysteresis.
+   * @returns The start of the current disconnection streak, if any.
+   */
+  public get disconnectedSince(): Temporal.PlainDateTime | null {
+    return this.#disconnectedSince
+  }
+
+  /**
    * Unique device identifier as assigned by MELCloud Home.
    * @returns The GUID string assigned by MELCloud Home.
    */
@@ -68,6 +81,8 @@ export class HomeDevice<TData extends HomeDeviceData = HomeDeviceData> {
 
   #data: TData
 
+  #disconnectedSince: Temporal.PlainDateTime | null = null
+
   #isOwner: boolean
 
   /**
@@ -92,6 +107,7 @@ export class HomeDevice<TData extends HomeDeviceData = HomeDeviceData> {
     this.#data = entry.device
     this.#isOwner = entry.isOwner
     this.type = entry.type
+    this.#trackConnectivity()
   }
 
   /**
@@ -129,5 +145,16 @@ export class HomeDevice<TData extends HomeDeviceData = HomeDeviceData> {
     this.#building = building
     this.#data = device
     this.#isOwner = isOwner
+    this.#trackConnectivity()
+  }
+
+  // A connected sync resets the streak; a disconnected one only stamps
+  // its start, so the timestamp marks the oldest uninterrupted `false`.
+  #trackConnectivity(): void {
+    if (this.#data.isConnected) {
+      this.#disconnectedSince = null
+    } else {
+      this.#disconnectedSince ??= Temporal.Now.plainDateTimeISO('UTC')
+    }
   }
 }

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -15,3 +15,4 @@ export {
 export { ClassicFloor } from './floor.ts'
 export { HomeDevice } from './home-device.ts'
 export { type HomeBuildingDevices, HomeRegistry } from './home-registry.ts'
+export { STALE_COMMUNICATION_HOURS } from './types.ts'

--- a/src/entities/types.ts
+++ b/src/entities/types.ts
@@ -1,3 +1,15 @@
+/**
+ * Hours of continuous negative signal before a device facade reports
+ * `isAvailable: false` — day-scale on BOTH dialects by design: Classic's
+ * `LastTimeStamp` is building-local wall clock (±14 h of worldwide skew)
+ * and its `Offline` flag is a ~2-4 min staleness boolean that flaps on
+ * healthy units (live-probed 2026-07-28), while Home's `isConnected` has
+ * a live-probed positive side but an unproven negative one — a
+ * persistence window this wide turns any Classic-style tight-threshold
+ * boolean harmless.
+ */
+export const STALE_COMMUNICATION_HOURS = 24
+
 /** Cross-dialect reachability contract: `true` while MELCloud can deliver writes to the unit. */
 export interface AvailabilityAware {
   readonly isAvailable: boolean

--- a/src/facades/classic-base-device.ts
+++ b/src/facades/classic-base-device.ts
@@ -13,6 +13,7 @@ import {
   type ClassicDeviceAny,
   ClassicDevice,
   isClassicDeviceOfType,
+  STALE_COMMUNICATION_HOURS,
 } from '../entities/index.ts'
 import { NoChangesError } from '../errors/index.ts'
 import { Intl, Temporal } from '../temporal.ts'
@@ -63,17 +64,6 @@ const ENERGY_REPORT_UNIT = 'kWh'
 
 // ISO 8601 weekday number for Sunday.
 const ISO_SUNDAY = 7
-
-// Day-scale by design: `LastTimeStamp` is building-local wall clock
-// (±14 h of worldwide skew) and the `Offline` flag flaps on healthy
-// units (live-probed 2026-07-28), so no finer threshold is trustworthy.
-// The staleness anchor is deliberately UTC, not `api.timezone`: UTC
-// bounds a healthy unit's apparent staleness at +14 h for ANY
-// Homey/building timezone pair, while a configured-zone anchor could
-// reach 26 h cross-zone (e.g. UTC+13 host, UTC-11 building) and wrongly
-// flag a live unit — accuracy of the "24 h" wording is traded for a
-// hard no-false-positive bound.
-const STALE_COMMUNICATION_HOURS = 24
 
 // `EnergyCost/Report` labels need repairs before the shared formatter:
 // one-day reports arrive as bare hour numbers (`LabelType.time`) that
@@ -203,10 +193,15 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
 
   /**
    * Whether MELCloud can still deliver writes to the unit: it
-   * communicated within the last 24 hours. The `Offline` flag is not
-   * usable (it flaps on healthy units) and `LastTimeStamp` is
-   * building-local wall clock, so only day-scale staleness is
-   * trustworthy; an unparsable or future-skewed value reads available.
+   * communicated within roughly the last day. The `Offline` flag is not
+   * usable (a ~2-4 min staleness boolean that flaps on healthy units)
+   * and `LastTimeStamp` is building-local wall clock, so only day-scale
+   * staleness is trustworthy; an unparsable or future-skewed value
+   * reads available. The staleness anchor is deliberately UTC, not
+   * `api.timezone`: UTC bounds a healthy unit's apparent staleness at
+   * +14 h for ANY host/building timezone pair, while a configured-zone
+   * anchor could reach 26 h cross-zone (e.g. UTC+13 host, UTC-11
+   * building) and wrongly flag a live unit.
    * @returns `false` after a day without communication.
    */
   public get isAvailable(): boolean {

--- a/src/facades/home-base-device.ts
+++ b/src/facades/home-base-device.ts
@@ -1,7 +1,11 @@
 import type { HomeAPIAdapter } from '../api/index.ts'
 import type { HomeDevice } from '../entities/home-device.ts'
-import type { AvailabilityAware } from '../entities/types.ts'
+import {
+  type AvailabilityAware,
+  STALE_COMMUNICATION_HOURS,
+} from '../entities/types.ts'
 import { EntityNotFoundError } from '../errors/index.ts'
+import { Temporal } from '../temporal.ts'
 import {
   type HomeDeviceData,
   type HomeEnergyData,
@@ -78,11 +82,21 @@ export abstract class HomeBaseDeviceFacade<
   /**
    * Whether MELCloud can still deliver writes to the unit. `false`
    * means the wifi adapter lost its link to the cloud: writes are
-   * accepted but never delivered, and readings go stale.
-   * @returns The `/context` connectivity flag.
+   * accepted but never delivered, and readings go stale. The
+   * `/context` `isConnected` flag only counts once it has read `false`
+   * for a full day: its negative side is unproven, and the persistence
+   * window makes a Classic-`Offline`-style tight-threshold boolean
+   * harmless (such a flag never stays `false` through a report cycle).
+   * @returns `false` after a day of continuous disconnection.
    */
   public get isAvailable(): boolean {
-    return this.model.data.isConnected
+    const { disconnectedSince } = this.model
+    return (
+      disconnectedSince === null ||
+      Temporal.Now.plainDateTimeISO('UTC')
+        .since(disconnectedSince)
+        .total('hours') <= STALE_COMMUNICATION_HOURS
+    )
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,6 +189,7 @@ export {
   HomeDevice,
   HomeRegistry,
   isClassicDeviceOfType,
+  STALE_COMMUNICATION_HOURS,
 } from './entities/index.ts'
 export {
   type HomeFanSpeed,

--- a/tests/unit/home-device-ata-facade.test.ts
+++ b/tests/unit/home-device-ata-facade.test.ts
@@ -69,13 +69,30 @@ describe('home device ata facade', () => {
       expect(facade.overheatProtection).toStrictEqual(overheatProtection)
     })
 
-    it('exposes availability from the context connectivity flag', () => {
+    it('keeps a freshly disconnected unit available within the persistence window', () => {
       const facade = new HomeDeviceAtaFacade(
         createApi(),
         homeDevice({ id: 'device-1', isConnected: false }),
       )
 
+      expect(facade.isAvailable).toBe(true)
+    })
+
+    it('reports the unit unavailable after a day of continuous disconnection, then clears on reconnect', () => {
+      const device = homeDevice({ id: 'device-1', isConnected: false })
+      const facade = new HomeDeviceAtaFacade(createApi(), device)
+      const later = Temporal.Now.plainDateTimeISO('UTC').add({ hours: 25 })
+      const spy = vi
+        .spyOn(Temporal.Now, 'plainDateTimeISO')
+        .mockReturnValue(later)
+
       expect(facade.isAvailable).toBe(false)
+
+      device.sync({ ...device.data, isConnected: true }, true, device.building)
+
+      expect(facade.isAvailable).toBe(true)
+
+      spy.mockRestore()
     })
 
     it('resolves the registry model by id, never a pinned snapshot', () => {

--- a/tests/unit/home-device.test.ts
+++ b/tests/unit/home-device.test.ts
@@ -35,4 +35,25 @@ describe('home device entity', () => {
 
     expect(owned.isOwner).toBe(false)
   })
+
+  it('tracks the start of a disconnection streak across syncs', () => {
+    const device = homeDevice({ id: 'ata-1', isConnected: false })
+    const start = device.disconnectedSince
+
+    expect(start).not.toBeNull()
+
+    device.sync({ ...device.data, isConnected: false }, true, homeBuildingRef())
+
+    expect(device.disconnectedSince).toBe(start)
+
+    device.sync({ ...device.data, isConnected: true }, true, homeBuildingRef())
+
+    expect(device.disconnectedSince).toBeNull()
+  })
+
+  it('starts with no disconnection streak while connected', () => {
+    const device = homeDevice({ id: 'ata-2' })
+
+    expect(device.disconnectedSince).toBeNull()
+  })
 })


### PR DESCRIPTION
The owner's challenge: the Classic support case proved nothing about Home, and our `isConnected` evidence only covers the positive side (12/12 `true` on healthy units). The exact Classic hack (timestamp staleness) is impossible on Home — `/context` carries no last-communication timestamp — so the same property is obtained by **hysteresis**: unavailable only after **24 h of continuous `isConnected: false`** (`HomeDevice.disconnectedSince` tracks the streak).

If Home's flag turns out to be a tight-threshold staleness boolean like Classic's `Offline` (~2-4 min, flaps every report cycle), it can never stay `false` for 24 h on a healthy unit — harmless. A real outage still flags within a day. Uniform policy across dialects, one exported threshold: `STALE_COMMUNICATION_HOURS`. 951 tests, 100 % coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)