### PR TITLE
refactor: drop exports nothing consumes

### DIFF
--- a/src/facades/home-report.ts
+++ b/src/facades/home-report.ts
@@ -389,7 +389,7 @@ export const resolveHomeHourWindow = (
 }
 
 /** Display bucket granularity of the Home energy charts. */
-export type HomeEnergyBucketUnit = 'day' | 'hour' | 'localDay'
+type HomeEnergyBucketUnit = 'day' | 'hour' | 'localDay'
 
 /**
  * Display bucket granularity for an energy-report window: hourly on a

--- a/src/facades/report-types.ts
+++ b/src/facades/report-types.ts
@@ -1,3 +1,13 @@
+/** Base chart options with date range and formatted axis labels. */
+interface ReportChartOptions {
+  /** Start date of the report period. */
+  readonly from: string
+  /** Formatted axis labels (dates, months, etc.). */
+  readonly labels: readonly string[]
+  /** End date of the report period. */
+  readonly to: string
+}
+
 /**
  * One background band over a line chart, expressed as an inclusive
  * `[from, to]` index range on the `labels` grid — e.g. an ATW
@@ -27,16 +37,6 @@ export interface ReportChartLineOptions extends ReportChartOptions {
   readonly unit: string
   /** Background bands (operation modes); absent on most charts. */
   readonly bands?: readonly ReportChartBand[] | undefined
-}
-
-/** Base chart options with date range and formatted axis labels. */
-export interface ReportChartOptions {
-  /** Start date of the report period. */
-  readonly from: string
-  /** Formatted axis labels (dates, months, etc.). */
-  readonly labels: readonly string[]
-  /** End date of the report period. */
-  readonly to: string
 }
 
 /**

--- a/src/observability/error.ts
+++ b/src/observability/error.ts
@@ -4,7 +4,7 @@ import { APICallRequestData } from './request.ts'
 import { APICallResponseData } from './response.ts'
 
 /** Log data extended with the error message from a failed API call. */
-export interface APICallLogDataWithErrorMessage extends APICallLogData {
+interface APICallLogDataWithErrorMessage extends APICallLogData {
   readonly errorMessage: string
 }
 

--- a/src/types/classic-generic.ts
+++ b/src/types/classic-generic.ts
@@ -21,8 +21,14 @@ import type {
   ClassicSetDeviceDataErv,
   ClassicUpdateDeviceDataErv,
 } from './classic-erv.ts'
-import type { Hour } from './hour.ts'
 import type { ClassicBuildingID, ClassicDeviceID } from './ids.ts'
+
+/** Common shape shared by every Classic zone variant returned from the registry — id, hierarchy depth, display name. */
+interface BaseZone {
+  readonly id: number
+  readonly level: number
+  readonly name: string
+}
 
 /**
  * Central mapping from device type to its associated data types.
@@ -49,13 +55,6 @@ interface DeviceDataMapping {
     set: ClassicSetDeviceDataErv
     update: ClassicUpdateDeviceDataErv
   }
-}
-
-/** Common shape shared by every Classic zone variant returned from the registry — id, hierarchy depth, display name. */
-export interface BaseZone {
-  readonly id: number
-  readonly level: number
-  readonly name: string
 }
 
 /**
@@ -590,9 +589,3 @@ export interface ClassicZoneSettings
   extends
     ClassicFrostProtectionData,
     Omit<ClassicHolidayModeData, 'EndDate' | 'StartDate'> {}
-
-/** POST body for the hourly temperature / signal endpoints — multiple devices for a fixed hour-of-day. */
-export interface HourlyReportPostData {
-  readonly devices: number[]
-  readonly hour: Hour
-}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -275,7 +275,7 @@ const getChartLineSeries = ({
  * `locale` stays an explicit, named, per-call argument (no global
  * mutable locale state).
  */
-export interface ChartLineFormatOptions {
+interface ChartLineFormatOptions {
   /** Legend entries for each data series. */
   readonly legend: readonly (string | undefined)[]
   /** Unit of measurement for the data. */

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -402,7 +402,7 @@ const ClassicBuildingStructureSchema = z.looseObject({
 })
 
 /** Minimal shape the {@link ClassicBuildingListSchema} guarantees on success. */
-export interface ClassicBuildingListEntry {
+interface ClassicBuildingListEntry {
   readonly ID: number
   readonly Name: string
   readonly Structure: unknown


### PR DESCRIPTION
## What

Removes exports nothing consumes, and one type that was both dead and wrong.

## The dead one, and why it mattered

`HourlyReportPostData` was declared once and referenced nowhere. Its eight sibling `Classic*PostData` types are used 6–13 times each; it was also the only one without the `Classic` prefix they all carry.

Worse, it described a shape the wire does not use:

```ts
/** POST body for the hourly temperature / signal endpoints — multiple devices … */
export interface HourlyReportPostData {
  readonly devices: number[]   // plural
  readonly hour: Hour
}
```

The adapter actually sends `postData: { device: number; hour: Hour }` — **singular**. So the comment claimed the hourly endpoints batch devices, which they do not. Dead code that also misinformed.

Deleting it surfaced a second corpse the linter then caught: the `Hour` import in `classic-generic.ts` existed only for it.

I did **not** replace it with a named type. There is a single inline call site, so naming it would trade one literal for one type with no gain.

## The un-exports

Six types are used only inside their declaring file, so `export` claimed a need that does not exist: `APICallLogDataWithErrorMessage`, `BaseZone`, `ChartLineFormatOptions`, `ClassicBuildingListEntry`, `HomeEnergyBucketUnit`, `ReportChartOptions`.

None is re-exported by a barrel — that is exactly how they were found, since a barrel re-export would count as an external reference.

## The published surface is provably untouched

The point that matters for a library. Built `dist/index.d.ts` before and after:

```
index.d.ts IDENTIQUE
```

Byte-identical, so no consumer can observe this change. `publint --strict` still passes.

## What I deliberately kept

`MS_PER_HOUR` in `time-units.ts` is unused today, and it stays. The module’s own docblock says why: *"Shared time unit constants. Single source of truth so callers don’t recompute (or worse, redefine with subtly different names)."* Deleting a member of a deliberately complete set would defeat its stated purpose — the next caller needing hours would redefine it, which is the exact failure the module exists to prevent.

## Checklist

- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm run test:coverage` passes (100%)
- [x] `npm run lint:package` (`publint --strict`) passes