### PR TITLE
refactor: name the Home device facade union once

### DIFF
--- a/src/facades/home-manager.ts
+++ b/src/facades/home-manager.ts
@@ -14,6 +14,7 @@ import {
   clampFrostProtection,
   clampOverheatProtection,
 } from '../protection.ts'
+import type { HomeDeviceFacadeAny } from './home-types.ts'
 import { HomeBuildingAtaFacade } from './home-building-ata.ts'
 import { HomeDeviceAtaFacade } from './home-device-ata.ts'
 import { HomeDeviceAtwFacade } from './home-device-atw.ts'
@@ -28,10 +29,7 @@ export class HomeFacadeManager {
 
   readonly #buildings = new Map<string, HomeBuildingAtaFacade>()
 
-  readonly #facades = new WeakMap<
-    HomeDevice,
-    HomeDeviceAtaFacade | HomeDeviceAtwFacade
-  >()
+  readonly #facades = new WeakMap<HomeDevice, HomeDeviceFacadeAny>()
 
   /**
    * Builds a facade manager bound to the given Home API client; facades
@@ -55,10 +53,10 @@ export class HomeFacadeManager {
   public get(): null
   public get(
     instance?: HomeDevice<HomeAtaDeviceData> | HomeDevice<HomeAtwDeviceData>,
-  ): HomeDeviceAtaFacade | HomeDeviceAtwFacade | null
+  ): HomeDeviceFacadeAny | null
   public get(
     instance?: HomeDevice<HomeAtaDeviceData> | HomeDevice<HomeAtwDeviceData>,
-  ): HomeDeviceAtaFacade | HomeDeviceAtwFacade | null {
+  ): HomeDeviceFacadeAny | null {
     if (instance === undefined) {
       return null
     }
@@ -121,7 +119,7 @@ export class HomeFacadeManager {
    * @param id - Device identifier.
    * @returns The facade, or `null` when the id is unknown.
    */
-  public getById(id: string): HomeDeviceAtaFacade | HomeDeviceAtwFacade | null {
+  public getById(id: string): HomeDeviceFacadeAny | null {
     const model = this.#api.registry.getById(id)
     if (model === undefined) {
       return null


### PR DESCRIPTION
## What

`HomeDeviceAtaFacade | HomeDeviceAtwFacade` appeared **four times** in `src/facades/home-manager.ts` (lines 33, 58, 61, 124). It now uses `HomeDeviceFacadeAny`.

## Why the existing name, not a new one

The library **already exports that exact union**:

```ts
// src/facades/home-types.ts:10
export type HomeDeviceFacadeAny = HomeDeviceAtaFacade | HomeDeviceAtwFacade
```

…re-exported from `src/facades/index.ts:41` and `src/index.ts:237`. So `home-manager.ts` was re-spelling a type the public API already names. Reusing it beats introducing a second alias for the same set.

Closes the **SonarCloud `typescript:S4323`** open since 2026-07-28. The repo doctrine requires zero open issues, so this was a standing violation.

## What I deliberately left alone

The overload parameter `HomeDevice<HomeAtaDeviceData> | HomeDevice<HomeAtwDeviceData>` (2 occurrences, below S4323's threshold) stays literal. `HomeDeviceData = HomeAtaDeviceData | HomeAtwDeviceData` exists, but `HomeDevice<A | B>` is **not** the same type as `HomeDevice<A> | HomeDevice<B>` — substituting it would change the very narrowing these overloads exist to preserve.

## Verification

- `dist/index.d.ts` built before and after: **byte-identical**. No consumer can observe this.
- `npm run format` / `lint` / `typecheck` pass
- `npm run test:coverage` passes (100%)
- `npm run lint:package` (`publint --strict`) passes