### PR TITLE
build(deps): bump temporal-polyfill to 1.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "45.1.0",
       "license": "MIT",
       "dependencies": {
-        "temporal-polyfill": "^1.0.1",
+        "temporal-polyfill": "^1.0.3",
         "tough-cookie": "^6.0.2",
         "undici": "^8.9.0",
         "zod": "^4.4.3"
@@ -5648,19 +5648,19 @@
       }
     },
     "node_modules/temporal-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.1.tgz",
-      "integrity": "sha512-N2SoI9olnW7BUsU8RosDphZQl9s+WJ8O7PoJMFCr/e5/1rFkVI4GNOWaSeySG+UoP04foPYsnLWbJmbXOiShZg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.3.tgz",
+      "integrity": "sha512-U8vuzZBc+dfMIfl8wXWcedfI7AJCxJjjVBIRpJUvIz5+UAp555UJDHguKsfZqHWaHRSdVUThm7mqqIWhN/xPBQ==",
       "license": "MIT",
       "dependencies": {
-        "temporal-spec": "1.0.0",
+        "temporal-spec": "1.0.1",
         "temporal-utils": "1.0.1"
       }
     },
     "node_modules/temporal-spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-1.0.0.tgz",
-      "integrity": "sha512-00Ahj1e1ifaERTMOIIGpOCdOo9IEk2m6GGSMedsn9a2SIsGLdOTbmME1Htv6IM82b6VHrzSUTIVc7YHy6hdhFQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-1.0.1.tgz",
+      "integrity": "sha512-wxVoanmDeavXie1vu2JaQ3WIc3JZnWAOYFBsJyATaVsXsycKYUflGsyBmrRSnoCpZJpwPyr38VpgSUlQ8CbFxg==",
       "license": "Apache-2.0"
     },
     "node_modules/temporal-utils": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "typecheck": "node ./node_modules/@typescript/native/bin/tsc --noEmit"
   },
   "dependencies": {
-    "temporal-polyfill": "^1.0.1",
+    "temporal-polyfill": "^1.0.3",
     "tough-cookie": "^6.0.2",
     "undici": "^8.9.0",
     "zod": "^4.4.3"

--- a/src/temporal.ts
+++ b/src/temporal.ts
@@ -15,22 +15,5 @@
 // Re-exporting via `export { ... }` preserves both the value and the
 // type namespace, so consumers can write `Temporal.Instant.from(...)`
 // and `function f(x: Temporal.Instant)` from a single import.
-// `temporal-polyfill` exports the Temporal-aware `Intl` VALUE at
-// runtime, but `temporal-spec` only declares the namespace's types —
-// merge the missing constructor declaration so the value import
-// type-checks. Drop this augmentation once upstream types the export.
-declare module 'temporal-spec' {
-  // eslint-disable-next-line @typescript-eslint/no-namespace -- namespace merging is the only way to add the missing value declaration to temporal-spec's type-only `Intl` namespace
-  namespace Intl {
-    const DateTimeFormat: Pick<
-      typeof globalThis.Intl.DateTimeFormat,
-      'supportedLocalesOf'
-    > &
-      (new (
-        locales?: string | string[],
-        options?: globalThis.Intl.DateTimeFormatOptions,
-      ) => DateTimeFormat)
-  }
-}
 
 export { Intl, Temporal } from 'temporal-polyfill'


### PR DESCRIPTION
temporal-polyfill 1.0.2 types its `Intl` export ("Intl export runtime value", fullcalendar/temporal-polyfill#97): `temporal-spec` now declares the `Intl.DateTimeFormat` value with construct and call signatures plus the statics — verified empirically against the installed package. That is a superset of the hand augmentation in `src/temporal.ts`, which now collides (TS2451), so the augmentation goes — it carried its own drop condition ("Drop this augmentation once upstream types the export") and takes an eslint-disable with it.

Bumped proactively rather than waiting for Dependabot: its grouped bump would have failed CI on the collision, exactly as heatzy-api's OlivierZal/heatzy-api#1169 did (fixed there the same way). Full suite green: format/lint/typecheck/coverage/lint:package/docs all 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3
