### PR TITLE
docs: sharpen the docs-currency sentence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,12 +167,12 @@ is on: no runtime enums, no parameter properties, no runtime namespaces.
 
 ## Repo process
 
-- Companion docs are part of a change's definition of done: a PR that
-  changes behavior, API surface, requirements or process must update
-  the affected companion files (README.md, CONTRIBUTING.md,
-  SECURITY.md, CLAUDE.md) in the same PR, never in a later sweep — the 2026-08
-  README audit caught exactly the drift this prevents (a shipped Home
-  ATW driver absent from its README, a stale `Result` kind list).
+- Companion docs are part of a change's definition of done: whenever a
+  PR changes behavior, API surface, requirements or process, the same
+  PR updates the affected companion files (README.md, CONTRIBUTING.md,
+  SECURITY.md, CLAUDE.md) — never a later sweep; the 2026-08 README
+  audit caught exactly the drift this prevents (a shipped Home ATW
+  driver absent from its README, a stale `Result` kind list).
 
 - The PR title IS the commit that lands: `squash_merge_commit_title` is
   `PR_TITLE`, so the title is the single source (under the former

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,9 +168,9 @@ is on: no runtime enums, no parameter properties, no runtime namespaces.
 ## Repo process
 
 - Companion docs are part of a change's definition of done: a PR that
-  changes behavior, surface, requirements or process updates the
-  affected companion files (README.md, CONTRIBUTING.md, SECURITY.md,
-  CLAUDE.md) in the same PR, never in a later sweep — the 2026-08
+  changes behavior, API surface, requirements or process must update
+  the affected companion files (README.md, CONTRIBUTING.md,
+  SECURITY.md, CLAUDE.md) in the same PR, never in a later sweep — the 2026-08
   README audit caught exactly the drift this prevents (a shipped Home
   ATW driver absent from its README, a stale `Result` kind list).
 


### PR DESCRIPTION
Follow-up to the family-alignment wave: the docs-currency sentence read "…or process updates the affected companion files", where "process updates" parses as a noun phrase (raised by Copilot on OlivierZal/heatzy-api#1175). Reworded to "must update" with "API surface" spelled out — the same fix lands on the two still-open sibling PRs, keeping the five doctrines aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3
