### PR TITLE
build: typecheck the config files

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'eslint/config'
+import { type Config, defineConfig } from 'eslint/config'
 import { flatConfigs as importXConfigs } from 'eslint-plugin-import-x'
 import { jsdoc } from 'eslint-plugin-jsdoc'
 import { configs as packageJsonConfigs } from 'eslint-plugin-package-json'
@@ -47,7 +47,7 @@ const typeLikeSortOptions = {
   ],
 }
 
-const config = defineConfig([
+const config: Config[] = defineConfig([
   {
     // `scripts/` holds gitignored one-shot wire probes, not shipped
     // code — outside the lint scope by decision, like the build outputs.
@@ -97,9 +97,7 @@ const config = defineConfig([
     files: ['**/*.ts'],
     languageOptions: {
       parserOptions: {
-        projectService: {
-          allowDefaultProject: ['*.config.ts'],
-        },
+        projectService: true,
         warnOnUnsupportedTypeScriptVersion: false,
       },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^4.4.5",
         "eslint-plugin-import-x": "^4.17.1",
-        "eslint-plugin-jsdoc": "^63.0.13",
+        "eslint-plugin-jsdoc": "^63.3.3",
         "eslint-plugin-package-json": "^1.6.0",
         "eslint-plugin-perfectionist": "^5.10.0",
         "eslint-plugin-unicorn": "^72.0.0",
@@ -142,9 +142,9 @@
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.89.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.89.0.tgz",
-      "integrity": "sha512-ESopDL0Bvyak+X5FQHlWkesK3TO2WNZOV5d4Rh4ouaZxekla9P8e7boSZpmxeTWQ0sTwcAp9h5eAeD1kZ9ywvA==",
+      "version": "0.91.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.91.0.tgz",
+      "integrity": "sha512-vgqlMGNNhZxwDYbUNIHj3Hskb4R28iqdXx90ufHyt/NeuTQkeqjTDslAs9I0/GCAfbxP5BpH5WsL1R1fht5Lxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -152,7 +152,7 @@
         "@typescript-eslint/types": "^8.65.0",
         "comment-parser": "1.4.7",
         "esquery": "^1.7.0",
-        "jsdoc-type-pratt-parser": "~7.2.0"
+        "jsdoc-type-pratt-parser": "~8.0.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -967,9 +967,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -987,9 +984,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -1007,9 +1001,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -1027,9 +1018,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -1047,9 +1035,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -1067,9 +1052,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2950,13 +2932,13 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "63.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.2.1.tgz",
-      "integrity": "sha512-4aPJDFGAIYq81kifBPvInvSHdAwowJ+nVXvSEoBC5SKzdr5Em9NFaVkdPX7UbVUyNN2Zn8JvQB+daNf3wSQE8Q==",
+      "version": "63.3.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.3.3.tgz",
+      "integrity": "sha512-xI4IeVRzRFA2DGHrPLIxF3U+oJHU3FE+P9Zb27fVs5dPHgfcpoAs0PyCbznVhK7pwR+9BPUztFeXSgpw/CL4Yg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.89.0",
+        "@es-joy/jsdoccomment": "~0.91.0",
         "@es-joy/resolve.exports": "1.2.0",
         "are-docs-informative": "^0.0.2",
         "comment-parser": "1.4.7",
@@ -3664,9 +3646,9 @@
       "license": "MIT"
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.2.0.tgz",
-      "integrity": "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-8.0.0.tgz",
+      "integrity": "sha512-uQu/fXVqVaMg6gM8/E5G5+eygVcZ1NV0Z51CvqhNa2bDWxvHMl484ETr6vph4oPyC+KUcbP/w2W2pewfCiR9aQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.5",
     "eslint-plugin-import-x": "^4.17.1",
-    "eslint-plugin-jsdoc": "^63.0.13",
+    "eslint-plugin-jsdoc": "^63.3.3",
     "eslint-plugin-package-json": "^1.6.0",
     "eslint-plugin-perfectionist": "^5.10.0",
     "eslint-plugin-unicorn": "^72.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     "types": ["node"],
     "verbatimModuleSyntax": true
   },
-  "include": ["src", "tests"]
+  "include": ["*.config.ts", "src", "tests"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vitest/config'
+import { type ViteUserConfig, defineConfig } from 'vitest/config'
 import swc from 'unplugin-swc'
 
-const config = defineConfig({
+const config: ViteUserConfig = defineConfig({
   oxc: false,
   plugins: [
     swc.vite({


### PR DESCRIPTION
## What

Makes `npm run typecheck` cover the three root config files (`eslint.config.ts`, `prettier.config.ts`, `vitest.config.ts`), which no project included until now.

- `tsconfig.json`: the config files enter the project (apps: drop `exclude: ["*.config.ts"]`; libraries: add `"*.config.ts"` to `include`).
- `eslint.config.ts` / `vitest.config.ts`: explicit type annotations on the exported config, which `isolatedDeclarations` requires — the same idiom `prettier.config.ts` already used (`const config: Config = …`).
- `eslint.config.ts`: `projectService.allowDefaultProject` drops to plain `projectService: true`.
- `eslint-plugin-jsdoc` → 63.3.3.

**`tsconfig.build.json` is untouched** — the configs must stay out of emission, and they do (verified: 0 config files in the build project).

## Why

An IDE reported a type error in `eslint.config.ts` that CI never saw. Root cause: the file was in no TypeScript project, so the editor opened it as an *inferred project* with its own options while `tsc` ignored it entirely.

Worth stating precisely, because I got it wrong at first: **the `exclude` entries in `tsconfig.build.json` are not typecheck exclusions, they are emission exclusions.** Measured with `tsc --noEmit --listFiles`: `tests`, `types`, `drivers`, `lib`, `widgets`, `public`, `settings` are all typechecked today. The only real gap was the root config files.

## The error was real, and upstream

`flat/recommended-tsdoc-error` exists at runtime but the `configs` record and the `jsdoc()` helper were typed as `` `flat/${ConfigGroups}${ConfigVariants}${ErrorLevelVariants}` ``, and `ConfigVariants` had no `-tsdoc`. Fixed upstream in [eslint-plugin-jsdoc 63.3.3](https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v63.3.3), hence the bump — without it, this PR would turn CI red.

## On dropping `allowDefaultProject`

Not a downgrade — it is what typescript-eslint asks for. Once a file is in the project, the parser errors outright:

> `eslint.config.ts was included by allowDefaultProject but also was found in the project service. Consider removing it from allowDefaultProject`

And the [docs](https://typescript-eslint.io/troubleshooting/typed-linting/) put it second: *"If possible, add the file to the closest `tsconfig.json`'s `include`"* — `allowDefaultProject` is the fallback for files you *cannot* add, capped at 8 and building a fresh TypeScript program per file.

Honest note: I measured lint wall-clock both ways and the difference is inside the noise (18.3–19.2 s either way). At three files the performance argument does not apply; the argument here is correctness.

## Verification

- Coverage is now real: `tsc --noEmit --listFiles | grep -c "config.ts$"` → **3** (was 0), and **0** under `tsconfig.build.json`.
- Mutation-tested rather than assumed: setting `branches: 'cent'` in `vitest.config.ts` now fails `typecheck` (TS2769) where it silently passed before.
- Full suite green.

## Checklist

- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm run test:coverage` passes (100%)
- [x] `npm run lint:package (publint --strict) passes`