### PR TITLE
fix: stop Classic isAvailable from swallowing a pruned registry id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [45.0.1] - 2026-07-28
+
+### Fixed
+
+- Classic `isAvailable` no longer swallows `EntityNotFoundError`: the registry lookup moved outside the guard that tolerates an unparsable timestamp, so a pruned id propagates like it already did on the Home facade instead of reading as reachable. A consumer that syncs availability before touching device data was calling `setAvailable()` on a vanished device.
+
+## [45.0.0] - 2026-07-28
+
+### Changed
+
+- **Breaking — one settings vocabulary:** `ProtectionUpdate`/`ProtectionState` (frost and overheat) and `HolidayModeState` join `HolidayModeUpdate` as the cross-dialect contracts. Classic maps its `FP*`/`HM*` wire fields (`*Defined: false` surfaces as `null`); the Home getters map their camelCase `/context` descriptors. `ClassicFrostProtectionQuery` is replaced by `ProtectionUpdate` (`isEnabled` now explicit).
+- **Breaking — one mutation outcome:** every facade mutation resolves `Promise<void>` and throws typed errors. Classic converts its `Success`/`AttributeErrors` wire union through the new `UpdateRejectedError` (carrying `attributeErrors`), including the power endpoint's bare-boolean acknowledgment; the Home and device-level group writes drop their faked success envelopes; `updatePower` drops its unread boolean echo. Building group writes settle every member and bundle concurrent failures into an `AggregateError`.
+- **Breaking — one registry vocabulary:** `HomeRegistry.getAll` → `getDevices`, `getByType` → `getDevicesByType` (with Classic's narrowing overloads), `getBuildingsByType(type)` → `getBuildings({ type? })` (optional type merges both connection types; name-sorted), `sync` → `syncDevices`.
+- **Breaking — manager parity:** `HomeFacadeManager` gains `getBuildings({ type? })`, `getZones({ type? })` (the flattened picker list, `HomeFlatZone`) and `getById(id)`; `ClassicFacadeManager` gains `getById(kind, id)` and its constructor takes `(api)` only — `ClassicAPIAdapter` now declares the `registry` it always had.
+- **Breaking — one wire-method vocabulary on Home:** `updateAtaValues`/`updateAtwValues` → `updateValues`, `getAtaEnergy`/`getAtwEnergy` → `getEnergy`, `getAtaErrorLog`/`getAtwErrorLog` → `getErrorLog`, `getAtaTemperatures`/`getAtwTemperatures` → `getTemperatures`; the registry model's connection type routes the wire path. Reads fold an unknown id into the new `not-found` `ApiRequestError` variant (a cold open may query before the first fetch); writes throw `EntityNotFoundError`. `getAtwInternalTemperatures` stays ATW-only.
+- **Breaking — one heartbeat name:** Home `list()` → `fetch()` (same sync-the-registry contract as Classic); Classic's raw no-registry `list()` is now private, and its low-level `login()` is protected behind `authenticate()`.
+- **Breaking — facade identity parity:** Home device facades expose a literal-typed `type`, the `HomeDeviceFacadeAny` union and `isHomeAtaFacade`/`isHomeAtwFacade` guards; Classic device facades gain the `power` and `rssi` getters; `Identifiable` is generic (`Identifiable<TId>`, default `number`) and the Home facades implement `Identifiable<string>`; `ClassicDevice` gains `isAta()`/`isAtw()`/`isErv()`.
+- **Breaking:** Home device facades resolve their model by id through the registry on every access instead of pinning the wrapper captured at construction — a pinned wrapper froze its data once the registry was rebuilt (logout/login), leaving a healed unit unavailable until restart. Accessors throw `EntityNotFoundError` (widened to Home GUID ids); the new `exists` getter is the non-throwing probe.
+
+### Added
+
+- `BaseAPIAdapter` — the session/infrastructure surface both dialect adapters extend, declaring the members consumers already used (`logOut`, and Classic's whole session half); `BaseAPISettings` declares the shared persisted material including the previously undeclared `loginBackoffUntil`; `ensureAuthenticated()` runs a sync check plus one best-effort `resumeSession` probe.
+
+## [44.1.0] - 2026-07-28
+
+### Changed
+
+- Home `isAvailable` now applies the same day-scale persistence as Classic: the unit reads unavailable only after 24 hours of continuous `isConnected: false` (`HomeDevice.disconnectedSince` tracks the streak, in-memory). The flag's negative side is unproven — its live-probed record is 12/12 `true` on healthy units — and the persistence window makes a Classic-`Offline`-style tight-threshold boolean harmless, since such a flag never stays `false` through a report cycle. The shared threshold is exported as `STALE_COMMUNICATION_HOURS`.
+
 ## [44.0.0] - 2026-07-28
 
 ### Changed
@@ -391,6 +420,9 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[45.0.1]: https://github.com/OlivierZal/melcloud-api/compare/45.0.0...45.0.1
+[45.0.0]: https://github.com/OlivierZal/melcloud-api/compare/44.1.0...45.0.0
+[44.1.0]: https://github.com/OlivierZal/melcloud-api/compare/44.0.0...44.1.0
 [44.0.0]: https://github.com/OlivierZal/melcloud-api/compare/43.3.0...44.0.0
 [43.3.0]: https://github.com/OlivierZal/melcloud-api/compare/43.2.0...43.3.0
 [43.2.0]: https://github.com/OlivierZal/melcloud-api/compare/43.1.0...43.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "45.0.0",
+  "version": "45.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "45.0.0",
+      "version": "45.0.1",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "45.0.0",
+  "version": "45.0.1",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/api/classic-types.ts
+++ b/src/api/classic-types.ts
@@ -57,13 +57,6 @@ import type {
  */
 export interface ClassicAPIAdapter extends BaseAPIAdapter {
   /**
-   * BCP-47 locale tag the Classic instance was configured with
-   * (`ClassicAPIConfig.locale`), or `undefined` when unset. Facades
-   * pass this through to `getChartLineOptions` so report labels
-   * (day-of-week, month names) render in the configured locale
-   * without needing a global mutable locale.
-   */
-  /**
    * Notify any registered `events.onSyncComplete` observer that a sync
    * just landed. Routed through the lifecycle emitter so a misbehaving
    * observer cannot break the caller.
@@ -71,13 +64,6 @@ export interface ClassicAPIAdapter extends BaseAPIAdapter {
   readonly notifySync: SyncCallback
   /** Classic model registry synced by the fetch cycle. */
   readonly registry: ClassicRegistry
-  /**
-   * IANA timezone identifier the Classic instance was configured with
-   * (`ClassicAPIConfig.timezone`), or `undefined` when unset. Facades
-   * use this to anchor "now"-derived defaults (`getSignalStrength` /
-   * `getHourlyTemperatures` hour) to the Classic timezone instead of the
-   * host runtime timezone.
-   */
   /** Fetch all buildings and sync the model registry. */
   readonly fetch: () => Promise<ClassicBuildingWithStructure[]>
   /** Fetch energy consumption report. Supported by ATA and ATW devices. */

--- a/src/api/home-types.ts
+++ b/src/api/home-types.ts
@@ -68,8 +68,6 @@ export interface HomeAPIAdapter extends BaseAPIAdapter {
   ) => Promise<Result<HomeReportData[]>>
   /** Fetch the current user's claims from the BFF. Returns `null` on failure. */
   readonly getUser: () => Promise<HomeUser | null>
-  /** Whether a user is currently authenticated (session cookie valid). */
-  /** Update the automatic sync interval and reschedule. Pass `false` to disable. */
   /** Batch frost-protection write (device ids grouped in `units`), then refresh. */
   readonly updateFrostProtection: (
     postData: HomeFrostProtectionPostData,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -3,14 +3,6 @@ import type { HttpClient } from '../http/index.ts'
 import type { LoginCredentials, UndefinedTolerant } from '../types/index.ts'
 
 /**
- * Common configuration shared by all API clients. Every property —
- * including the inherited {@link LoginCredentials} pair — may be
- * absent or explicitly `undefined`, interchangeably: the runtime
- * applies the same default either way (credentials can also arrive
- * later via `authenticate` or the {@link SettingManager}).
- * @category Configuration
- */
-/**
  * Session and infrastructure surface shared by both dialects' API
  * adapters — the cross-dialect base a consumer can program against
  * without knowing which wire it talks to.
@@ -48,6 +40,14 @@ export interface BaseAPIAdapter {
   readonly setSyncInterval: (minutes: number | false) => void
 }
 
+/**
+ * Common configuration shared by all API clients. Every property —
+ * including the inherited {@link LoginCredentials} pair — may be
+ * absent or explicitly `undefined`, interchangeably: the runtime
+ * applies the same default either way (credentials can also arrive
+ * later via `authenticate` or the {@link SettingManager}).
+ * @category Configuration
+ */
 export interface BaseAPIConfig extends UndefinedTolerant<LoginCredentials> {
   /**
    * Optional shutdown signal applied to every outgoing request.

--- a/src/facades/classic-base-device.ts
+++ b/src/facades/classic-base-device.ts
@@ -205,10 +205,15 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
    * @returns `false` after a day without communication.
    */
   public get isAvailable(): boolean {
+    // The registry lookup stays OUTSIDE the guard: a pruned id must
+    // propagate as EntityNotFoundError like the Home facade does, or a
+    // vanished device would read as reachable. Only the wall-clock parse
+    // is guarded.
+    const { LastTimeStamp: lastTimestamp } = this.data
     try {
       return (
         Temporal.Now.plainDateTimeISO('UTC')
-          .since(Temporal.PlainDateTime.from(this.data.LastTimeStamp))
+          .since(Temporal.PlainDateTime.from(lastTimestamp))
           .total('hours') <= STALE_COMMUNICATION_HOURS
       )
     } catch {

--- a/tests/unit/classic-facades.test.ts
+++ b/tests/unit/classic-facades.test.ts
@@ -1533,6 +1533,25 @@ describe('device facade availability', () => {
     expect(facade.isAvailable).toBe(false)
   })
 
+  it('propagates a pruned registry id instead of reading available', () => {
+    const registry = new ClassicRegistry()
+    registry.syncBuildings([classicBuildingData({ HMDefined: true })])
+    registry.syncFloors([classicFloorData()])
+    registry.syncAreas([classicAreaData()])
+    registry.syncDevices([classicAtaDevice()])
+    const instance = defined(registry.devices.getById(1000))
+    assertClassicDeviceType(instance, ClassicDeviceType.Ata)
+    const facade = new ClassicDeviceAtaFacade(
+      createMockClassicApi(),
+      registry,
+      instance,
+    )
+
+    registry.syncDevices([])
+
+    expect(() => facade.isAvailable).toThrow(EntityNotFoundError)
+  })
+
   it('errs on the available side for an unparsable timestamp', () => {
     const facade = buildAtaFacade({ LastTimeStamp: 'garbage' })
 


### PR DESCRIPTION
Two defects the session's completion audit surfaced in shipped code.

**1. `isAvailable` reported a vanished device as reachable.** The registry lookup (`this.data` → `instance`) sat inside the try/catch that tolerates an unparsable `LastTimeStamp`, so `EntityNotFoundError` was swallowed and answered `true`. The Home facade propagates it. A consumer that syncs availability before reading device data — which com.melcloud does — therefore called `setAvailable()` on a pruned device before falling into its not-found branch, making its own "keeps the last known availability" comment false. Now only the wall-clock parse is guarded, and a test pins the propagation.

**2. The 44.1.0 and 45.0.0 CHANGELOG entries never existed in git.** The 44.1.0 edit failed silently; the 45.0.0 write was then a string replace anchored on that missing entry, so it was a no-op nobody noticed — while the v45.0.0 release body pointed readers at it. Both are restored, with their comparison links, plus a 45.0.1 entry for this fix.

Suite green (975 tests, 100 % coverage), lint/typecheck/docs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)