### PR TITLE
ci: align the workflow family to one form

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,14 @@ jobs:
         run: npm test -- --coverage
       - if: matrix.node-version != 'lts/*'
         run: npm test
+      # Self-armed on the secret: until SONAR_TOKEN is provisioned the
+      # upload skips instead of failing the leg.
       - if: matrix.node-version == 'lts/*' && env.SONAR_TOKEN != '' && (github.event_name == 'push' || (github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository))
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22, latest, lts/*]
+        node-version: [22, latest, 'lts/*']
     timeout-minutes: 20
 name: CI
 on:

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -63,5 +63,6 @@ name: Claude Dependabot Fix
 on:
   workflow_run:
     types: [completed]
+    # The repo's two always-running required build gates (see ruleset).
     workflows: [CI, Zizmor]
 permissions: {}


### PR DESCRIPTION
One slice of a five-repo alignment (same title everywhere). A hash matrix of every workflow across the repos found the last drifts — action pins behind in two repos, three rationale comments on one side of the family only, an undocumented `workflows:` gate list, split matrix quoting. After the five PRs: **zizmor, claude, claude-code-review and claude-issue-triage are byte-identical across all five repos**; ci and audit are identical within each family; every remaining cross-family difference is auth or domain, verified by diff. `zizmor` locally clean on all five.