### PR TITLE
chore: adopt eslint-plugin-unicorn 73

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -749,9 +749,9 @@ const config: Config[] = defineConfig([
       'unicorn/custom-error-definition': 'error',
       // Owned by `@typescript-eslint/naming-convention`.
       'unicorn/id-match': 'off',
+      'unicorn/iteration-fallback-style': 'error',
       // Vocabulary opt-out: the abbreviation renames it forces
       // (`args` -> `arguments_`, ...) fight the domain naming.
-      'unicorn/iteration-fallback-style': 'error',
       'unicorn/name-replacements': 'off',
       // Owned by `import-x/no-anonymous-default-export`.
       'unicorn/no-anonymous-default-export': 'off',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -751,6 +751,7 @@ const config: Config[] = defineConfig([
       'unicorn/id-match': 'off',
       // Vocabulary opt-out: the abbreviation renames it forces
       // (`args` -> `arguments_`, ...) fight the domain naming.
+      'unicorn/iteration-fallback-style': 'error',
       'unicorn/name-replacements': 'off',
       // Owned by `import-x/no-anonymous-default-export`.
       'unicorn/no-anonymous-default-export': 'off',
@@ -952,9 +953,6 @@ const config: Config[] = defineConfig([
       // decorator protocol rebinds `this` at call time, which an arrow
       // cannot receive.
       'unicorn/consistent-function-style': 'off',
-      // Replacement accessors/methods receive `this` through the
-      // decorator protocol — there is no class body to put it in.
-      'unicorn/no-this-outside-of-class': 'off',
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "eslint-plugin-jsdoc": "^63.3.3",
         "eslint-plugin-package-json": "^1.6.2",
         "eslint-plugin-perfectionist": "^5.10.0",
-        "eslint-plugin-unicorn": "^72.0.0",
+        "eslint-plugin-unicorn": "^73.0.0",
         "eslint-plugin-yml": "^3.6.0",
         "jiti": "^2.7.0",
         "jsonc-eslint-parser": "^3.1.0",
@@ -3063,9 +3063,9 @@
       }
     },
     "node_modules/eslint-plugin-unicorn": {
-      "version": "72.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-72.0.0.tgz",
-      "integrity": "sha512-hqO6ksoOHO+ZhdseTuKRVQbx9U7PRO/cv8qAR1mctwzdVO2hYud8uS9luAhp43RJgziYgHAph8eHyipT8GL0ng==",
+      "version": "73.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-73.0.0.tgz",
+      "integrity": "sha512-V0YatLe9nkGhXEXKe2Qljb1EY0sJHwDV0HUF1NKFwtsHh/fU7qGHDgv+6fchzZcgU2/7noHo2gdjnmo0P2uDPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "eslint-plugin-jsdoc": "^63.3.3",
     "eslint-plugin-package-json": "^1.6.2",
     "eslint-plugin-perfectionist": "^5.10.0",
-    "eslint-plugin-unicorn": "^72.0.0",
+    "eslint-plugin-unicorn": "^73.0.0",
     "eslint-plugin-yml": "^3.6.0",
     "jiti": "^2.7.0",
     "jsonc-eslint-parser": "^3.1.0",

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -155,9 +155,13 @@ const throttleBackoffMs = (error: AuthenticationThrottledError): number => {
  * the sync runner closure).
  */
 interface BaseAPIConstructorOptions {
-  /** Subclass default for {@link BaseAPIConfig.syncIntervalMinutes}. */
+  /**
+   * Subclass default for {@link BaseAPIConfig.syncIntervalMinutes}.
+   */
   defaultSyncIntervalMinutes: number | false
-  /** Subclass-fixed HTTP defaults (baseURL, optional dispatcher). */
+  /**
+   * Subclass-fixed HTTP defaults (baseURL, optional dispatcher).
+   */
   httpConfig: Omit<HttpClientConfig, 'timeout'>
   /**
    * Label prefixed to every log line (e.g. `[Classic]`): the two
@@ -166,9 +170,13 @@ interface BaseAPIConstructorOptions {
    * could not tell which account a diagnostics report was about.
    */
   logLabel: string
-  /** Sliding-window length the rate-limit gate observes. */
+  /**
+   * Sliding-window length the rate-limit gate observes.
+   */
   rateLimitHours: number
-  /** Sync runner the auto-timer drives. */
+  /**
+   * Sync runner the auto-timer drives.
+   */
   syncCallback: () => Promise<unknown>
 }
 
@@ -403,7 +411,9 @@ export abstract class BaseAPI implements Disposable {
     await this.#finishLogin(epoch)
   }
 
-  /** Cancels any pending auto-sync timer; subsequent `setSyncInterval` or `fetch` calls re-arm it. */
+  /**
+   * Cancels any pending auto-sync timer; subsequent `setSyncInterval` or `fetch` calls re-arm it.
+   */
   public clearSync(): void {
     this.#syncManager.clear()
   }
@@ -532,7 +542,9 @@ export abstract class BaseAPI implements Disposable {
     }
   }
 
-  /** Releases the auto-sync timer and any retry-guard timers; the instance must not be reused after disposal. */
+  /**
+   * Releases the auto-sync timer and any retry-guard timers; the instance must not be reused after disposal.
+   */
   public [Symbol.dispose](): void {
     this.#syncManager[Symbol.dispose]()
     this.retryGuard[Symbol.dispose]()

--- a/src/api/classic-types.ts
+++ b/src/api/classic-types.ts
@@ -62,17 +62,25 @@ export interface ClassicAPIAdapter extends BaseAPIAdapter {
    * observer cannot break the caller.
    */
   readonly notifySync: SyncCallback
-  /** Classic model registry synced by the fetch cycle. */
+  /**
+   * Classic model registry synced by the fetch cycle.
+   */
   readonly registry: ClassicRegistry
-  /** Fetch all buildings and sync the model registry. */
+  /**
+   * Fetch all buildings and sync the model registry.
+   */
   readonly fetch: () => Promise<ClassicBuildingWithStructure[]>
-  /** Fetch energy consumption report. Supported by ATA and ATW devices. */
+  /**
+   * Fetch energy consumption report. Supported by ATA and ATW devices.
+   */
   readonly getEnergy: <T extends ClassicDeviceType>({
     postData,
   }: {
     postData: ClassicEnergyPostData
   }) => Promise<Result<ClassicEnergyData<T>>>
-  /** Fetch raw error log entries from the Classic API. */
+  /**
+   * Fetch raw error log entries from the Classic API.
+   */
   readonly getErrorEntries: ({
     postData,
   }: {
@@ -86,55 +94,73 @@ export interface ClassicAPIAdapter extends BaseAPIAdapter {
     query: ClassicErrorLogQuery,
     deviceIds: number[],
   ) => Promise<Result<ClassicErrorLog>>
-  /** Get frost protection settings for a building, floor, area, or device. */
+  /**
+   * Get frost protection settings for a building, floor, area, or device.
+   */
   readonly getFrostProtection: ({
     params,
   }: {
     params: ClassicSettingsParams
   }) => Promise<Result<ClassicFrostProtectionData>>
-  /** Fetch ATA device group state. ATA only. */
+  /**
+   * Fetch ATA device group state. ATA only.
+   */
   readonly getGroup: ({
     postData,
   }: {
     postData: ClassicGetGroupPostData
   }) => Promise<Result<ClassicGetGroupData>>
-  /** Get holiday mode settings for a building, floor, area, or device. */
+  /**
+   * Get holiday mode settings for a building, floor, area, or device.
+   */
   readonly getHolidayMode: ({
     params,
   }: {
     params: ClassicSettingsParams
   }) => Promise<Result<ClassicHolidayModeData>>
-  /** Fetch hourly temperature report. ATW only. */
+  /**
+   * Fetch hourly temperature report. ATW only.
+   */
   readonly getHourlyTemperatures: ({
     postData,
   }: {
     postData: { device: number; hour: Hour }
   }) => Promise<Result<ClassicReportData>>
-  /** Fetch internal temperature report. ATW only. */
+  /**
+   * Fetch internal temperature report. ATW only.
+   */
   readonly getInternalTemperatures: ({
     postData,
   }: {
     postData: ClassicReportPostData
   }) => Promise<Result<ClassicReportData>>
-  /** Fetch operation mode log data for charting. */
+  /**
+   * Fetch operation mode log data for charting.
+   */
   readonly getOperationModes: ({
     postData,
   }: {
     postData: ClassicReportPostData
   }) => Promise<Result<ClassicOperationModeLogData>>
-  /** Fetch WiFi signal strength report. */
+  /**
+   * Fetch WiFi signal strength report.
+   */
   readonly getSignal: ({
     postData,
   }: {
     postData: { devices: number | number[]; hour: Hour }
   }) => Promise<Result<ClassicReportData>>
-  /** Fetch temperature log data. */
+  /**
+   * Fetch temperature log data.
+   */
   readonly getTemperatures: ({
     postData,
   }: {
     postData: ClassicTemperatureLogPostData
   }) => Promise<Result<ClassicReportData>>
-  /** Fetch tile data for device overview. */
+  /**
+   * Fetch tile data for device overview.
+   */
   readonly getTiles: (({
     postData,
   }: {
@@ -145,37 +171,49 @@ export interface ClassicAPIAdapter extends BaseAPIAdapter {
     }: {
       postData: ClassicTilesPostData<T>
     }) => Promise<Result<ClassicTilesData<T>>>)
-  /** Fetch current device data by device and building ID. */
+  /**
+   * Fetch current device data by device and building ID.
+   */
   readonly getValues: <T extends ClassicDeviceType>({
     params,
   }: {
     params: ClassicGetDeviceDataParams
   }) => Promise<Result<ClassicGetDeviceData<T>>>
-  /** Update frost protection settings. */
+  /**
+   * Update frost protection settings.
+   */
   readonly updateFrostProtection: ({
     postData,
   }: {
     postData: ClassicFrostProtectionPostData
   }) => Promise<ClassicFailureData | ClassicSuccessData>
-  /** Update ATA device group state. ATA only. */
+  /**
+   * Update ATA device group state. ATA only.
+   */
   readonly updateGroupState: ({
     postData,
   }: {
     postData: ClassicSetGroupPostData
   }) => Promise<ClassicFailureData | ClassicSuccessData>
-  /** Update holiday mode settings. */
+  /**
+   * Update holiday mode settings.
+   */
   readonly updateHolidayMode: ({
     postData,
   }: {
     postData: ClassicHolidayModePostData
   }) => Promise<ClassicFailureData | ClassicSuccessData>
-  /** Turn devices on or off. */
+  /**
+   * Turn devices on or off.
+   */
   readonly updatePower: ({
     postData,
   }: {
     postData: ClassicSetPowerPostData
   }) => Promise<boolean>
-  /** Send updated device values to the Classic API. */
+  /**
+   * Send updated device values to the Classic API.
+   */
   readonly updateValues: <T extends ClassicDeviceType>({
     postData,
     type,
@@ -190,7 +228,9 @@ export interface ClassicAPIAdapter extends BaseAPIAdapter {
  * @category Configuration
  */
 export interface ClassicAPIConfig extends BaseAPIConfig {
-  /** Upstream account language code (e.g. `'en'`, `'fr'`). */
+  /**
+   * Upstream account language code (e.g. `'en'`, `'fr'`).
+   */
   readonly language?: string | undefined
   /**
    * BCP-47 locale tag for report chart labels (day-of-week, month
@@ -199,9 +239,13 @@ export interface ClassicAPIConfig extends BaseAPIConfig {
    * locally. Defaults to the runtime locale when unset.
    */
   readonly locale?: string | undefined
-  /** Whether to verify SSL certificates. Defaults to `true`. */
+  /**
+   * Whether to verify SSL certificates. Defaults to `true`.
+   */
   readonly shouldVerifySSL?: boolean | undefined
-  /** IANA timezone identifier (e.g. `'Europe/Paris'`). */
+  /**
+   * IANA timezone identifier (e.g. `'Europe/Paris'`).
+   */
   readonly timezone?: string | undefined
 }
 
@@ -210,7 +254,9 @@ export interface ClassicAPIConfig extends BaseAPIConfig {
  * @category Configuration
  */
 export interface ClassicAPISettings extends BaseAPISettings {
-  /** MELCloud session context key. */
+  /**
+   * MELCloud session context key.
+   */
   readonly contextKey?: string | null
 }
 
@@ -219,11 +265,17 @@ export interface ClassicAPISettings extends BaseAPISettings {
  * @category Configuration
  */
 export interface ClassicErrorDetails {
-  /** ISO 8601 date of the error occurrence. */
+  /**
+   * ISO 8601 date of the error occurrence.
+   */
   readonly date: string
-  /** Numeric ID of the device that reported the error. */
+  /**
+   * Numeric ID of the device that reported the error.
+   */
   readonly deviceId: number
-  /** Error message text. */
+  /**
+   * Error message text.
+   */
   readonly error: string
 }
 
@@ -232,13 +284,21 @@ export interface ClassicErrorDetails {
  * @category Configuration
  */
 export interface ClassicErrorLog {
-  /** List of error entries, sorted in reverse chronological order. */
+  /**
+   * List of error entries, sorted in reverse chronological order.
+   */
   readonly errors: readonly ClassicErrorDetails[]
-  /** ISO date string for the queried period start. */
+  /**
+   * ISO date string for the queried period start.
+   */
   readonly fromDate: string
-  /** ISO date string for the next page's start date. */
+  /**
+   * ISO date string for the next page's start date.
+   */
   readonly nextFromDate: string
-  /** ISO date string for the next page's end date. */
+  /**
+   * ISO date string for the next page's end date.
+   */
   readonly nextToDate: string
 }
 
@@ -259,8 +319,12 @@ export interface ClassicErrorLogQuery {
    * one-day boundary so consecutive pages don't overlap.
    */
   readonly offset?: number | undefined
-  /** Number of days per page. Defaults to `1`. */
+  /**
+   * Number of days per page. Defaults to `1`.
+   */
   readonly period?: number | undefined
-  /** End date in ISO 8601 format. Defaults to now. */
+  /**
+   * End date in ISO 8601 format. Defaults to now.
+   */
   readonly to?: string | undefined
 }

--- a/src/api/home-types.ts
+++ b/src/api/home-types.ts
@@ -33,18 +33,28 @@ import type { BaseAPIAdapter, BaseAPIConfig, BaseAPISettings } from './types.ts'
  * @category Configuration
  */
 export interface HomeAPIAdapter extends BaseAPIAdapter {
-  /** Home device registry with stable model references across syncs. */
+  /**
+   * Home device registry with stable model references across syncs.
+   */
   readonly registry: HomeRegistry
-  /** The currently authenticated user, or `null`. */
+  /**
+   * The currently authenticated user, or `null`.
+   */
   readonly user: HomeUser | null
-  /** Fetch all buildings and sync the device registry — the heartbeat, mirroring Classic `fetch()`. */
+  /**
+   * Fetch all buildings and sync the device registry — the heartbeat, mirroring Classic `fetch()`.
+   */
   readonly fetch: () => Promise<HomeBuilding[]>
-  /** Fetch the internal-temperatures report (flow/return/tank/zone) for an ATW unit. */
+  /**
+   * Fetch the internal-temperatures report (flow/return/tank/zone) for an ATW unit.
+   */
   readonly getAtwInternalTemperatures: (
     id: string,
     params: { from: string; period: string; to: string },
   ) => Promise<Result<HomeReportData[]>>
-  /** Fetch energy telemetry for a unit; the registry's connection type selects the measure family. */
+  /**
+   * Fetch energy telemetry for a unit; the registry's connection type selects the measure family.
+   */
   readonly getEnergy: (
     id: string,
     params: {
@@ -54,33 +64,49 @@ export interface HomeAPIAdapter extends BaseAPIAdapter {
       measure?: 'consumed' | 'produced'
     },
   ) => Promise<Result<HomeEnergyData>>
-  /** Fetch the error log for a unit; the registry's connection type selects the unit path. */
+  /**
+   * Fetch the error log for a unit; the registry's connection type selects the unit path.
+   */
   readonly getErrorLog: (id: string) => Promise<Result<HomeErrorLogEntry[]>>
-  /** Fetch WiFi signal strength (RSSI) telemetry for a device. */
+  /**
+   * Fetch WiFi signal strength (RSSI) telemetry for a device.
+   */
   readonly getSignal: (
     id: string,
     params: { from: string; to: string },
   ) => Promise<Result<HomeEnergyData>>
-  /** Fetch the temperature report for a unit; the registry's connection type selects the endpoint. */
+  /**
+   * Fetch the temperature report for a unit; the registry's connection type selects the endpoint.
+   */
   readonly getTemperatures: (
     id: string,
     params: { from: string; period: string; to: string },
   ) => Promise<Result<HomeReportData[]>>
-  /** Fetch the current user's claims from the BFF. Returns `null` on failure. */
+  /**
+   * Fetch the current user's claims from the BFF. Returns `null` on failure.
+   */
   readonly getUser: () => Promise<HomeUser | null>
-  /** Batch frost-protection write (device ids grouped in `units`), then refresh. */
+  /**
+   * Batch frost-protection write (device ids grouped in `units`), then refresh.
+   */
   readonly updateFrostProtection: (
     postData: HomeFrostProtectionPostData,
   ) => Promise<void>
-  /** Batch holiday-mode write (device ids grouped in `units`), then refresh. */
+  /**
+   * Batch holiday-mode write (device ids grouped in `units`), then refresh.
+   */
   readonly updateHolidayMode: (
     postData: HomeHolidayModePostData,
   ) => Promise<void>
-  /** Batch overheat-protection write (ATA-only feature), then refresh. */
+  /**
+   * Batch overheat-protection write (ATA-only feature), then refresh.
+   */
   readonly updateOverheatProtection: (
     postData: HomeOverheatProtectionPostData,
   ) => Promise<void>
-  /** Push a setpoint update (wire path from the registry's connection type), then refresh. */
+  /**
+   * Push a setpoint update (wire path from the registry's connection type), then refresh.
+   */
   readonly updateValues: (
     id: string,
     values: HomeAtaValues | HomeAtwValues,
@@ -92,7 +118,9 @@ export interface HomeAPIAdapter extends BaseAPIAdapter {
  * @category Configuration
  */
 export interface HomeAPIConfig extends BaseAPIConfig {
-  /** Base URL of the MELCloud Home BFF server. */
+  /**
+   * Base URL of the MELCloud Home BFF server.
+   */
   readonly baseURL?: string | undefined
   /**
    * BCP-47 locale tag for report chart labels (dates, times).
@@ -113,8 +141,12 @@ export interface HomeAPIConfig extends BaseAPIConfig {
  * @category Configuration
  */
 export interface HomeAPISettings extends BaseAPISettings {
-  /** IdentityServer access token (Bearer). */
+  /**
+   * IdentityServer access token (Bearer).
+   */
   readonly accessToken?: string | null
-  /** IdentityServer refresh token. */
+  /**
+   * IdentityServer refresh token.
+   */
   readonly refreshToken?: string | null
 }

--- a/src/api/token-auth.ts
+++ b/src/api/token-auth.ts
@@ -27,7 +27,9 @@ const STATE_RANDOM_BYTES = 16
 const REDIRECT_STATUS_MIN = 300
 const REDIRECT_STATUS_MAX = 400
 
-/** Options for {@link authRequest}. */
+/**
+ * Options for {@link authRequest}.
+ */
 interface AuthRequestOptions {
   config: {
     headers: Record<string, string>
@@ -39,7 +41,9 @@ interface AuthRequestOptions {
   abortSignal?: AbortSignal
 }
 
-/** Options for {@link authFollowRedirects}. */
+/**
+ * Options for {@link authFollowRedirects}.
+ */
 interface FollowRedirectsOptions {
   jar: CookieJar
   url: string
@@ -58,7 +62,9 @@ interface OidcResponse<T = unknown> {
   readonly status: number
 }
 
-/** Inputs for {@link fetchPostForm}. */
+/**
+ * Inputs for {@link fetchPostForm}.
+ */
 interface PostFormOptions {
   body: string
   headers: Record<string, string>
@@ -66,7 +72,9 @@ interface PostFormOptions {
   abortSignal?: AbortSignal
 }
 
-/** Options for {@link submitCredentials}. */
+/**
+ * Options for {@link submitCredentials}.
+ */
 interface SubmitCredentialsOptions {
   authorizeUrl: string
   credentials: { password: string; username: string }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -9,15 +9,25 @@ import type { LoginCredentials, UndefinedTolerant } from '../types/index.ts'
  * @category API
  */
 export interface BaseAPIAdapter {
-  /** Whether the client is currently inside a server rate-limit backoff. */
+  /**
+   * Whether the client is currently inside a server rate-limit backoff.
+   */
   readonly isRateLimited: boolean
-  /** BCP-47 locale tag the instance was configured with, or `undefined`. */
+  /**
+   * BCP-47 locale tag the instance was configured with, or `undefined`.
+   */
   readonly locale: string | undefined
-  /** IANA timezone the instance was configured with, or `undefined`. */
+  /**
+   * IANA timezone the instance was configured with, or `undefined`.
+   */
   readonly timezone: string | undefined
-  /** Sign in with explicit credentials; throws on rejection. */
+  /**
+   * Sign in with explicit credentials; throws on rejection.
+   */
   readonly authenticate: (credentials: LoginCredentials) => Promise<void>
-  /** Cancel any pending automatic sync. */
+  /**
+   * Cancel any pending automatic sync.
+   */
   readonly clearSync: () => void
   /**
    * Sync check first; when it reads `false`, one best-effort
@@ -26,9 +36,13 @@ export interface BaseAPIAdapter {
    * unauthenticated until a context fetch has run).
    */
   readonly ensureAuthenticated: () => Promise<boolean>
-  /** Whether a session is currently usable, from local state alone. */
+  /**
+   * Whether a session is currently usable, from local state alone.
+   */
   readonly isAuthenticated: () => boolean
-  /** Explicit sign-out: clears the persisted session material. */
+  /**
+   * Explicit sign-out: clears the persisted session material.
+   */
   readonly logOut: () => void
   /**
    * Best-effort session restore from persisted credentials. Never
@@ -36,7 +50,9 @@ export interface BaseAPIAdapter {
    * sign-in fails (logged via the SDK logger).
    */
   readonly resumeSession: () => Promise<boolean>
-  /** Update the automatic sync interval and reschedule. Pass `false` to disable. */
+  /**
+   * Update the automatic sync interval and reschedule. Pass `false` to disable.
+   */
   readonly setSyncInterval: (minutes: number | false) => void
 }
 
@@ -66,9 +82,13 @@ export interface BaseAPIConfig extends UndefinedTolerant<LoginCredentials> {
    * (pino / winston / OpenTelemetry / custom metrics).
    */
   readonly events?: LifecycleEvents | undefined
-  /** Custom logger. Defaults to `console`. */
+  /**
+   * Custom logger. Defaults to `console`.
+   */
   readonly logger?: Logger | undefined
-  /** External setting manager for persisting credentials and session data. */
+  /**
+   * External setting manager for persisting credentials and session data.
+   */
   readonly settingManager?: SettingManager | undefined
   /**
    * Restore the persisted session in the background instead of awaiting
@@ -86,7 +106,9 @@ export interface BaseAPIConfig extends UndefinedTolerant<LoginCredentials> {
    * default (1 for Home, 5 for Classic).
    */
   readonly syncIntervalMinutes?: number | false | undefined
-  /** HTTP transport: pre-built {@link HttpClient} or build options. */
+  /**
+   * HTTP transport: pre-built {@link HttpClient} or build options.
+   */
   readonly transport?: TransportConfig | undefined
 }
 
@@ -98,13 +120,21 @@ export interface BaseAPIConfig extends UndefinedTolerant<LoginCredentials> {
  * @category API
  */
 export interface BaseAPISettings {
-  /** Session expiry timestamp in ISO 8601 format. */
+  /**
+   * Session expiry timestamp in ISO 8601 format.
+   */
   readonly expiry?: string | null
-  /** Epoch-ms deadline before which automatic re-logins are refused. */
+  /**
+   * Epoch-ms deadline before which automatic re-logins are refused.
+   */
   readonly loginBackoffUntil?: string | null
-  /** Account password. */
+  /**
+   * Account password.
+   */
   readonly password?: string | null
-  /** Account username (email). */
+  /**
+   * Account username (email).
+   */
   readonly username?: string | null
 }
 
@@ -138,14 +168,22 @@ export interface LifecycleEvents {
    * two events always alternate.
    */
   readonly onAuthenticationRestored?: (() => void) | undefined
-  /** Invoked after a successful HTTP response is received. */
+  /**
+   * Invoked after a successful HTTP response is received.
+   */
   readonly onRequestComplete?:
     ((event: RequestCompleteEvent) => void) | undefined
-  /** Invoked when a request fails permanently (retries exhausted). */
+  /**
+   * Invoked when a request fails permanently (retries exhausted).
+   */
   readonly onRequestError?: ((event: RequestErrorEvent) => void) | undefined
-  /** Invoked before each backoff-scheduled retry attempt. */
+  /**
+   * Invoked before each backoff-scheduled retry attempt.
+   */
   readonly onRequestRetry?: ((event: RequestRetryEvent) => void) | undefined
-  /** Invoked when a request is dispatched for the first time. */
+  /**
+   * Invoked when a request is dispatched for the first time.
+   */
   readonly onRequestStart?: ((event: RequestStartEvent) => void) | undefined
   /**
    * Invoked after each sync trigger (auto-timer or
@@ -160,9 +198,13 @@ export interface LifecycleEvents {
  * @category Configuration
  */
 export interface Logger {
-  /** Log error messages. */
+  /**
+   * Log error messages.
+   */
   readonly error: Console['error']
-  /** Log informational messages. */
+  /**
+   * Log informational messages.
+   */
   readonly log: Console['log']
 }
 
@@ -171,9 +213,13 @@ export interface Logger {
  * @category Configuration
  */
 export interface RequestCompleteEvent extends RequestLifecycleContext {
-  /** Elapsed time in milliseconds, including any retry delays. */
+  /**
+   * Elapsed time in milliseconds, including any retry delays.
+   */
   readonly durationMs: number
-  /** Final HTTP status code returned by the upstream server. */
+  /**
+   * Final HTTP status code returned by the upstream server.
+   */
   readonly status: number
 }
 
@@ -182,9 +228,13 @@ export interface RequestCompleteEvent extends RequestLifecycleContext {
  * @category Configuration
  */
 export interface RequestErrorEvent extends RequestLifecycleContext {
-  /** Elapsed time in milliseconds, including any retry delays. */
+  /**
+   * Elapsed time in milliseconds, including any retry delays.
+   */
   readonly durationMs: number
-  /** The terminal error thrown by the request. */
+  /**
+   * The terminal error thrown by the request.
+   */
   readonly error: unknown
 }
 
@@ -197,11 +247,17 @@ export interface RequestErrorEvent extends RequestLifecycleContext {
  * @category Configuration
  */
 export interface RequestLifecycleContext {
-  /** Unique request identifier (UUID v4). */
+  /**
+   * Unique request identifier (UUID v4).
+   */
   readonly correlationId: string
-  /** HTTP method, uppercase. */
+  /**
+   * HTTP method, uppercase.
+   */
   readonly method: string
-  /** Request URL (possibly relative to the client's baseURL). */
+  /**
+   * Request URL (possibly relative to the client's baseURL).
+   */
   readonly url: string
 }
 
@@ -210,11 +266,17 @@ export interface RequestLifecycleContext {
  * @category Configuration
  */
 export interface RequestRetryEvent extends RequestLifecycleContext {
-  /** 1-based retry attempt number (1 = first retry, not the initial try). */
+  /**
+   * 1-based retry attempt number (1 = first retry, not the initial try).
+   */
   readonly attempt: number
-  /** Backoff delay in milliseconds before this retry fires. */
+  /**
+   * Backoff delay in milliseconds before this retry fires.
+   */
   readonly delayMs: number
-  /** The error that triggered the retry. */
+  /**
+   * The error that triggered the retry.
+   */
   readonly error: unknown
 }
 
@@ -229,9 +291,13 @@ export type RequestStartEvent = RequestLifecycleContext
  * @category Configuration
  */
 export interface SettingManager {
-  /** Retrieve a setting value by key. Returns the stored value, or `null`/`undefined` if absent. */
+  /**
+   * Retrieve a setting value by key. Returns the stored value, or `null`/`undefined` if absent.
+   */
   readonly get: (key: string) => string | null | undefined
-  /** Store a setting value by key. */
+  /**
+   * Store a setting value by key.
+   */
   readonly set: (key: string, value: string) => void
   /**
    * Delete a setting key. Optional: when a host does not provide it, the

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,11 +3,17 @@
  * @category Constants
  */
 export const ClassicDeviceType = {
-  /** Air-to-Air (ATA) heat pump. */
+  /**
+   * Air-to-Air (ATA) heat pump.
+   */
   Ata: 0,
-  /** Air-to-Water (ATW) heat pump. */
+  /**
+   * Air-to-Water (ATW) heat pump.
+   */
   Atw: 1,
-  /** Energy Recovery Ventilation (ERV) unit. */
+  /**
+   * Energy Recovery Ventilation (ERV) unit.
+   */
   Erv: 3,
 } as const
 export type ClassicDeviceType =
@@ -18,9 +24,13 @@ export type ClassicDeviceType =
  * @category Constants
  */
 export const HomeDeviceType = {
-  /** Air-to-Air (ATA) heat pump. */
+  /**
+   * Air-to-Air (ATA) heat pump.
+   */
   Ata: 'airToAir',
-  /** Air-to-Water (ATW) heat pump. */
+  /**
+   * Air-to-Water (ATW) heat pump.
+   */
   Atw: 'airToWater',
 } as const
 
@@ -177,11 +187,15 @@ export const classicHeatModes: ReadonlySet<ClassicOperationMode> = new Set([
 export const ClassicOperationModeState = {
   cooling: 3,
   defrost: 5,
-  /** Domestic hot water — the heat pump is currently heating the tank. */
+  /**
+   * Domestic hot water — the heat pump is currently heating the tank.
+   */
   dhw: 1,
   heating: 2,
   idle: 0,
-  /** Legionella prevention cycle — a periodic high-temperature sanitisation of the hot water tank. */
+  /**
+   * Legionella prevention cycle — a periodic high-temperature sanitisation of the hot water tank.
+   */
   legionellaPrevention: 6,
 } as const
 export type ClassicOperationModeState =
@@ -192,12 +206,18 @@ export type ClassicOperationModeState =
  * @category Constants
  */
 export const ClassicOperationModeStateHotWater = {
-  /** Domestic hot water — the heat pump is currently heating the tank. */
+  /**
+   * Domestic hot water — the heat pump is currently heating the tank.
+   */
   dhw: 'dhw',
   idle: 'idle',
-  /** Legionella prevention cycle — a periodic high-temperature sanitisation of the hot water tank. */
+  /**
+   * Legionella prevention cycle — a periodic high-temperature sanitisation of the hot water tank.
+   */
   legionellaPrevention: 'legionella',
-  /** Hot water production is disabled (e.g. prohibit flag set or holiday mode active). */
+  /**
+   * Hot water production is disabled (e.g. prohibit flag set or holiday mode active).
+   */
   prohibited: 'prohibited',
 } as const
 export type ClassicOperationModeStateHotWater =
@@ -212,7 +232,9 @@ export const ClassicOperationModeStateZone = {
   defrost: 'defrost',
   heating: 'heating',
   idle: 'idle',
-  /** Zone regulation is disabled (e.g. prohibit flag set or holiday mode active). */
+  /**
+   * Zone regulation is disabled (e.g. prohibit flag set or holiday mode active).
+   */
   prohibited: 'prohibited',
 } as const
 export type ClassicOperationModeStateZone =
@@ -226,11 +248,15 @@ export type ClassicOperationModeStateZone =
 export const HomeAtwOperationalState = {
   cooling: 'cooling',
   defrost: 'defrost',
-  /** Domestic hot water — the heat pump is currently heating the tank. */
+  /**
+   * Domestic hot water — the heat pump is currently heating the tank.
+   */
   dhw: 'dhw',
   heating: 'heating',
   idle: 'idle',
-  /** Legionella prevention cycle — a periodic high-temperature sanitisation of the hot water tank. */
+  /**
+   * Legionella prevention cycle — a periodic high-temperature sanitisation of the hot water tank.
+   */
   legionellaPrevention: 'legionella',
 } as const
 export type HomeAtwOperationalState =
@@ -257,15 +283,25 @@ export type HomeAtwZoneMode =
  * @category Constants
  */
 export const ClassicOperationModeZone = {
-  /** ClassicTemperature curve-based regulation. */
+  /**
+   * ClassicTemperature curve-based regulation.
+   */
   curve: 2,
-  /** Fixed flow temperature. */
+  /**
+   * Fixed flow temperature.
+   */
   flow: 1,
-  /** Fixed flow temperature with cooling. */
+  /**
+   * Fixed flow temperature with cooling.
+   */
   flow_cool: 4,
-  /** Room thermostat regulation. */
+  /**
+   * Room thermostat regulation.
+   */
   room: 0,
-  /** Room thermostat regulation with cooling. */
+  /**
+   * Room thermostat regulation with cooling.
+   */
   room_cool: 3,
 } as const
 export type ClassicOperationModeZone =
@@ -276,11 +312,17 @@ export type ClassicOperationModeZone =
  * @category Constants
  */
 export const ClassicTemperature = {
-  /** Minimum target temperature when the device is in a cooling-capable mode. */
+  /**
+   * Minimum target temperature when the device is in a cooling-capable mode.
+   */
   cooling_min: 16,
-  /** Maximum target temperature across all modes. */
+  /**
+   * Maximum target temperature across all modes.
+   */
   max: 31,
-  /** Minimum target temperature in heating/auto/dry/fan modes. */
+  /**
+   * Minimum target temperature in heating/auto/dry/fan modes.
+   */
   min: 10,
 } as const
 export type ClassicTemperature =
@@ -292,9 +334,13 @@ export type ClassicTemperature =
  */
 export const ClassicVentilationMode = {
   auto: 2,
-  /** Outside air flows straight through without passing the heat exchanger (free-cooling). */
+  /**
+   * Outside air flows straight through without passing the heat exchanger (free-cooling).
+   */
   bypass: 1,
-  /** Outside air passes through the heat exchanger to recover energy from extract air. */
+  /**
+   * Outside air passes through the heat exchanger to recover energy from extract air.
+   */
   recovery: 0,
 } as const
 export type ClassicVentilationMode =

--- a/src/entities/classic-types.ts
+++ b/src/entities/classic-types.ts
@@ -4,7 +4,9 @@ import type { BaseModel } from './base.ts'
 import type { ClassicBuilding } from './building.ts'
 import type { ClassicDevice } from './classic-device.ts'
 
-/** Base building model providing zone settings (frost protection, holiday mode). */
+/**
+ * Base building model providing zone settings (frost protection, holiday mode).
+ */
 export type ClassicBaseBuilding = Pick<ClassicBuilding, 'data'>
 
 /**
@@ -44,5 +46,7 @@ export const isClassicDeviceOfType = <T extends ClassicDeviceType>(
  */
 export type ClassicDeviceAny = ClassicDevice<ClassicDeviceType>
 
-/** ClassicModel kind discriminants for polymorphic dispatch without instanceof. */
+/**
+ * ClassicModel kind discriminants for polymorphic dispatch without instanceof.
+ */
 export type ClassicModelKind = 'area' | 'building' | 'device' | 'floor'

--- a/src/entities/types.ts
+++ b/src/entities/types.ts
@@ -10,7 +10,9 @@
  */
 export const STALE_COMMUNICATION_HOURS = 24
 
-/** Cross-dialect reachability contract: `true` while MELCloud can deliver writes to the unit. */
+/**
+ * Cross-dialect reachability contract: `true` while MELCloud can deliver writes to the unit.
+ */
 export interface AvailabilityAware {
   readonly isAvailable: boolean
 }

--- a/src/enum-mappings.ts
+++ b/src/enum-mappings.ts
@@ -71,11 +71,15 @@ export const fanSpeedToClassic: Record<HomeFanSpeed, ClassicFanSpeed> = {
   Two: ClassicFanSpeed.slow,
 }
 
-/** Type guard: `value` is a valid Classic fan speed numeric value. */
+/**
+ * Type guard: `value` is a valid Classic fan speed numeric value.
+ */
 export const isClassicFanSpeed: (key: PropertyKey) => key is ClassicFanSpeed =
   isKeyOf(fanSpeedFromClassic)
 
-/** Type guard: `value` is a valid Home fan speed string. */
+/**
+ * Type guard: `value` is a valid Home fan speed string.
+ */
 export const isHomeFanSpeed: (key: PropertyKey) => key is HomeFanSpeed =
   isKeyOf(fanSpeedToClassic)
 

--- a/src/errors/entity-not-found.ts
+++ b/src/errors/entity-not-found.ts
@@ -24,12 +24,16 @@ import { APIError } from './base.ts'
  * @category Errors
  */
 export class EntityNotFoundError extends APIError {
-  /** Id that could not be resolved in the registry — a number for Classic, a GUID string for Home. */
+  /**
+   * Id that could not be resolved in the registry — a number for Classic, a GUID string for Home.
+   */
   public readonly entityId: number | string
 
   public override readonly name = 'EntityNotFoundError'
 
-  /** Registry table the lookup was performed against (e.g. `'DeviceLocation'`), or `'Device'` for the Home registry. */
+  /**
+   * Registry table the lookup was performed against (e.g. `'DeviceLocation'`), or `'Device'` for the Home registry.
+   */
   public readonly tableName: 'Device' | ClassicSettingsParams['tableName']
 
   /**

--- a/src/errors/no-changes.ts
+++ b/src/errors/no-changes.ts
@@ -20,7 +20,9 @@ import { APIError } from './base.ts'
  * @category Errors
  */
 export class NoChangesError extends APIError {
-  /** Id of the entity the update targeted (device, zone, building, etc.). */
+  /**
+   * Id of the entity the update targeted (device, zone, building, etc.).
+   */
   public readonly entityId: number | string
 
   public override readonly name = 'NoChangesError'

--- a/src/errors/update-rejected.ts
+++ b/src/errors/update-rejected.ts
@@ -9,7 +9,9 @@ import { APIError } from './base.ts'
  * @category Errors
  */
 export class UpdateRejectedError extends APIError {
-  /** Per-attribute rejection messages as reported by the wire. */
+  /**
+   * Per-attribute rejection messages as reported by the wire.
+   */
   public readonly attributeErrors: Record<string, readonly string[]>
 
   public override readonly name = 'UpdateRejectedError'

--- a/src/facades/classic-flags.ts
+++ b/src/facades/classic-flags.ts
@@ -13,7 +13,9 @@ import type { ClassicUpdateDeviceData } from '../types/index.ts'
 // `ClassicUpdateDeviceData<T>` so adding a field without a flag (or a
 // flag without a field) fails to type-check.
 
-/** `EffectiveFlags` bitfield values for ATA update payloads — one bit per updatable field. */
+/**
+ * `EffectiveFlags` bitfield values for ATA update payloads — one bit per updatable field.
+ */
 export const classicAtaFlags: {
   readonly OperationMode: 0x2
   readonly Power: 0x1
@@ -32,7 +34,9 @@ export const classicAtaFlags: {
   Record<keyof ClassicUpdateDeviceData<typeof ClassicDeviceType.Ata>, number>
 >
 
-/** `EffectiveFlags` bitfield values for ATW update payloads — one bit per updatable field. */
+/**
+ * `EffectiveFlags` bitfield values for ATW update payloads — one bit per updatable field.
+ */
 export const classicAtwFlags: {
   readonly ForcedHotWaterMode: 0x1_00_00
   readonly OperationModeZone1: 0x8
@@ -61,7 +65,9 @@ export const classicAtwFlags: {
   Record<keyof ClassicUpdateDeviceData<typeof ClassicDeviceType.Atw>, number>
 >
 
-/** `EffectiveFlags` bitfield values for ERV update payloads — one bit per updatable field. */
+/**
+ * `EffectiveFlags` bitfield values for ERV update payloads — one bit per updatable field.
+ */
 export const classicErvFlags: {
   readonly Power: 0x1
   readonly SetFanSpeed: 0x8

--- a/src/facades/classic-types.ts
+++ b/src/facades/classic-types.ts
@@ -32,10 +32,14 @@ import type {
   ReportQuery,
 } from './report-types.ts'
 
-/** Facade for a MELCloud building, combining zone settings with super device operations. */
+/**
+ * Facade for a MELCloud building, combining zone settings with super device operations.
+ */
 export interface ClassicBuildingFacade
   extends ClassicBaseBuilding, ClassicZoneFacade {
-  /** Fetch the latest building zone settings after syncing devices. */
+  /**
+   * Fetch the latest building zone settings after syncing devices.
+   */
   readonly fetch: () => Promise<ClassicZoneSettings>
 }
 
@@ -48,25 +52,39 @@ export interface ClassicBuildingFacade
 export interface ClassicDeviceAtaFacade extends ClassicDeviceFacade<
   typeof ClassicDeviceType.Ata
 > {
-  /** Read this device's current state projected as a group state. */
+  /**
+   * Read this device's current state projected as a group state.
+   */
   readonly getGroup: () => Promise<Result<ClassicGroupState>>
-  /** Apply a group state to this device. */
+  /**
+   * Apply a group state to this device.
+   */
   readonly updateGroupState: (state: ClassicGroupState) => Promise<void>
 }
 
-/** Facade for Air-to-Water (ATW) devices with hot water and zone state access. */
+/**
+ * Facade for Air-to-Water (ATW) devices with hot water and zone state access.
+ */
 export interface ClassicDeviceAtwFacade extends ClassicDeviceFacade<
   typeof ClassicDeviceType.Atw
 > {
-  /** Current hot water state. */
+  /**
+   * Current hot water state.
+   */
   readonly hotWater: ClassicHotWaterState
-  /** Current zone 1 state. */
+  /**
+   * Current zone 1 state.
+   */
   readonly zone1: ClassicZoneState
 }
 
-/** Facade for ATW devices with two heating/cooling zones. */
+/**
+ * Facade for ATW devices with two heating/cooling zones.
+ */
 export interface ClassicDeviceAtwHasZone2Facade extends ClassicDeviceAtwFacade {
-  /** Current zone 2 state. */
+  /**
+   * Current zone 2 state.
+   */
   readonly zone2: ClassicZoneState
 }
 
@@ -78,15 +96,25 @@ export interface ClassicDeviceAtwHasZone2Facade extends ClassicDeviceAtwFacade {
  */
 export interface ClassicDeviceFacade<T extends ClassicDeviceType>
   extends AvailabilityAware, ClassicBaseDevice<T>, ClassicFacade {
-  /** Bitfield flags mapping each updatable property to its effective flag value. */
+  /**
+   * Bitfield flags mapping each updatable property to its effective flag value.
+   */
   readonly flags: Record<keyof ClassicUpdateDeviceData<T>, number>
-  /** Whether the unit is powered on. */
+  /**
+   * Whether the unit is powered on.
+   */
   readonly power: boolean
-  /** Last-reported Wi-Fi signal strength, in dBm. */
+  /**
+   * Last-reported Wi-Fi signal strength, in dBm.
+   */
   readonly rssi: number
-  /** Fetch the latest device data after syncing. */
+  /**
+   * Fetch the latest device data after syncing.
+   */
   readonly fetch: () => Promise<Readonly<ClassicListDeviceData<T>>>
-  /** Fetch energy consumption report. ATA and ATW only. */
+  /**
+   * Fetch energy consumption report. ATA and ATW only.
+   */
   readonly getEnergy: (
     query: ReportQuery,
   ) => Promise<Result<ClassicEnergyData<T>>>
@@ -97,30 +125,44 @@ export interface ClassicDeviceFacade<T extends ClassicDeviceType>
   readonly getEnergyReport: (
     query?: ReportQuery,
   ) => Promise<Result<ReportChartLineOptions>>
-  /** Fetch hourly temperature report. ATW only. */
+  /**
+   * Fetch hourly temperature report. ATW only.
+   */
   readonly getHourlyTemperatures: (
     hour?: Hour,
   ) => Promise<Result<ReportChartLineOptions>>
-  /** Fetch internal temperature report. ATW only. */
+  /**
+   * Fetch internal temperature report. ATW only.
+   */
   readonly getInternalTemperatures: (
     query: ReportQuery,
   ) => Promise<Result<ReportChartLineOptions>>
-  /** Fetch operation mode usage as pie chart data. */
+  /**
+   * Fetch operation mode usage as pie chart data.
+   */
   readonly getOperationModes: (
     query: ReportQuery,
   ) => Promise<Result<ReportChartPieOptions>>
-  /** Fetch temperature history as line chart data. */
+  /**
+   * Fetch temperature history as line chart data.
+   */
   readonly getTemperatures: (
     query: ReportQuery,
   ) => Promise<Result<ReportChartLineOptions>>
-  /** Fetch tile overview data, optionally selecting a specific device. */
+  /**
+   * Fetch tile overview data, optionally selecting a specific device.
+   */
   readonly getTiles: ((
     device: true | ClassicDeviceAny,
   ) => Promise<Result<ClassicTilesData<T>>>) &
     ((device?: false) => Promise<Result<ClassicTilesData<null>>>)
-  /** Fetch current device values from the Classic API. */
+  /**
+   * Fetch current device values from the Classic API.
+   */
   readonly getValues: () => Promise<Result<ClassicGetDeviceData<T>>>
-  /** Send updated device values, clamping temperatures to valid ranges. */
+  /**
+   * Send updated device values, clamping temperatures to valid ranges.
+   */
   readonly updateValues: (
     data: ClassicUpdateDeviceData<T>,
   ) => Promise<ClassicSetDeviceData<T>>
@@ -156,7 +198,9 @@ export interface ClassicEnergyReportExtract {
  * @category Facades
  */
 export interface ClassicFacade extends Identifiable {
-  /** All devices managed by this facade. */
+  /**
+   * All devices managed by this facade.
+   */
   readonly devices: readonly ClassicDeviceAny[]
   /**
    * Whether the underlying entity still exists in the registry.
@@ -164,34 +208,52 @@ export interface ClassicFacade extends Identifiable {
    * throwing counterpart surfaced by other accessors.
    */
   readonly exists: boolean
-  /** Retrieve the error log for all devices in this facade. */
+  /**
+   * Retrieve the error log for all devices in this facade.
+   */
   readonly getErrorLog: (
     query: ClassicErrorLogQuery,
   ) => Promise<Result<ClassicErrorLog>>
-  /** Get the current frost protection settings, `null` when never configured. */
+  /**
+   * Get the current frost protection settings, `null` when never configured.
+   */
   readonly getFrostProtection: () => Promise<Result<ProtectionState | null>>
-  /** Get the current holiday mode settings, `null` when never configured. */
+  /**
+   * Get the current holiday mode settings, `null` when never configured.
+   */
   readonly getHolidayMode: () => Promise<Result<HolidayModeState | null>>
-  /** Fetch WiFi signal strength report as line chart data. */
+  /**
+   * Fetch WiFi signal strength report as line chart data.
+   */
   readonly getSignalStrength: (
     hour?: Hour,
   ) => Promise<Result<ReportChartLineOptions>>
-  /** Fetch tile overview data, optionally selecting a specific device. */
+  /**
+   * Fetch tile overview data, optionally selecting a specific device.
+   */
   readonly getTiles: ((
     device?: false,
   ) => Promise<Result<ClassicTilesData<null>>>) &
     (<T extends ClassicDeviceType>(
       device: ClassicDevice<T>,
     ) => Promise<Result<ClassicTilesData<T>>>)
-  /** Trigger a sync callback for downstream consumers. */
+  /**
+   * Trigger a sync callback for downstream consumers.
+   */
   readonly notifySync: (params?: {
     type?: ClassicDeviceType | undefined
   }) => Promise<void>
-  /** Update frost protection settings with temperature clamping. */
+  /**
+   * Update frost protection settings with temperature clamping.
+   */
   readonly updateFrostProtection: (update: ProtectionUpdate) => Promise<void>
-  /** Enable or disable holiday mode. */
+  /**
+   * Enable or disable holiday mode.
+   */
   readonly updateHolidayMode: (update: HolidayModeUpdate) => Promise<void>
-  /** Turn all devices in this facade on or off. */
+  /**
+   * Turn all devices in this facade on or off.
+   */
   readonly updatePower: (value?: boolean) => Promise<void>
 }
 
@@ -200,9 +262,13 @@ export interface ClassicFacade extends Identifiable {
  * @category Facades
  */
 export interface ClassicZoneFacade extends ClassicFacade {
-  /** Get the current group state for all ATA devices. */
+  /**
+   * Get the current group state for all ATA devices.
+   */
   readonly getGroup: () => Promise<Result<ClassicGroupState>>
-  /** Update the group state for all ATA devices. */
+  /**
+   * Update the group state for all ATA devices.
+   */
   readonly updateGroupState: (state: ClassicGroupState) => Promise<void>
 }
 

--- a/src/facades/home-report.ts
+++ b/src/facades/home-report.ts
@@ -388,7 +388,9 @@ export const resolveHomeHourWindow = (
   return { from, to: from.add({ hours: 1 }) }
 }
 
-/** Display bucket granularity of the Home energy charts. */
+/**
+ * Display bucket granularity of the Home energy charts.
+ */
 type HomeEnergyBucketUnit = 'day' | 'hour' | 'localDay'
 
 /**

--- a/src/facades/report-types.ts
+++ b/src/facades/report-types.ts
@@ -1,10 +1,18 @@
-/** Base chart options with date range and formatted axis labels. */
+/**
+ * Base chart options with date range and formatted axis labels.
+ */
 interface ReportChartOptions {
-  /** Start date of the report period. */
+  /**
+   * Start date of the report period.
+   */
   readonly from: string
-  /** Formatted axis labels (dates, months, etc.). */
+  /**
+   * Formatted axis labels (dates, months, etc.).
+   */
   readonly labels: readonly string[]
-  /** End date of the report period. */
+  /**
+   * End date of the report period.
+   */
   readonly to: string
 }
 
@@ -16,11 +24,17 @@ interface ReportChartOptions {
  * @category Facades
  */
 export interface ReportChartBand {
-  /** Index of the first covered label. */
+  /**
+   * Index of the first covered label.
+   */
   readonly from: number
-  /** Band name (Classic operation-mode vocabulary, e.g. `'HotWater'`). */
+  /**
+   * Band name (Classic operation-mode vocabulary, e.g. `'HotWater'`).
+   */
   readonly label: string
-  /** Index of the last covered label. */
+  /**
+   * Index of the last covered label.
+   */
   readonly to: number
 }
 
@@ -33,9 +47,13 @@ export interface ReportChartLineOptions extends ReportChartOptions {
     readonly data: (number | null)[]
     readonly name: string
   }[]
-  /** Measurement unit label (e.g. `'°C'`, `'dBm'`). */
+  /**
+   * Measurement unit label (e.g. `'°C'`, `'dBm'`).
+   */
   readonly unit: string
-  /** Background bands (operation modes); absent on most charts. */
+  /**
+   * Background bands (operation modes); absent on most charts.
+   */
   readonly bands?: readonly ReportChartBand[] | undefined
 }
 
@@ -44,7 +62,9 @@ export interface ReportChartLineOptions extends ReportChartOptions {
  * @category Facades
  */
 export interface ReportChartPieOptions extends ReportChartOptions {
-  /** Numeric values for each pie segment. */
+  /**
+   * Numeric values for each pie segment.
+   */
   readonly series: number[]
 }
 
@@ -53,8 +73,12 @@ export interface ReportChartPieOptions extends ReportChartOptions {
  * @category Facades
  */
 export interface ReportQuery {
-  /** Start date in ISO 8601 format. Defaults to `'1970-01-01'`. */
+  /**
+   * Start date in ISO 8601 format. Defaults to `'1970-01-01'`.
+   */
   readonly from?: string | undefined
-  /** End date in ISO 8601 format. Defaults to now. */
+  /**
+   * End date in ISO 8601 format. Defaults to now.
+   */
   readonly to?: string | undefined
 }

--- a/src/holiday-mode.ts
+++ b/src/holiday-mode.ts
@@ -12,11 +12,17 @@
  * @category Facades
  */
 export interface HolidayModeState {
-  /** Window end (ISO 8601 wall clock), when set. */
+  /**
+   * Window end (ISO 8601 wall clock), when set.
+   */
   readonly endDate: string | null
-  /** Whether holiday mode is on. */
+  /**
+   * Whether holiday mode is on.
+   */
   readonly isEnabled: boolean
-  /** Window start (ISO 8601 wall clock), when set. */
+  /**
+   * Window start (ISO 8601 wall clock), when set.
+   */
   readonly startDate: string | null
 }
 
@@ -28,10 +34,16 @@ export interface HolidayModeState {
  * @category Facades
  */
 export interface HolidayModeUpdate {
-  /** Window end (ISO 8601). Ignored when `isEnabled` is `false`. */
+  /**
+   * Window end (ISO 8601). Ignored when `isEnabled` is `false`.
+   */
   readonly endDate: string
-  /** Whether holiday mode is on. */
+  /**
+   * Whether holiday mode is on.
+   */
   readonly isEnabled: boolean
-  /** Window start (ISO 8601). Ignored when `isEnabled` is `false`. */
+  /**
+   * Window start (ISO 8601). Ignored when `isEnabled` is `false`.
+   */
   readonly startDate: string
 }

--- a/src/http/status.ts
+++ b/src/http/status.ts
@@ -7,14 +7,24 @@
  * here without a real call site is dead weight.
  */
 export const HttpStatus = {
-  /** HTTP 502 — transient upstream failure. Eligible for retry on GET. */
+  /**
+   * HTTP 502 — transient upstream failure. Eligible for retry on GET.
+   */
   BadGateway: 502,
-  /** HTTP 504 — transient upstream timeout. Eligible for retry on GET. */
+  /**
+   * HTTP 504 — transient upstream timeout. Eligible for retry on GET.
+   */
   GatewayTimeout: 504,
-  /** HTTP 503 — transient service unavailability. Eligible for retry on GET. */
+  /**
+   * HTTP 503 — transient service unavailability. Eligible for retry on GET.
+   */
   ServiceUnavailable: 503,
-  /** HTTP 429 — rate limited. Feeds into the rate-limit gate. */
+  /**
+   * HTTP 429 — rate limited. Feeds into the rate-limit gate.
+   */
   TooManyRequests: 429,
-  /** HTTP 401 — authentication required or rejected. Triggers session re-auth. */
+  /**
+   * HTTP 401 — authentication required or rejected. Triggers session re-auth.
+   */
   Unauthorized: 401,
 } as const

--- a/src/observability/context.ts
+++ b/src/observability/context.ts
@@ -89,7 +89,9 @@ const redactValue = (value: unknown): unknown => {
   )
 }
 
-/** Abstract base for API call logging data, serializable to JSON with a fixed set of log keys. */
+/**
+ * Abstract base for API call logging data, serializable to JSON with a fixed set of log keys.
+ */
 export abstract class APICallLogData {
   declare public readonly dataType: string
 

--- a/src/observability/error.ts
+++ b/src/observability/error.ts
@@ -3,7 +3,9 @@ import type { APICallLogData } from './context.ts'
 import { APICallRequestData } from './request.ts'
 import { APICallResponseData } from './response.ts'
 
-/** Log data extended with the error message from a failed API call. */
+/**
+ * Log data extended with the error message from a failed API call.
+ */
 interface APICallLogDataWithErrorMessage extends APICallLogData {
   readonly errorMessage: string
 }

--- a/src/observability/request.ts
+++ b/src/observability/request.ts
@@ -1,6 +1,8 @@
 import { type LoggableRequestConfig, APICallLogData } from './context.ts'
 
-/** Structured log data for an outgoing API request. */
+/**
+ * Structured log data for an outgoing API request.
+ */
 export class APICallRequestData extends APICallLogData {
   public override readonly dataType = 'API request'
 

--- a/src/observability/response.ts
+++ b/src/observability/response.ts
@@ -1,7 +1,9 @@
 import type { HttpResponse } from '../http/index.ts'
 import { type LoggableRequestConfig, APICallLogData } from './context.ts'
 
-/** Structured log data for an API response. */
+/**
+ * Structured log data for an API response.
+ */
 export class APICallResponseData extends APICallLogData {
   public override readonly dataType = 'API response'
 

--- a/src/protection.ts
+++ b/src/protection.ts
@@ -6,7 +6,9 @@
  * @module
  */
 
-/** Minimum gap required between min and max, in °C (both features). */
+/**
+ * Minimum gap required between min and max, in °C (both features).
+ */
 export const PROTECTION_GAP = 2
 
 /**
@@ -17,11 +19,17 @@ export const PROTECTION_GAP = 2
  * @category Facades
  */
 export interface ProtectionState {
-  /** Whether the protection is on. */
+  /**
+   * Whether the protection is on.
+   */
   readonly isEnabled: boolean
-  /** Upper temperature bound, in °C. */
+  /**
+   * Upper temperature bound, in °C.
+   */
   readonly max: number
-  /** Lower temperature bound, in °C. */
+  /**
+   * Lower temperature bound, in °C.
+   */
   readonly min: number
 }
 
@@ -38,18 +46,28 @@ export interface ProtectionState {
  * @category Facades
  */
 export interface ProtectionUpdate {
-  /** Whether the protection is on. */
+  /**
+   * Whether the protection is on.
+   */
   readonly isEnabled: boolean
-  /** Requested upper bound, in °C. */
+  /**
+   * Requested upper bound, in °C.
+   */
   readonly max: number
-  /** Requested lower bound, in °C. */
+  /**
+   * Requested lower bound, in °C.
+   */
   readonly min: number
 }
 
-/** Absolute frost-protection min/max the units accept, in °C. */
+/**
+ * Absolute frost-protection min/max the units accept, in °C.
+ */
 export const FROST_PROTECTION_RANGE = { max: 16, min: 4 }
 
-/** Absolute overheat-protection min/max the units accept, in °C. */
+/**
+ * Absolute overheat-protection min/max the units accept, in °C.
+ */
 export const OVERHEAT_PROTECTION_RANGE = { max: 40, min: 31 }
 
 const clampProtection = (

--- a/src/resilience/disposable-timeout.ts
+++ b/src/resilience/disposable-timeout.ts
@@ -17,7 +17,9 @@ export class DisposableTimeout implements Disposable {
 
   #timeout?: ReturnType<typeof setTimeout> | undefined
 
-  /** Cancel the current timeout if one is active. */
+  /**
+   * Cancel the current timeout if one is active.
+   */
   public clear(): void {
     if (this.#timeout === undefined) {
       return
@@ -27,7 +29,9 @@ export class DisposableTimeout implements Disposable {
     this.#timeout = undefined
   }
 
-  /** Clear the timeout on disposal, preventing leaked timers. */
+  /**
+   * Clear the timeout on disposal, preventing leaked timers.
+   */
   public [Symbol.dispose](): void {
     this.clear()
   }

--- a/src/resilience/rate-limit-gate.ts
+++ b/src/resilience/rate-limit-gate.ts
@@ -186,7 +186,9 @@ export class RateLimitGate {
       parseRetryAfter(retryAfter, now) ?? now.add(this.#fallback)
   }
 
-  /** Reset the gate immediately (testing or manual unblock). */
+  /**
+   * Reset the gate immediately (testing or manual unblock).
+   */
   public reset(): void {
     this.#pausedUntil = Temporal.Now.instant()
   }

--- a/src/resilience/retry-backoff.ts
+++ b/src/resilience/retry-backoff.ts
@@ -61,15 +61,25 @@ export const DEFAULT_TRANSIENT_RETRY_OPTIONS: Pick<
   maxRetries: 4,
 }
 
-/** Options for {@link withRetryBackoff}. */
+/**
+ * Options for {@link withRetryBackoff}.
+ */
 export interface RetryBackoffOptions {
-  /** Initial delay in milliseconds before the first retry. */
+  /**
+   * Initial delay in milliseconds before the first retry.
+   */
   readonly initialDelayMs: number
-  /** Jitter ratio applied to each computed delay (`0..1`). */
+  /**
+   * Jitter ratio applied to each computed delay (`0..1`).
+   */
   readonly jitterRatio: number
-  /** Upper bound on the backoff delay. */
+  /**
+   * Upper bound on the backoff delay.
+   */
   readonly maxDelayMs: number
-  /** Maximum retry attempts after the initial try (0 disables retries). */
+  /**
+   * Maximum retry attempts after the initial try (0 disables retries).
+   */
   readonly maxRetries: number
   /**
    * Optional abort signal. When fired during a backoff sleep, the
@@ -78,9 +88,13 @@ export interface RetryBackoffOptions {
    * delay before the next attempt would have started.
    */
   readonly signal?: AbortSignal | undefined
-  /** Predicate deciding whether a thrown error is worth retrying. */
+  /**
+   * Predicate deciding whether a thrown error is worth retrying.
+   */
   readonly isRetryable: (error: unknown) => boolean
-  /** Optional hook invoked before the next attempt. */
+  /**
+   * Optional hook invoked before the next attempt.
+   */
   readonly onRetry?: (attempt: number, error: unknown, delayMs: number) => void
 }
 

--- a/src/resilience/retry-guard.ts
+++ b/src/resilience/retry-guard.ts
@@ -25,7 +25,9 @@ export class RetryGuard implements Disposable {
     this.#delay = delayMs
   }
 
-  /** Cancel the current retry window on disposal, preventing leaked timers. */
+  /**
+   * Cancel the current retry window on disposal, preventing leaked timers.
+   */
   public [Symbol.dispose](): void {
     this.#timeout[Symbol.dispose]()
   }

--- a/src/resilience/transient-retry-policy.ts
+++ b/src/resilience/transient-retry-policy.ts
@@ -5,7 +5,9 @@ import {
   withRetryBackoff,
 } from './retry-backoff.ts'
 
-/** Callback surface for per-retry instrumentation. */
+/**
+ * Callback surface for per-retry instrumentation.
+ */
 export interface RetryTelemetry {
   readonly onRetry: (attempt: number, error: unknown, delayMs: number) => void
 }

--- a/src/time-units.ts
+++ b/src/time-units.ts
@@ -4,13 +4,21 @@
  * `MILLISECONDS_IN_SECOND` vs `MILLISECONDS_PER_SECOND`).
  */
 
-/** Number of milliseconds in one second. */
+/**
+ * Number of milliseconds in one second.
+ */
 export const MS_PER_SECOND = 1000
-/** Number of milliseconds in one minute. */
+/**
+ * Number of milliseconds in one minute.
+ */
 export const MS_PER_MINUTE = 60_000
-/** Number of milliseconds in one hour. */
+/**
+ * Number of milliseconds in one hour.
+ */
 export const MS_PER_HOUR = 3_600_000
-/** Number of milliseconds in one day. */
+/**
+ * Number of milliseconds in one day.
+ */
 export const MS_PER_DAY = 86_400_000
 
 const SESSION_REFRESH_AHEAD_MINUTES = 5

--- a/src/types/classic-generic.ts
+++ b/src/types/classic-generic.ts
@@ -23,7 +23,9 @@ import type {
 } from './classic-erv.ts'
 import type { ClassicBuildingID, ClassicDeviceID } from './ids.ts'
 
-/** Common shape shared by every Classic zone variant returned from the registry — id, hierarchy depth, display name. */
+/**
+ * Common shape shared by every Classic zone variant returned from the registry — id, hierarchy depth, display name.
+ */
 interface BaseZone {
   readonly id: number
   readonly level: number

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -101,7 +101,9 @@ export const isKeyOf =
   (key: PropertyKey): key is keyof T =>
     Object.hasOwn(record, key)
 
-/** Maps ATA set-command keys to their corresponding list-data keys. */
+/**
+ * Maps ATA set-command keys to their corresponding list-data keys.
+ */
 export const fromSetToListAta: {
   readonly SetFanSpeed: 'FanSpeed'
   readonly VaneHorizontal: 'VaneHorizontalDirection'
@@ -124,7 +126,9 @@ export const isSetDeviceDataAtaNotInList: (
   key: PropertyKey,
 ) => key is KeyOfClassicSetDeviceDataAtaNotInList = isKeyOf(fromSetToListAta)
 
-/** Maps ATA list-data keys to their corresponding set-command keys. */
+/**
+ * Maps ATA list-data keys to their corresponding set-command keys.
+ */
 export const fromListToSetAta: {
   readonly FanSpeed: 'SetFanSpeed'
   readonly VaneHorizontalDirection: 'VaneHorizontal'
@@ -276,9 +280,13 @@ const getChartLineSeries = ({
  * mutable locale state).
  */
 interface ChartLineFormatOptions {
-  /** Legend entries for each data series. */
+  /**
+   * Legend entries for each data series.
+   */
   readonly legend: readonly (string | undefined)[]
-  /** Unit of measurement for the data. */
+  /**
+   * Unit of measurement for the data.
+   */
   readonly unit: string
   /**
    * BCP-47 locale tag for day-of-week and month-name labels. Defaults

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -25,7 +25,9 @@ import { ValidationError } from '../errors/index.ts'
 // actually consumes fields from — the wire format carries many more
 // keys that the compile-time types already document.
 
-/** Classic /Login/ClientLogin3 response. */
+/**
+ * Classic /Login/ClientLogin3 response.
+ */
 export const ClassicLoginDataSchema: z.ZodType<ClassicLoginData> =
   z.looseObject({
     ErrorId: z.number().nullable().optional(),
@@ -38,13 +40,17 @@ export const ClassicLoginDataSchema: z.ZodType<ClassicLoginData> =
     LoginMinutes: z.number().nullable().optional(),
   })
 
-/** Home OIDC /connect/par response. */
+/**
+ * Home OIDC /connect/par response.
+ */
 export const HomeParResponseSchema: z.ZodType<{ request_uri: string }> =
   z.looseObject({
     request_uri: z.string().min(1),
   })
 
-/** Home OIDC /connect/token response. */
+/**
+ * Home OIDC /connect/token response.
+ */
 export const HomeTokenResponseSchema: z.ZodType<HomeTokenResponse> =
   z.looseObject({
     access_token: z.string().min(1),
@@ -192,7 +198,9 @@ const HomeBuildingSchema = z.looseObject({
   timezone: z.string(),
 })
 
-/** Home BFF /context response. */
+/**
+ * Home BFF /context response.
+ */
 export const HomeContextSchema: z.ZodType<HomeContext> = z.looseObject({
   buildings: z.array(HomeBuildingSchema),
   country: z.string(),
@@ -332,7 +340,9 @@ const HomeReportTriggerSchema = z.looseObject({
   value: z.number().nullable(),
 })
 
-/** Home /report/v1/{comfort-graph,internaltemperatures,trendsummary} response. */
+/**
+ * Home /report/v1/{comfort-graph,internaltemperatures,trendsummary} response.
+ */
 export const HomeReportDataSchema: z.ZodType<HomeReportData> = z.looseObject({
   annotations: z.array(HomeReportAnnotationSchema).optional(),
   datasets: z.array(HomeReportDatasetSchema),
@@ -344,7 +354,9 @@ export const HomeReportDataSchema: z.ZodType<HomeReportData> = z.looseObject({
   to: z.string().optional(),
 })
 
-/** Home /monitor/{ata,atw}unit/{id}/errorlog response (array of entries). */
+/**
+ * Home /monitor/{ata,atw}unit/{id}/errorlog response (array of entries).
+ */
 export const HomeErrorLogEntryListSchema: z.ZodType<HomeErrorLogEntry[]> =
   z.array(
     z.looseObject({
@@ -357,7 +369,9 @@ export const HomeErrorLogEntryListSchema: z.ZodType<HomeErrorLogEntry[]> =
 
 const MAX_HOUR = 23
 
-/** Integer hour of the day in 24-hour form (0 through 23). */
+/**
+ * Integer hour of the day in 24-hour form (0 through 23).
+ */
 export const HourSchema: z.ZodType<Hour> = z.custom<Hour>(
   (value) =>
     typeof value === 'number' &&
@@ -401,7 +415,9 @@ const ClassicBuildingStructureSchema = z.looseObject({
   Floors: z.array(ClassicFloorSchema),
 })
 
-/** Minimal shape the {@link ClassicBuildingListSchema} guarantees on success. */
+/**
+ * Minimal shape the {@link ClassicBuildingListSchema} guarantees on success.
+ */
 interface ClassicBuildingListEntry {
   readonly ID: number
   readonly Name: string
@@ -430,7 +446,9 @@ export const ClassicBuildingListSchema: z.ZodType<ClassicBuildingListEntry[]> =
 // ValidationError. `z.number()` already rejects NaN and ±Infinity, so
 // every validated field is guaranteed finite.
 
-/** Classic `EnergyCost/Report` bucket label type (numeric on this endpoint). */
+/**
+ * Classic `EnergyCost/Report` bucket label type (numeric on this endpoint).
+ */
 const ClassicLabelTypeSchema = z.union([
   z.literal(ClassicLabelType.time),
   z.literal(ClassicLabelType.raw),
@@ -439,7 +457,9 @@ const ClassicLabelTypeSchema = z.union([
   z.literal(ClassicLabelType.day_of_week),
 ])
 
-/** Classic `/EnergyCost/Report` response for an ATA (air-to-air) device. */
+/**
+ * Classic `/EnergyCost/Report` response for an ATA (air-to-air) device.
+ */
 export const ClassicEnergyDataAtaSchema: z.ZodType<ClassicEnergyDataAta> =
   z.looseObject({
     Auto: z.array(z.number()),

--- a/tests/contracts/holiday-mode-state.test.ts
+++ b/tests/contracts/holiday-mode-state.test.ts
@@ -21,7 +21,9 @@ import {
   homeTestRegistry,
 } from '../home-fixtures.ts'
 
-/** A window both dialects can carry: the wire's date fields are never null. */
+/**
+ * A window both dialects can carry: the wire's date fields are never null.
+ */
 interface BoundedWindow extends HolidayModeState {
   readonly endDate: string
   readonly startDate: string

--- a/tests/contracts/no-changes.test.ts
+++ b/tests/contracts/no-changes.test.ts
@@ -41,9 +41,13 @@ const CASES: readonly { readonly kind: NoOpKind; readonly label: string }[] = [
  * count belongs to that attempt alone.
  */
 interface Attempt {
-  /** How many times the write reached the wire. */
+  /**
+   * How many times the write reached the wire.
+   */
   readonly wireCalls: () => number
-  /** Performs the write. */
+  /**
+   * Performs the write.
+   */
   readonly write: () => Promise<unknown>
 }
 

--- a/tests/unit/base-api.test.ts
+++ b/tests/unit/base-api.test.ts
@@ -110,7 +110,9 @@ class TestAPI extends BaseAPI {
     this.tryReuseSessionMock.mockResolvedValue(false)
   }
 
-  /** Expose the protected dispatch for direct testing. */
+  /**
+   * Expose the protected dispatch for direct testing.
+   */
   public async callDispatch<T = unknown>(
     method: string,
     url: string,
@@ -119,12 +121,16 @@ class TestAPI extends BaseAPI {
     return this.dispatch<T>(method, url, config)
   }
 
-  /** Expose the protected ensureSession for direct testing. */
+  /**
+   * Expose the protected ensureSession for direct testing.
+   */
   public async callEnsureSession(): Promise<void> {
     return this.ensureSession()
   }
 
-  /** Expose the protected request for testing. */
+  /**
+   * Expose the protected request for testing.
+   */
   public async callRequest<T = unknown>(
     method: string,
     url: string,
@@ -133,7 +139,9 @@ class TestAPI extends BaseAPI {
     return this.request<T>(method, url, config)
   }
 
-  /** Expose the protected runSyncCycle for direct testing. */
+  /**
+   * Expose the protected runSyncCycle for direct testing.
+   */
   public async callRunSyncCycle<T>(work: () => Promise<T[]>): Promise<T[]> {
     return this.runSyncCycle(work)
   }


### PR DESCRIPTION
## What

`eslint-plugin-unicorn` `^72` → `^73`, with every new rule settled on **measured evidence** (v73 probed against the real sources before any verdict) — one PR per repo, same title.

| rule | preset | violations (family) | verdict |
|---|---|---|---|
| `single-line-block-comment-style` | auto-on | 326 | **adopted** — single-line JSDoc → canonical 3-line form |
| `no-unsafe-sqlite-interpolation` | auto-on | 0 | inert (no sqlite), free protection |
| `iteration-fallback-style` | opt-in | 0 | **adopted at error** — free guard, mutation-verified |
| `consistent-arrow-return-style` | opt-in | ~496 | **refused** — multiline implicit return is the house idiom |
| `no-barrel-files` | opt-in | 28 | **refused** — the barrels ARE the public API (`exports` map, publint-validated); the anti-barrel cost model targets bundled apps with deep transitive graphs, not a small Node-loaded library. Revisit if the library is ever bundled. |

## The autofix incident, and why the diff is script-made

`eslint --fix` for the comment rule **interacting with `multiline-comment-style: separate-lines`** produced two damage shapes instead of the approved preview: doc comments degraded to bare `//` triples (JSDoc semantics lost — typedoc, IDE hover), and expansions without the `*` prefix. Both were caught, reverted, and the expansion re-done by a **deterministic script**: `/** X */` → the canonical 3-line form.

**Purity proven**: the JSDoc diff touches **zero non-comment lines** (measured), and `npm run docs` (typedoc) passes on the rebuilt comments.

## Ledger movement (libraries)

- `no-this-outside-of-class` off **lifted**: v73 allows explicit TypeScript `this` parameters — exactly the decorator-protocol reason the entry documented. Zero violations with the rule live; a genuine violation (undeclared `this`) fires. One documented disable less.
- `no-nonstandard-builtin-properties` off **stays**: still flags `Symbol.dispose` (17+13 sites), the documented reason remains true.

## Checklist

- [x] `npm run format` / `lint` / `typecheck` pass
- [x] `npm run test:coverage` passes (100%)
- [x] apps: `homey:validate` at publish level · libs: `lint:package` + `docs` pass
