### PR TITLE
ci: gate the Sonar step on the secret's presence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
     # still reports failure, so keep `Test (Node latest)` out of the
     # required status checks or it will still block merges.
     continue-on-error: ${{ matrix.node-version == 'latest' }}
+    # Job-level so the Sonar step can gate on the secret's presence: the
+    # `secrets` context is not available in a step-level `if`, `env` is.
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     name: Test (Node ${{ matrix.node-version }})
     permissions:
       contents: read
@@ -47,10 +51,8 @@ jobs:
         run: npm test -- --coverage
       - if: matrix.node-version != 'lts/*'
         run: npm test
-      - if: matrix.node-version == 'lts/*' && (github.event_name == 'push' || (github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository))
+      - if: matrix.node-version == 'lts/*' && env.SONAR_TOKEN != '' && (github.event_name == 'push' || (github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository))
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Closes the last CI-parity gap the audit measured: the `env.SONAR_TOKEN != ''` self-arming guard existed in com.heatzy, com.melcloud.extension and heatzy-api, was added to com.melcloud in its wave — and was still missing here. Canonical wording, job-level `env`, redundant step-level `env` dropped, `zizmor` locally clean.