### PR TITLE
docs: say why the protection read and write twins stay separate

### DIFF
--- a/src/protection.ts
+++ b/src/protection.ts
@@ -29,6 +29,12 @@ export interface ProtectionState {
  * A protection update to apply — the write contract shared by frost
  * (Classic and Home) and overheat (Home ATA) protection, clamped by the
  * sibling helpers before it reaches the wire.
+ *
+ * Structurally identical to {@link ProtectionState} today, and kept
+ * separate on purpose: the read twin gains whatever the wire starts
+ * reporting, the write twin only what the units accept. Its holiday
+ * counterparts already diverge that way — {@link HolidayModeState}
+ * nulls a bound the wire left unset, where its update requires both.
  * @category Facades
  */
 export interface ProtectionUpdate {


### PR DESCRIPTION
## What

One doc paragraph on `ProtectionUpdate`.

## Why

`ProtectionState` and `ProtectionUpdate` are structurally identical, so the pair reads as duplication worth collapsing — until one of them has to move alone. Their holiday counterparts already show what that divergence looks like: `HolidayModeState` nulls a bound the wire left unset, where `HolidayModeUpdate` requires both.

Recording the intent costs a paragraph and heads off a future dedupe that would have to be undone.

## Checklist

- [x] `npm run format` passes
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run docs` passes (validation warnings fail the build; the cross-module link resolves)