### PR TITLE
chore(release): 45.1.0 — honour the announced login lockout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [45.1.0] - 2026-07-29
+
+### Fixed
+
+- **The sign-in backoff now waits the lockout MELCloud announces, instead of a flat two hours.** `ClientLogin3` counts the remaining lockout down in `LoginMinutes` on every throttle rejection (`ErrorId 6`), and the schema parsed neither it nor `LoginStatus`. A user report showed a 60-minute lockout answered with a 120-minute pause — an extra hour of a heat pump nobody could control, asked for by nothing. The two-hour constant is now the cap and the fallback: an absent window (the Home 429 carries none) or an absurd one cannot shorten the pause below what a blind caller would have waited, and a non-positive `LoginMinutes` reads as "none announced" (the endpoint sends sentinels such as `-10033`).
+
+### Added
+
+- **`AuthenticationThrottledError.retryAfter`** — the window the server announced, as a `Temporal.Duration`, mirroring `RateLimitError.retryAfter` so a consumer can phrase "try again in N minutes" without parsing the message. `null` when the upstream announced none. The constructor's options bag stays optional, so existing `new AuthenticationThrottledError(message)` call sites are unaffected.
+- `ClassicLoginData.LoginMinutes`, typed and validated alongside the fields the login flow already consumed.
+
 ## [45.0.2] - 2026-07-28
 
 ### Fixed
@@ -426,6 +437,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[45.1.0]: https://github.com/OlivierZal/melcloud-api/compare/45.0.2...45.1.0
 [45.0.2]: https://github.com/OlivierZal/melcloud-api/compare/45.0.1...45.0.2
 [45.0.1]: https://github.com/OlivierZal/melcloud-api/compare/45.0.0...45.0.1
 [45.0.0]: https://github.com/OlivierZal/melcloud-api/compare/44.1.0...45.0.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "45.0.2",
+  "version": "45.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "45.0.2",
+      "version": "45.1.0",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "45.0.2",
+  "version": "45.1.0",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -570,11 +570,10 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
       ) {
         // The BFF/Cognito login throttle — the Home mirror of Classic's
         // ErrorId 6. Valid credentials, blocked endpoint: back off. The
-        // 429 carries no window this layer reads, so the caller keeps
-        // its own conservative pause.
+        // 429 carries no window this layer reads, so the error announces
+        // none and the caller keeps its own conservative pause.
         throw new AuthenticationThrottledError(
           'MELCloud Home is temporarily blocking sign-ins (too many attempts)',
-          { retryAfter: null },
         )
       }
       const authError = normalizeUnauthorized(error)

--- a/src/errors/authentication-throttled.ts
+++ b/src/errors/authentication-throttled.ts
@@ -22,19 +22,19 @@ export class AuthenticationThrottledError extends AuthenticationError {
   public readonly retryAfter: Temporal.Duration | null
 
   /**
-   * Builds the error from the message and the announced window.
+   * Builds the error from the message and, when the upstream announced
+   * one, the window it asks the caller to wait.
    * @param message - Human-readable error description.
-   * @param options - Throttle window metadata plus optional cause.
+   * @param options - Optional throttle window metadata plus cause.
    * @param options.retryAfter - `Temporal.Duration` the server asks the
-   * caller to wait, or `null` when it announced none.
+   * caller to wait; omit or pass `null` when it announced none.
    * @param options.cause - Original error that triggered this one.
    */
   public constructor(
     message: string,
-    options: { retryAfter: Temporal.Duration | null; cause?: unknown },
+    options?: { cause?: unknown; retryAfter?: Temporal.Duration | null },
   ) {
-    const { retryAfter } = options
     super(message, options)
-    this.retryAfter = retryAfter
+    this.retryAfter = options?.retryAfter ?? null
   }
 }

--- a/tests/unit/base-api.test.ts
+++ b/tests/unit/base-api.test.ts
@@ -982,7 +982,7 @@ describe('automatic login backoff', () => {
           .settingManager,
       })
       api.doAuthenticateMock.mockRejectedValue(
-        new AuthenticationThrottledError('locked', { retryAfter: null }),
+        new AuthenticationThrottledError('locked'),
       )
 
       await expect(


### PR DESCRIPTION
## What

Cuts 45.1.0, carrying #1652's fix to consumers, and relaxes `AuthenticationThrottledError`'s options bag back to optional.

## The release

`CHANGELOG.md` had no entry for #1652 — my miss when merging it. Added now, under **Fixed** (the backoff waits the announced lockout instead of a flat two hours) and **Added** (`AuthenticationThrottledError.retryAfter`, `ClassicLoginData.LoginMinutes`).

## Why the constructor is optional again

#1652 made the options bag required. That would have turned a one-field addition into a **breaking change** for every consumer constructing the error — and forced a major — for no gain:

- `null` is the right default, and it is exactly what the Home 429 path passes (that endpoint announces no window);
- `APIError`'s own options are optional, so the class was the odd one out;
- nothing in the fix depends on the caller being explicit.

So 45.1.0 is a **minor**: new public field, new behaviour, no signature anyone has to follow.

## Next

Publishing this unblocks com.melcloud, which pins `45.0.2` exactly and therefore cannot receive the fix. The app bump follows once this is on the registry.

## Checklist

- [x] `npm run format` passes
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (1014 tests, coverage 100% on statements, branches, functions and lines)
- [x] `npm run docs` passes