### PR TITLE
test: type the fixtures instead of casting them

### DIFF
--- a/tests/classic-fixtures.ts
+++ b/tests/classic-fixtures.ts
@@ -1,6 +1,10 @@
 import { vi } from 'vitest'
 
-import type { ClassicAPIAdapter, SyncCallback } from '../src/api/index.ts'
+import type {
+  ClassicAPIAdapter,
+  ClassicErrorLog,
+  SyncCallback,
+} from '../src/api/index.ts'
 import {
   ClassicDeviceType,
   ClassicLabelType,
@@ -25,6 +29,9 @@ import {
   type ClassicListDeviceDataErv,
   type ClassicReportData,
   type ClassicSetDeviceDataAta,
+  type ClassicTilesData,
+  type ClassicTilesPostData,
+  type Result,
   ok,
   toClassicAreaId,
   toClassicBuildingId,
@@ -303,6 +310,10 @@ export const classicBuildingWithStructure = (
 export const classicRawDevice = (
   overrides: Record<string, unknown> = {},
 ): ClassicListDeviceAny =>
+  // Raw on purpose: this models the wire payload BEFORE branding and
+  // validation, so its ids are plain numbers and `Device` is empty. A
+  // typed factory rightly rejects it — `cast` is the deliberate
+  // off-shape entry point.
   cast({
     AreaID: null,
     BuildingID: 1,
@@ -318,9 +329,15 @@ export const classicRawDevice = (
 // Mock factories
 // ---------------------------------------------------------------------------
 
-const emptyTilesResponse = (): Awaited<
-  ReturnType<ClassicAPIAdapter['getTiles']>
-> => ok(cast({ SelectedDevice: null, Tiles: [] }))
+// The whole-building form (`SelectedDevice: null`), which is what
+// `ClassicTilesData<null>` means. Declaring it through
+// `ReturnType<getTiles>` resolved to the LAST overload — the
+// device-scoped one — so the type said "a device response" while the
+// value was a building response, and an assertion hid the mismatch. The
+// caller's `cast` is a separate concession: an overloaded function cannot
+// be satisfied by one `vi.fn`.
+const emptyTilesResponse = (): Result<ClassicTilesData<null>> =>
+  ok(mock<ClassicTilesData<null>>({ SelectedDevice: null, Tiles: [] }))
 
 export const createMockClassicApi = (
   overrides: Partial<ClassicAPIAdapter> = {},
@@ -335,17 +352,18 @@ export const createMockClassicApi = (
       .mockResolvedValue(ok([])),
     getErrorLog: vi
       .fn<ClassicAPIAdapter['getErrorLog']>()
-      .mockResolvedValue(ok(cast({ errors: [] }))),
+      .mockResolvedValue(ok(mock<ClassicErrorLog>({ errors: [] }))),
     getFrostProtection: vi
       .fn<ClassicAPIAdapter['getFrostProtection']>()
       .mockResolvedValue(
         ok(classicFrostProtectionResponse({ FPDefined: true })),
       ),
-    getGroup: vi
-      .fn<ClassicAPIAdapter['getGroup']>()
-      .mockResolvedValue(
-        ok(cast({ Data: { Group: { State: { Power: true } } } })),
-      ),
+    getGroup: vi.fn<ClassicAPIAdapter['getGroup']>().mockResolvedValue(
+      // `Partial<T>` is shallow, so a typed factory here would need one
+      // nested factory per wire level to assert the single field this
+      // skeleton exists for.
+      ok(cast({ Data: { Group: { State: { Power: true } } } })),
+    ),
     getHolidayMode: vi
       .fn<ClassicAPIAdapter['getHolidayMode']>()
       .mockResolvedValue(ok(classicHolidayModeResponse({ HMDefined: true }))),
@@ -364,9 +382,16 @@ export const createMockClassicApi = (
     getTemperatures: vi
       .fn<ClassicAPIAdapter['getTemperatures']>()
       .mockResolvedValue(ok(classicReportData())),
+    // Typed on the whole-building overload, which is the form the default
+    // response models; the outer `cast` is the unavoidable part — one
+    // `vi.fn` cannot satisfy an overloaded signature.
     getTiles: cast(
       vi
-        .fn<ClassicAPIAdapter['getTiles']>()
+        .fn<
+          (args: {
+            postData: ClassicTilesPostData<null>
+          }) => Promise<Result<ClassicTilesData<null>>>
+        >()
         .mockResolvedValue(emptyTilesResponse()),
     ),
     getValues: vi

--- a/tests/integration/api-lifecycle.test.ts
+++ b/tests/integration/api-lifecycle.test.ts
@@ -5,7 +5,7 @@ import type { HomeAPI } from '../../src/api/home.ts'
 import type { SyncCallback } from '../../src/api/index.ts'
 import { ClassicDeviceType } from '../../src/constants.ts'
 import { ClassicFacadeManager } from '../../src/facades/classic-manager.ts'
-import { HttpError } from '../../src/http/index.ts'
+import { type HttpResponse, HttpError } from '../../src/http/index.ts'
 import { Temporal } from '../../src/temporal.ts'
 import {
   type ClassicBuildingWithStructure,
@@ -21,7 +21,6 @@ import {
   classicBuildingData,
 } from '../classic-fixtures.ts'
 import {
-  cast,
   createMockHttpClient,
   createSettingStore,
   defined,
@@ -307,7 +306,7 @@ describe('api lifecycle', () => {
 
     // eslint-disable-next-line @typescript-eslint/require-await -- promise-function-async autofixes sync Promise returns back to async: the pair leaves no disable-free way to satisfy an async contract synchronously
     mockRequest.mockImplementation(async (config) =>
-      cast({
+      mock<HttpResponse>({
         data:
           config.url === '/FrostProtection/Update'
             ? { AttributeErrors: null, Success: true }

--- a/tests/unit/classic-facades.test.ts
+++ b/tests/unit/classic-facades.test.ts
@@ -34,7 +34,10 @@ import {
 } from '../../src/facades/index.ts'
 import { Temporal } from '../../src/temporal.ts'
 import {
+  type ClassicEnergyDataAta,
+  type ClassicEnergyDataAtw,
   type ClassicListDeviceDataAta,
+  type ClassicSetDeviceDataAtw,
   type ClassicSetDevicePostData,
   err,
   ok,
@@ -190,7 +193,7 @@ const atwSetValuesResponse = (
 ): Partial<ClassicAPIAdapter> => ({
   updateValues: cast(
     vi.fn<ClassicAPIAdapter['updateValues']>().mockResolvedValue(
-      cast({
+      mock<ClassicSetDeviceDataAtw>({
         DeviceType: ClassicDeviceType.Atw,
         EffectiveFlags: 0x1,
         ForcedHotWaterMode: false,
@@ -874,7 +877,7 @@ describe('ata device facade', () => {
     const { api, facade } = createAtaFacade({
       getEnergy: vi.fn<ClassicAPIAdapter['getEnergy']>().mockResolvedValue(
         ok(
-          cast({
+          mock<ClassicEnergyDataAta>({
             Auto: [0, 0],
             Cooling: [0.5, 1],
             Dry: [0, 0],
@@ -920,7 +923,7 @@ describe('ata device facade', () => {
     const { facade } = createAtaFacade({
       getEnergy: vi.fn<ClassicAPIAdapter['getEnergy']>().mockResolvedValue(
         ok(
-          cast({
+          mock<ClassicEnergyDataAta>({
             Auto: [0, 0, 0, 0, 0, 0, 0],
             Cooling: [1, 1, 1, 1, 1, 1, 1],
             Dry: [0, 0, 0, 0, 0, 0, 0],
@@ -963,7 +966,7 @@ describe('ata device facade', () => {
   it('lowers Z-suffixed report bounds to wall-clock in the display timezone', async () => {
     const getEnergy = vi.fn<ClassicAPIAdapter['getEnergy']>().mockResolvedValue(
       ok(
-        cast({
+        mock<ClassicEnergyDataAta>({
           Auto: [0, 0],
           Cooling: [0.5, 1],
           Dry: [0, 0],
@@ -1007,7 +1010,7 @@ describe('ata device facade', () => {
     const { facade } = createAtaFacade({
       getEnergy: vi.fn<ClassicAPIAdapter['getEnergy']>().mockResolvedValue(
         ok(
-          cast({
+          mock<ClassicEnergyDataAta>({
             Auto: [0, 0],
             Cooling: [0.2, 0.3],
             Dry: [0, 0],
@@ -1314,7 +1317,7 @@ describe('atw device facade', () => {
     const { facade } = createAtwFacade({
       getEnergy: vi.fn<ClassicAPIAdapter['getEnergy']>().mockResolvedValue(
         ok(
-          cast({
+          mock<ClassicEnergyDataAtw>({
             Cooling: [0, 0],
             CoP: [2.5, null],
             Heating: [5.1, 4.9],

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { ReportChartLineOptions } from '../../src/facades/index.ts'
-import { ok } from '../../src/types/index.ts'
+import { err, ok } from '../../src/types/index.ts'
 import {
   fromListToSetAta,
   fromSetToListAta,
@@ -14,7 +14,7 @@ import {
   padHourlyChartToMidnight,
   typedFromEntries,
 } from '../../src/utils.ts'
-import { cast, okValue } from '../helpers.ts'
+import { okValue } from '../helpers.ts'
 
 describe.concurrent('ata set-to-list conversion', () => {
   it('maps set keys to list keys', () => {
@@ -152,9 +152,7 @@ describe.concurrent(mergeHourlyChartResults, () => {
   })
 
   it('propagates the first hourly failure untouched', () => {
-    const failure: ReturnType<typeof mergeHourlyChartResults> = cast({
-      ok: false,
-    })
+    const failure = err({ cause: new Error('fail'), kind: 'network' })
 
     expect(
       mergeHourlyChartResults([hourOptions(['00:00'], [-60]), failure]),


### PR DESCRIPTION
## What

Ten `cast` sites become `mock<T>()` calls. In this repo `mock` is `<T extends object>(value?: Partial<T>) => T`, so **keys and values** are both checked — `cast` returns `never` and checks nothing.

`cast` goes from 81 uses to 71; of the 26 that were object literals, 16 remain, each for a reason now written down.

## Proof the checking is real

Retyping one payload field:

```diff
-            LabelType: 4,
+            LabelType: 'four',
```

→ `TS2322: Type 'string' is not assignable to type 'ClassicLabelType | undefined'`.

Under `cast` that compiled silently. All six converted payloads passed unchanged, which means they were complete and correct all along — the casts were simply unnecessary.

## Two files now hold no cast at all

- **`utils.test.ts`** hand-built `{ ok: false }` as a `Failure`. The library exports `err()` — the fully typed constructor for exactly that. One line, no helper.
- **`api-lifecycle.test.ts`**'s response fixture is a plain `HttpResponse`; the generic already defaults to `unknown`.

## One conversion found a real mismatch

`emptyTilesResponse` declared its type through `ReturnType<ClassicAPIAdapter['getTiles']>`, which TypeScript resolves to the **last overload** — the device-scoped one. Its value, though, is the whole-building response: `SelectedDevice: null`, which is precisely what `ClassicTilesData<null>` means (the type is conditional on the parameter).

So the declared type said *a device response* over *a building response*, and the cast hid it. It now declares `Result<ClassicTilesData<null>>`, and the mocked `vi.fn` is typed on the matching overload — the outer `cast` stays, because one `vi.fn` cannot satisfy an overloaded signature, which is a different and unavoidable concession.

## The 16 survivors are the helper's actual purpose

`cast` exists to feed a value the type **deliberately forbids**. That is the opposite need from building a typed double, and key checking would defeat those tests:

| kept | why |
|---|---|
| 9 present-`undefined` keys | `exactOptionalPropertyTypes` bans writing them; only a JS caller produces one, which is what the tests assert |
| 3 mismatched union members | `{...classicAtaDevice(), Type: Atw}` is inconsistent **on purpose**, to cover the type-changed-between-syncs branches |
| the raw wire payload | unbranded numeric ids, empty `Device` — a typed factory rightly rejects it, and the fixture is named `classicRawDevice` |
| 2 generic adapter methods | the fixture cannot fix `<T extends ClassicDeviceType>` |
| 1 nested skeleton | `Partial<T>` is shallow: a typed factory would need one nested factory per wire level to assert the single field the skeleton exists for — more machinery than the check is worth |

The last two now carry a comment, so the next reader does not re-derive the reasoning.

## heatzy-api needs nothing

Checked: its 13 `cast` uses contain **zero** object literals — all are existing values (`cast(JSON.parse(...))` in the observability tests), where no factory applies and `cast` is the documented boundary scoping the `no-unsafe-assignment` concession against `JSON.parse`'s `any`.

## Checklist

- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm run test:coverage` passes — 100% statements/branches/functions/lines
- [x] `npm run lint:package` (`publint --strict`) passes

Tests only, no source change.