### PR TITLE
docs: align the README with its family and pin docs currency in doctrine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,13 @@ is on: no runtime enums, no parameter properties, no runtime namespaces.
 
 ## Repo process
 
+- Companion docs are part of a change's definition of done: a PR that
+  changes behavior, surface, requirements or process updates the
+  affected companion files (README.md, CONTRIBUTING.md, SECURITY.md,
+  CLAUDE.md) in the same PR, never in a later sweep — the 2026-08
+  README audit caught exactly the drift this prevents (a shipped Home
+  ATW driver absent from its README, a stale `Result` kind list).
+
 - The PR title IS the commit that lands: `squash_merge_commit_title` is
   `PR_TITLE`, so the title is the single source (under the former
   `COMMIT_OR_PR_TITLE`, a one-commit PR silently took its commit subject

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A typed Node.js client for the [MELCloud](https://app.melcloud.com/) and [MELClo
 
 [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=OlivierZal_melcloud-api&metric=alert_status)](https://sonarcloud.io/dashboard?id=OlivierZal_melcloud-api)
 [![Test coverage](https://sonarcloud.io/api/project_badges/measure?project=OlivierZal_melcloud-api&metric=coverage)](https://sonarcloud.io/component_measures?id=OlivierZal_melcloud-api&metric=coverage)
-[![Docs coverage](https://olivierzal.github.io/melcloud-api/coverage.svg?v=2)](https://olivierzal.github.io/melcloud-api/)
+[![Docs coverage](https://olivierzal.github.io/melcloud-api/coverage.svg)](https://olivierzal.github.io/melcloud-api/)
 
 ## Features
 
@@ -18,6 +18,7 @@ A typed Node.js client for the [MELCloud](https://app.melcloud.com/) and [MELClo
 - **Two APIs, one client** — Classic and Home behind consistent ergonomics; pick what your account uses.
 - **Ata / Atw / Erv support** — air conditioners, heat pumps with hot water, and energy-recovery ventilation units.
 - **Resilient by default** — auto-retry on transient failures, rate-limit awareness, pre-emptive session refresh.
+- **Validated boundaries** — Zod schemas guard every consumed payload, so upstream shape drift surfaces as a typed `ValidationError` instead of a deep `undefined` crash.
 - **Typed failures** — telemetry, reports and error-log getters return `Result<T>` so callers branch on `network` / `unauthorized` / `rate-limited` / `validation` / `server` / `not-found` instead of catching generic exceptions.
 - **Tree-shakable** — `sideEffects: false` plus `/classic`, `/home` and `/constants` subpath exports for namespace-style imports.
 


### PR DESCRIPTION
Family-alignment audit of the five READMEs, by repo nature (API lib vs Homey app), plus the docs-currency doctrine rule. Per repo: melcloud-api gains the `Validated boundaries` feature bullet its heatzy-api twin already had (zod guards its payloads too — `src/validation/schemas.ts`) and the docs badge loses its stale `?v=2`; com.melcloud gains the API-layer architecture bullet com.heatzy already had; the extension gains its nature's equivalent (wire-level dependency, app id `com.mecloud`); and all five doctrines now state that companion docs (README, CONTRIBUTING, SECURITY, CLAUDE.md) are updated in the same PR as the change they describe — the 2026-08 README audit caught exactly the drift this prevents. Remaining cross-family differences are deliberate and code-backed (Error handling and Imports sections only where `Result` and subpath exports exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3
