### PR TITLE
fix: recommend the workspace extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 .env
 .env.*
 /.vscode/*
+!/.vscode/extensions.json
 !/.vscode/settings.json
 /coverage/
 /dist/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "sonarsource.sonarlint-vscode",
+    "typescriptteam.native-preview"
+  ]
+}


### PR DESCRIPTION
Follow-up to the just-merged audit wave, mirroring com.heatzy#1061's review point: `.vscode/settings.json` carries extension-specific settings (`typescript.native-preview.tsdk`, the SonarLint binding) that a fresh contributor's editor would silently ignore. `.vscode/extensions.json` now recommends both extensions — ids read off a machine where they are installed, not guessed.