### PR TITLE
fix: stop ensureAuthenticated from signing the user out while probing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [45.0.2] - 2026-07-28
+
+### Fixed
+
+- `ensureAuthenticated()` no longer signs the user out while probing. It went straight to `resumeSession()`, which routes through `authenticate()` and wipes the persisted session _before_ re-logging in — so a session that was merely unexercised (a boot-time context fetch that lost the network reads unauthenticated while a valid refresh token sits in storage) was destroyed by the probe meant to restore it, and a failing re-login then left the account signed out. The probe is now a non-destructive registry sync, with `resumeSession()` kept as the fallback.
+
 ## [45.0.1] - 2026-07-28
 
 ### Fixed
@@ -420,6 +426,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[45.0.2]: https://github.com/OlivierZal/melcloud-api/compare/45.0.1...45.0.2
 [45.0.1]: https://github.com/OlivierZal/melcloud-api/compare/45.0.0...45.0.1
 [45.0.0]: https://github.com/OlivierZal/melcloud-api/compare/44.1.0...45.0.0
 [44.1.0]: https://github.com/OlivierZal/melcloud-api/compare/44.0.0...44.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "45.0.1",
+  "version": "45.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "45.0.1",
+      "version": "45.0.2",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "45.0.1",
+  "version": "45.0.2",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -387,15 +387,30 @@ export abstract class BaseAPI implements Disposable {
   }
 
   /**
-   * Sync check first; when it reads `false`, one best-effort
-   * {@link resumeSession} probe, then a re-check — the lazy self-heal
-   * consumers otherwise hand-roll (a valid persisted Home token reads
-   * unauthenticated until a context fetch has run).
+   * Sync check first; when it reads `false`, a NON-DESTRUCTIVE probe —
+   * one registry sync, which exercises the persisted session without
+   * touching it — and only if that still leaves us unauthenticated, the
+   * best-effort {@link resumeSession} fallback. The order matters:
+   * `resumeSession` goes through {@link authenticate}, which wipes the
+   * persisted session before re-logging in, so probing with it first
+   * would sign out a user whose tokens were merely unexercised (a
+   * boot-time context fetch that lost the network reads unauthenticated
+   * while a perfectly valid refresh token sits in storage).
    * @returns `true` when a session is usable afterwards.
    */
   public async ensureAuthenticated(): Promise<boolean> {
     if (this.isAuthenticated()) {
       return true
+    }
+    if (this.hasPersistedSession()) {
+      try {
+        await this.syncRegistry()
+      } catch (error) {
+        this.logger.error('Session probe failed:', error)
+      }
+      if (this.isAuthenticated()) {
+        return true
+      }
     }
     await this.resumeSession()
     return this.isAuthenticated()

--- a/tests/unit/base-api.test.ts
+++ b/tests/unit/base-api.test.ts
@@ -1132,14 +1132,40 @@ describe('ensureAuthenticated', () => {
     expect(api.hasPersistedSessionMock).not.toHaveBeenCalled()
   })
 
-  it('runs one best-effort restore probe when unauthenticated', async () => {
+  it('probes with a registry sync, never a destructive re-login', async () => {
     const api = new TestAPI()
     api.isAuthenticatedMock.mockReturnValueOnce(false).mockReturnValue(true)
     api.hasPersistedSessionMock.mockReturnValue(true)
-    api.tryReuseSessionMock.mockResolvedValue(true)
-    api.reuseSucceededMock.mockReturnValue(true)
 
     await expect(api.ensureAuthenticated()).resolves.toBe(true)
+
+    // The decisive assertion: authenticate() wipes the persisted session
+    // before logging in, so a session that is merely unexercised must be
+    // restored by the sync alone.
+    expect(api.syncRegistryMock).toHaveBeenCalledTimes(1)
+    expect(api.doAuthenticateMock).not.toHaveBeenCalled()
+    expect(api.clearPersistedSessionMock).not.toHaveBeenCalled()
+  })
+
+  it('tolerates a throwing probe and falls back to the restore', async () => {
+    const api = new TestAPI()
+    api.isAuthenticatedMock.mockReturnValue(false)
+    api.hasPersistedSessionMock.mockReturnValue(true)
+    api.syncRegistryMock.mockRejectedValue(new Error('offline'))
+
+    await expect(api.ensureAuthenticated()).resolves.toBe(false)
+
+    expect(api.syncRegistryMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips the probe when nothing is persisted', async () => {
+    const api = new TestAPI()
+    api.isAuthenticatedMock.mockReturnValue(false)
+    api.hasPersistedSessionMock.mockReturnValue(false)
+
+    await expect(api.ensureAuthenticated()).resolves.toBe(false)
+
+    expect(api.syncRegistryMock).not.toHaveBeenCalled()
   })
 
   it('stays false when the restore probe cannot help', async () => {


### PR DESCRIPTION
**A regression this session introduced and shipped.** `ensureAuthenticated()` replaced the consumer's hand-rolled lazy retry, which re-fetched `/context` non-destructively. The replacement went straight to `resumeSession()` → `authenticate()` → **`clearPersistedSession()`**, which wipes the tokens *before* attempting the login.

**Failure scenario**: the Homey box reboots and the network is not ready, so the boot-time context fetch fails — `isAuthenticated()` reads false while a perfectly valid refresh token sits in storage. The user opens the com.melcloud settings page, which calls `GET /home/sessions`. That probe wipes the valid session and attempts a full credential login; if it fails (network still flaky, or Cognito throttles), the user is now **signed out of MELCloud Home just for opening the settings page**.

The probe is now a non-destructive `syncRegistry()` — the same thing the app used to do — with `resumeSession()` kept as the fallback when it does not help. Three tests pin the behaviour, including that `authenticate()` and `clearPersistedSession()` are never reached on the probe path; reverting the fix turns two of them red (verified).

988 tests, 100 % coverage, lint/typecheck/docs clean. Version 45.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)