### PR TITLE
fix: hold sign-ins for the lockout MELCloud announces, not a guess

### DIFF
--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -126,6 +126,28 @@ const LOGIN_BACKOFF_FAILURE_MS = 900_000
 const LOGIN_BACKOFF_THROTTLE_MS = 7_200_000
 
 /**
+ * How long to hold sign-ins after a throttle rejection. The server's own
+ * countdown wins when it announced one — waiting past it is downtime the
+ * upstream never asked for, and a field report showed exactly that: a
+ * 60-minute lockout answered with a 120-minute pause, leaving a heat
+ * pump uncontrollable for the extra hour. The constant stays the cap and
+ * the fallback, so an absent or absurd window cannot shorten the pause
+ * below what a blind caller would have waited.
+ * @param error - The throttle rejection that is arming the backoff.
+ * @returns Milliseconds to hold automatic sign-ins.
+ */
+const throttleBackoffMs = (error: AuthenticationThrottledError): number => {
+  const { retryAfter } = error
+  if (retryAfter === null) {
+    return LOGIN_BACKOFF_THROTTLE_MS
+  }
+  return Math.min(
+    retryAfter.total({ unit: 'milliseconds' }),
+    LOGIN_BACKOFF_THROTTLE_MS,
+  )
+}
+
+/**
  * Subclass-internal options injected into the {@link BaseAPI}
  * constructor. Distinct from {@link BaseAPIConfig} (the user-facing
  * surface) — these capture **what the subclass knows** that the user
@@ -753,7 +775,7 @@ export abstract class BaseAPI implements Disposable {
     }
     const backoffMs =
       error instanceof AuthenticationThrottledError
-        ? LOGIN_BACKOFF_THROTTLE_MS
+        ? throttleBackoffMs(error)
         : LOGIN_BACKOFF_FAILURE_MS
     this.#setLoginBackoffUntil(
       Temporal.Now.instant().epochMilliseconds + backoffMs,

--- a/src/api/classic.ts
+++ b/src/api/classic.ts
@@ -619,7 +619,11 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
     password,
     username,
   }: LoginCredentials): Promise<void> {
-    const { ErrorId: errorId, LoginData: loginData } = await this.login({
+    const {
+      ErrorId: errorId,
+      LoginData: loginData,
+      LoginMinutes: loginMinutes,
+    } = await this.login({
       postData: {
         AppVersion: APP_VERSION,
         Email: username,
@@ -631,10 +635,19 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
     if (loginData === null) {
       // ErrorId 6 is MELCloud's login throttle (LoginStatus 6, high
       // LoginAttempts): the credentials may be perfectly valid — asking
-      // the user to re-log would keep the lockout alive.
+      // the user to re-log would keep the lockout alive. The lockout it
+      // still has to run is in LoginMinutes, counting down between
+      // attempts; a non-positive value is one of the sentinels the
+      // endpoint sends when it announces no window at all.
       throw errorId === LOGIN_THROTTLE_ERROR_ID
         ? new AuthenticationThrottledError(
             'MELCloud is temporarily blocking sign-ins (too many attempts)',
+            {
+              retryAfter:
+                typeof loginMinutes === 'number' && loginMinutes > 0
+                  ? Temporal.Duration.from({ minutes: loginMinutes })
+                  : null,
+            },
           )
         : new AuthenticationError('MELCloud Classic rejected the credentials')
     }

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -569,9 +569,12 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
         error.response.status === HttpStatus.TooManyRequests
       ) {
         // The BFF/Cognito login throttle — the Home mirror of Classic's
-        // ErrorId 6. Valid credentials, blocked endpoint: back off.
+        // ErrorId 6. Valid credentials, blocked endpoint: back off. The
+        // 429 carries no window this layer reads, so the caller keeps
+        // its own conservative pause.
         throw new AuthenticationThrottledError(
           'MELCloud Home is temporarily blocking sign-ins (too many attempts)',
+          { retryAfter: null },
         )
       }
       const authError = normalizeUnauthorized(error)

--- a/src/errors/authentication-throttled.ts
+++ b/src/errors/authentication-throttled.ts
@@ -1,3 +1,4 @@
+import type { Temporal } from '../temporal.ts'
 import { AuthenticationError } from './authentication.ts'
 
 /**
@@ -7,7 +8,33 @@ import { AuthenticationError } from './authentication.ts'
  * automatic re-login backoff widens when this error arms it; sessions
  * established BEFORE the throttle keep working (MELCloud stays generous
  * with existing keys).
+ *
+ * `retryAfter` carries the window the server itself announced — Classic
+ * counts it down in `LoginMinutes` — mirroring `RateLimitError`'s field
+ * so a consumer can say "try again in N minutes" without parsing the
+ * message. It is `null` when the upstream announced none, which is what
+ * makes the caller fall back to its own conservative pause.
+ * @category Errors
  */
 export class AuthenticationThrottledError extends AuthenticationError {
   public override readonly name = 'AuthenticationThrottledError'
+
+  public readonly retryAfter: Temporal.Duration | null
+
+  /**
+   * Builds the error from the message and the announced window.
+   * @param message - Human-readable error description.
+   * @param options - Throttle window metadata plus optional cause.
+   * @param options.retryAfter - `Temporal.Duration` the server asks the
+   * caller to wait, or `null` when it announced none.
+   * @param options.cause - Original error that triggered this one.
+   */
+  public constructor(
+    message: string,
+    options: { retryAfter: Temporal.Duration | null; cause?: unknown },
+  ) {
+    const { retryAfter } = options
+    super(message, options)
+    this.retryAfter = retryAfter
+  }
 }

--- a/src/types/classic-generic.ts
+++ b/src/types/classic-generic.ts
@@ -416,6 +416,13 @@ export interface ClassicLoginData {
     readonly Expiry: string
   } | null
   readonly ErrorId?: number | null | undefined
+  /**
+   * Minutes MELCloud will keep refusing sign-ins, sent alongside a
+   * throttle rejection (`ErrorId 6`) and counting down between
+   * attempts. Absent, null or non-positive when the response carries
+   * no such window.
+   */
+  readonly LoginMinutes?: number | null | undefined
 }
 
 /**

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -35,6 +35,7 @@ export const ClassicLoginDataSchema: z.ZodType<ClassicLoginData> =
         Expiry: z.string(),
       })
       .nullable(),
+    LoginMinutes: z.number().nullable().optional(),
   })
 
 /** Home OIDC /connect/par response. */

--- a/tests/contracts/is-available.test.ts
+++ b/tests/contracts/is-available.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
+import { ClassicDeviceType } from '../../src/constants.ts'
+import { ClassicRegistry } from '../../src/entities/index.ts'
+import { EntityNotFoundError } from '../../src/errors/index.ts'
+import { ClassicDeviceAtaFacade } from '../../src/facades/classic-device-ata.ts'
+import { HomeDeviceAtaFacade } from '../../src/facades/home-device-ata.ts'
+import { Temporal } from '../../src/temporal.ts'
+import {
+  assertClassicDeviceType,
+  classicAreaData,
+  classicAtaDevice,
+  classicAtaDeviceData,
+  classicBuildingData,
+  classicFloorData,
+  createMockClassicApi,
+} from '../classic-fixtures.ts'
+import { cast, defined, mock } from '../helpers.ts'
+import { homeDevice, homeTestRegistry } from '../home-fixtures.ts'
+
+// `isAvailable` answers one question on both dialects — has this unit
+// gone quiet for longer than the stale window? — from two different
+// sources: Classic reads a last-communication timestamp, Home a
+// disconnection streak. That difference is real and is not the contract;
+// what follows is.
+//
+// The clauses live here once because the dialects diverging on one of
+// them is not hypothetical: 45.0.1 fixed Classic reading a pruned id as
+// reachable where Home already threw, with both at 100% coverage and
+// nothing asking them the same question.
+const CASES: readonly {
+  readonly isAvailable: boolean
+  readonly label: string
+  readonly silentHours: number
+}[] = [
+  { isAvailable: true, label: 'heard from just now', silentHours: 0 },
+  { isAvailable: true, label: 'quiet for an hour', silentHours: 1 },
+  { isAvailable: false, label: 'quiet for over a day', silentHours: 25 },
+]
+
+/**
+ * Runs the `isAvailable` contract against one dialect.
+ * @param name - Implementation label used in the test titles.
+ * @param read - Reads availability for a unit quiet that many hours.
+ * @param readPruned - Reads availability once the registry has dropped
+ * the id, which must throw rather than answer.
+ */
+const describeIsAvailableContract = (
+  name: string,
+  read: (silentHours: number) => boolean,
+  readPruned: () => boolean,
+): void => {
+  describe(`isAvailable — ${name}`, () => {
+    it.each(CASES)(
+      'reads a unit $label as isAvailable=$isAvailable',
+      ({ isAvailable, silentHours }) => {
+        expect(read(silentHours)).toBe(isAvailable)
+      },
+    )
+
+    it('propagates a pruned id instead of reading available', () => {
+      expect(readPruned).toThrow(EntityNotFoundError)
+    })
+  })
+}
+
+const now = (): Temporal.PlainDateTime => Temporal.Now.plainDateTimeISO('UTC')
+
+const classicRegistry = (): ClassicRegistry => {
+  const registry = new ClassicRegistry()
+  registry.syncBuildings([classicBuildingData()])
+  registry.syncFloors([classicFloorData()])
+  registry.syncAreas([classicAreaData()])
+  return registry
+}
+
+const classicFacade = (
+  registry: ClassicRegistry,
+  device = classicAtaDevice(),
+): ClassicDeviceAtaFacade => {
+  registry.syncDevices([device])
+  const instance = defined(registry.devices.getById(device.DeviceID))
+  assertClassicDeviceType(instance, ClassicDeviceType.Ata)
+  return new ClassicDeviceAtaFacade(createMockClassicApi(), registry, instance)
+}
+
+describeIsAvailableContract(
+  'Classic device',
+  (silentHours) =>
+    classicFacade(
+      classicRegistry(),
+      classicAtaDevice({
+        Device: classicAtaDeviceData({
+          LastTimeStamp: now().subtract({ hours: silentHours }).toString(),
+        }),
+      }),
+    ).isAvailable,
+  () => {
+    const registry = classicRegistry()
+    const facade = classicFacade(registry)
+    registry.syncDevices([])
+    return facade.isAvailable
+  },
+)
+
+const homeApi = (): HomeAPIAdapter =>
+  mock<HomeAPIAdapter>({ registry: cast(homeTestRegistry) })
+
+// Home expresses silence as a disconnection streak, so the clock is
+// moved rather than the payload; `isConnected` stays true for a unit
+// heard from just now.
+describeIsAvailableContract(
+  'Home device',
+  (silentHours) => {
+    const facade = new HomeDeviceAtaFacade(
+      homeApi(),
+      homeDevice({
+        id: `contract-available-${String(silentHours)}`,
+        isConnected: silentHours === 0,
+      }),
+    )
+    if (silentHours === 0) {
+      return facade.isAvailable
+    }
+    const later = now().add({ hours: silentHours })
+    const spy = vi
+      .spyOn(Temporal.Now, 'plainDateTimeISO')
+      .mockReturnValue(later)
+    try {
+      return facade.isAvailable
+    } finally {
+      spy.mockRestore()
+    }
+  },
+  () => {
+    const facade = new HomeDeviceAtaFacade(
+      homeApi(),
+      homeDevice({ id: 'contract-available-pruned' }),
+    )
+    homeTestRegistry.delete('contract-available-pruned')
+    return facade.isAvailable
+  },
+)

--- a/tests/unit/base-api.test.ts
+++ b/tests/unit/base-api.test.ts
@@ -982,7 +982,7 @@ describe('automatic login backoff', () => {
           .settingManager,
       })
       api.doAuthenticateMock.mockRejectedValue(
-        new AuthenticationThrottledError('locked'),
+        new AuthenticationThrottledError('locked', { retryAfter: null }),
       )
 
       await expect(
@@ -995,6 +995,67 @@ describe('automatic login backoff', () => {
       expect(api.doAuthenticateMock).toHaveBeenCalledTimes(1)
 
       vi.advanceTimersByTime(6_300_000)
+
+      await expect(api.resumeSession()).resolves.toBe(false)
+      expect(api.doAuthenticateMock).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('honours the announced window instead of the two-hour default', async () => {
+    vi.useFakeTimers()
+    mockTemporalNowInstant()
+    try {
+      const api = new TestAPI({
+        settingManager: createSettingStore({ password: 'p', username: 'u' })
+          .settingManager,
+      })
+      api.doAuthenticateMock.mockRejectedValue(
+        new AuthenticationThrottledError('locked', {
+          retryAfter: Temporal.Duration.from({ minutes: 60 }),
+        }),
+      )
+
+      await expect(
+        api.authenticate({ password: 'p', username: 'u' }),
+      ).rejects.toThrow('locked')
+
+      // Still held a minute short of the announced hour…
+      vi.advanceTimersByTime(3_540_000)
+
+      await expect(api.resumeSession()).resolves.toBe(false)
+      expect(api.doAuthenticateMock).toHaveBeenCalledTimes(1)
+
+      // …and released at it, an hour before the blind default would.
+      vi.advanceTimersByTime(60_001)
+
+      await expect(api.resumeSession()).resolves.toBe(false)
+      expect(api.doAuthenticateMock).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('caps an announced window at the two-hour default', async () => {
+    vi.useFakeTimers()
+    mockTemporalNowInstant()
+    try {
+      const api = new TestAPI({
+        settingManager: createSettingStore({ password: 'p', username: 'u' })
+          .settingManager,
+      })
+      api.doAuthenticateMock.mockRejectedValue(
+        new AuthenticationThrottledError('locked', {
+          retryAfter: Temporal.Duration.from({ hours: 48 }),
+        }),
+      )
+
+      await expect(
+        api.authenticate({ password: 'p', username: 'u' }),
+      ).rejects.toThrow('locked')
+
+      vi.advanceTimersByTime(7_200_001)
 
       await expect(api.resumeSession()).resolves.toBe(false)
       expect(api.doAuthenticateMock).toHaveBeenCalledTimes(2)

--- a/tests/unit/classic-api.test.ts
+++ b/tests/unit/classic-api.test.ts
@@ -1156,4 +1156,37 @@ describe('mELCloud Classic API', () => {
       api.authenticate({ password: 'p', username: 'u@test.com' }),
     ).rejects.toThrow(AuthenticationThrottledError)
   })
+
+  it('carries the announced lockout from LoginMinutes', async () => {
+    mockRequest.mockResolvedValue(
+      wrap({ ErrorId: 6, LoginData: null, LoginMinutes: 60 }),
+    )
+    const api = await createApi()
+
+    await expect(
+      api.authenticate({ password: 'p', username: 'u@test.com' }),
+    ).rejects.toMatchObject({
+      retryAfter: expect.objectContaining({ minutes: 60 }) as unknown,
+    })
+  })
+
+  it.each([
+    { announced: undefined, label: 'absent' },
+    { announced: null, label: 'null' },
+    { announced: 0, label: 'zero' },
+    // The endpoint sent -10033 in the field: a sentinel, not a window.
+    { announced: -10_033, label: 'negative' },
+  ])(
+    'announces no window when LoginMinutes is $label',
+    async ({ announced }) => {
+      mockRequest.mockResolvedValue(
+        wrap({ ErrorId: 6, LoginData: null, LoginMinutes: announced }),
+      )
+      const api = await createApi()
+
+      await expect(
+        api.authenticate({ password: 'p', username: 'u@test.com' }),
+      ).rejects.toMatchObject({ retryAfter: null })
+    },
+  )
 })


### PR DESCRIPTION
## What

Reads `LoginMinutes` off the `ClientLogin3` rejection and uses it as the sign-in backoff, instead of a flat two hours.

## Why

From a user report on com.melcloud 45.11.0 ("its not cooling anymore"), the login response was:

```
"ErrorId": 6, "LoginStatus": 6, "UserId": 186637,
"LoginMinutes": 60,          ← then 59 on the next attempt
"LoginAttempts": 112035
```

MELCloud counts the remaining lockout down in `LoginMinutes` on every throttle rejection. The schema parsed neither it nor `LoginStatus`, so the backoff applied `LOGIN_BACKOFF_THROTTLE_MS` — **120 minutes against a 60-minute lockout**. That is an extra hour of a heat pump nobody can control, asked for by nothing.

The classification itself was already right (`ErrorId 6` → `AuthenticationThrottledError`, and the app already tells the user to wait rather than to re-enter credentials); only the duration was invented.

## How

`AuthenticationThrottledError` carries the announced window as `retryAfter`, mirroring `RateLimitError`'s field so a consumer can phrase "try again in N minutes" without parsing the message. The two-hour constant becomes the **cap and the fallback**:

- no window announced (the Home 429 carries none) → unchanged two hours;
- announced window → waited exactly, capped at two hours so an absurd value cannot extend it;
- non-positive → read as "none announced".

## The undocumented fields, now measured

The wire semantics were settled by probing the live endpoint directly rather than guessed:

| Case | ErrorId | LoginAttempts | LoginData |
|---|---|---|---|
| Unknown email | 1 | 0 | null |
| Wrong password, real account | 1 | 1 | null |
| Correct password | null | 0 | present |

- **`ErrorId 1` covers both rejection cases**, so the binary classification (6 = throttle, everything else = rejected) is **complete** for every reproducible code — there is no hidden distinction the catch-all was flattening. The report's `ErrorId 1` rejection was a genuine credential failure, and disarming the sync was the right call.
- **`LoginAttempts` counts failures since the last success** (0 → 1 after one failure, → 0 after a success), so the report's 112 034 is that many *consecutive* failures, not a lifetime tally.
- **`UserId: 0` means nothing about account resolution** — a successful login returns 0 too.
- `LoginMinutes` is 0 on an `ErrorId 1`; the field's `-10033` in the report is a sentinel, not a window. Hence reading it only on `ErrorId 6`, and treating any non-positive value as "none announced".

## Checklist

- [x] `npm run format` passes
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (1014 tests, coverage 100% on statements, branches, functions and lines)
- [x] `npm run docs` passes
