### PR TITLE
style: drop the bespoke export-type lint rule for documented doctrine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,14 @@ is on: no runtime enums, no parameter properties, no runtime namespaces.
   re-evaluate one when its stated reason expires (target bump, new
   tooling).
 - Zero-warning policy: every enabled rule is at `error`.
+- All-type exports hoist the keyword (`export type { A, B }`); mixed
+  exports keep inline `type` specifiers, mirroring the
+  inline-type-imports style. No shipped rule enforces the export side
+  (`consistent-type-exports` tolerates inline specifiers once present;
+  `import-x/consistent-type-specifier-style` covers imports only): the
+  convention is maintained by hand, in review — a bespoke
+  `no-restricted-syntax` selector for it was removed by decision
+  (2026-07-28).
 - Metric caps (`complexity`, `max-depth`, `vitest/max-nested-describe`) are
   pinned to measured codebase ceilings: exceeding one means refactor, not
   bump. Prove any stricter option with an instrumented run (zero violations)

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -527,18 +527,6 @@ const config = defineConfig([
           ],
         },
       ],
-      // `consistent-type-exports` tolerates inline specifiers on all-type
-      // exports; no shipped rule hoists them, so the constraint is spelled
-      // out here (imports get the same via `consistent-type-imports`).
-      'no-restricted-syntax': [
-        'error',
-        {
-          message:
-            'An all-type export hoists the keyword: `export type { … }`.',
-          selector:
-            "ExportNamedDeclaration[exportKind='value']:has(ExportSpecifier[exportKind='type']):not(:has(ExportSpecifier[exportKind='value']))",
-        },
-      ],
       'no-return-assign': ['error', 'always'],
       'no-self-compare': 'error',
       'no-sequences': [


### PR DESCRIPTION
The owner prefers the convention maintained by hand: all-type exports hoist the keyword, mixed exports keep inline specifiers. The `no-restricted-syntax` selector is removed and the convention recorded in CLAUDE.md instead — same change as the four sibling repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)