### PR TITLE
style: collapse unnecessary object line breaks

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -101,34 +101,22 @@ const config: Config[] = defineConfig([
         warnOnUnsupportedTypeScriptVersion: false,
       },
     },
-    plugins: {
-      '@stylistic': stylistic,
-      perfectionist,
-    },
+    plugins: { '@stylistic': stylistic, perfectionist },
     rules: {
       '@stylistic/multiline-comment-style': [
         'error',
         'separate-lines',
-        {
-          checkExclamation: true,
-        },
+        { checkExclamation: true },
       ],
       '@stylistic/quotes': [
         'error',
         'single',
-        {
-          allowTemplateLiterals: 'never',
-          avoidEscape: true,
-        },
+        { allowTemplateLiterals: 'never', avoidEscape: true },
       ],
       '@stylistic/spaced-comment': [
         'error',
         'always',
-        {
-          block: {
-            balanced: true,
-          },
-        },
+        { block: { balanced: true } },
       ],
       '@typescript-eslint/class-methods-use-this': 'error',
       '@typescript-eslint/consistent-type-assertions': [
@@ -141,15 +129,11 @@ const config: Config[] = defineConfig([
       ],
       '@typescript-eslint/consistent-type-exports': [
         'error',
-        {
-          fixMixedExportsWithInlineTypeSpecifier: true,
-        },
+        { fixMixedExportsWithInlineTypeSpecifier: true },
       ],
       '@typescript-eslint/consistent-type-imports': [
         'error',
-        {
-          fixStyle: 'inline-type-imports',
-        },
+        { fixStyle: 'inline-type-imports' },
       ],
       '@typescript-eslint/default-param-last': 'error',
       '@typescript-eslint/explicit-function-return-type': 'error',
@@ -173,11 +157,7 @@ const config: Config[] = defineConfig([
           selector: 'variable',
         },
         // Destructured — we don't control external shapes (API responses, libs).
-        {
-          format: null,
-          modifiers: ['destructured'],
-          selector: 'variable',
-        },
+        { format: null, modifiers: ['destructured'], selector: 'variable' },
         // ── Booleans (variables, parameters, class properties) ──
         // Semantic prefixes make intent obvious at the call site.
         // `device` is excluded: its type includes `false` as a sentinel but it is not a boolean flag.
@@ -248,29 +228,14 @@ const config: Config[] = defineConfig([
           selector: 'classProperty',
         },
         // ── Imports ──────────────────────────────────────────
-        {
-          format: ['camelCase', 'PascalCase'],
-          selector: 'import',
-        },
+        { format: ['camelCase', 'PascalCase'], selector: 'import' },
         // ── Types, interfaces, classes, enums ────────────────
-        {
-          format: ['PascalCase'],
-          selector: 'typeLike',
-        },
+        { format: ['PascalCase'], selector: 'typeLike' },
         // ── Type parameters (generics) ───────────────────────
         // T-prefix: T, TKey, TValue, TResult — universal TS convention.
-        {
-          format: ['PascalCase'],
-          prefix: ['T'],
-          selector: 'typeParameter',
-        },
+        { format: ['PascalCase'], prefix: ['T'], selector: 'typeParameter' },
       ],
-      '@typescript-eslint/no-base-to-string': [
-        'error',
-        {
-          checkUnknown: true,
-        },
-      ],
+      '@typescript-eslint/no-base-to-string': ['error', { checkUnknown: true }],
       '@typescript-eslint/no-floating-promises': [
         'error',
         {
@@ -303,47 +268,30 @@ const config: Config[] = defineConfig([
       ],
       '@typescript-eslint/no-unnecessary-condition': [
         'error',
-        {
-          checkTypePredicates: true,
-        },
+        { checkTypePredicates: true },
       ],
       '@typescript-eslint/no-unnecessary-type-assertion': [
         'error',
-        {
-          checkLiteralConstAssertions: true,
-        },
+        { checkLiteralConstAssertions: true },
       ],
       '@typescript-eslint/no-unsafe-type-assertion': 'error',
       '@typescript-eslint/no-unused-private-class-members': 'error',
       '@typescript-eslint/no-unused-vars': [
         'error',
-        {
-          enableAutofixRemoval: {
-            imports: true,
-          },
-        },
+        { enableAutofixRemoval: { imports: true } },
       ],
       '@typescript-eslint/no-useless-empty-export': 'error',
       '@typescript-eslint/only-throw-error': [
         'error',
-        {
-          allowThrowingAny: false,
-          allowThrowingUnknown: false,
-        },
+        { allowThrowingAny: false, allowThrowingUnknown: false },
       ],
       // Assignment and renamed-property enforcement breeds unreadable
       // destructuring.
       '@typescript-eslint/prefer-destructuring': [
         'error',
         {
-          AssignmentExpression: {
-            array: false,
-            object: false,
-          },
-          VariableDeclarator: {
-            array: true,
-            object: true,
-          },
+          AssignmentExpression: { array: false, object: false },
+          VariableDeclarator: { array: true, object: true },
         },
         {
           enforceForDeclarationWithTypeAnnotation: true,
@@ -369,11 +317,7 @@ const config: Config[] = defineConfig([
       '@typescript-eslint/return-await': ['error', 'in-try-catch'],
       '@typescript-eslint/strict-boolean-expressions': [
         'error',
-        {
-          allowNullableObject: false,
-          allowNumber: false,
-          allowString: false,
-        },
+        { allowNullableObject: false, allowNumber: false, allowString: false },
       ],
       '@typescript-eslint/strict-void-return': 'error',
       '@typescript-eslint/switch-exhaustiveness-check': [
@@ -385,20 +329,10 @@ const config: Config[] = defineConfig([
         },
       ],
       'accessor-pairs': 'error',
-      'array-callback-return': [
-        'error',
-        {
-          checkForEach: true,
-        },
-      ],
+      'array-callback-return': ['error', { checkForEach: true }],
       'arrow-body-style': 'error',
       // Measured codebase ceiling.
-      complexity: [
-        'error',
-        {
-          max: 10,
-        },
-      ],
+      complexity: ['error', { max: 10 }],
       curly: 'error',
       'default-case-last': 'error',
       eqeqeq: 'error',
@@ -410,24 +344,12 @@ const config: Config[] = defineConfig([
       'import-x/no-absolute-path': 'error',
       'import-x/no-anonymous-default-export': [
         'error',
-        {
-          allowCallExpression: false,
-        },
+        { allowCallExpression: false },
       ],
       'import-x/no-cycle': 'error',
       'import-x/no-default-export': 'error',
-      'import-x/no-duplicates': [
-        'error',
-        {
-          'prefer-inline': true,
-        },
-      ],
-      'import-x/no-dynamic-require': [
-        'error',
-        {
-          esmodule: true,
-        },
-      ],
+      'import-x/no-duplicates': ['error', { 'prefer-inline': true }],
+      'import-x/no-dynamic-require': ['error', { esmodule: true }],
       'import-x/no-empty-named-blocks': 'error',
       'import-x/no-extraneous-dependencies': [
         'error',
@@ -448,12 +370,7 @@ const config: Config[] = defineConfig([
       'import-x/no-relative-packages': 'error',
       'import-x/no-self-import': 'error',
       'import-x/no-unassigned-import': 'error',
-      'import-x/no-unresolved': [
-        'error',
-        {
-          caseSensitiveStrict: true,
-        },
-      ],
+      'import-x/no-unresolved': ['error', { caseSensitiveStrict: true }],
       'import-x/no-unused-modules': [
         'error',
         {
@@ -467,12 +384,7 @@ const config: Config[] = defineConfig([
       'import-x/unambiguous': 'error',
       'max-classes-per-file': 'error',
       // Measured codebase ceiling.
-      'max-depth': [
-        'error',
-        {
-          max: 3,
-        },
-      ],
+      'max-depth': ['error', { max: 3 }],
       'max-lines-per-function': 'error',
       'max-statements': 'error',
       'no-await-in-loop': 'error',
@@ -483,26 +395,11 @@ const config: Config[] = defineConfig([
       'no-eval': 'error',
       'no-extend-native': 'error',
       'no-extra-bind': 'error',
-      'no-extra-boolean-cast': [
-        'error',
-        {
-          enforceForInnerExpressions: true,
-        },
-      ],
-      'no-fallthrough': [
-        'error',
-        {
-          reportUnusedFallthroughComment: true,
-        },
-      ],
+      'no-extra-boolean-cast': ['error', { enforceForInnerExpressions: true }],
+      'no-fallthrough': ['error', { reportUnusedFallthroughComment: true }],
       'no-implicit-coercion': 'error',
       'no-inline-comments': 'error',
-      'no-irregular-whitespace': [
-        'error',
-        {
-          skipStrings: false,
-        },
-      ],
+      'no-irregular-whitespace': ['error', { skipStrings: false }],
       'no-labels': 'error',
       'no-lone-blocks': 'error',
       'no-lonely-if': 'error',
@@ -527,12 +424,7 @@ const config: Config[] = defineConfig([
       ],
       'no-return-assign': ['error', 'always'],
       'no-self-compare': 'error',
-      'no-sequences': [
-        'error',
-        {
-          allowInParentheses: false,
-        },
-      ],
+      'no-sequences': ['error', { allowInParentheses: false }],
       'no-template-curly-in-string': 'error',
       'no-unmodified-loop-condition': 'error',
       'no-unneeded-ternary': 'error',
@@ -636,24 +528,16 @@ const config: Config[] = defineConfig([
             // Side-effect imports carry no specifiers, so only the bare
             // selectors can match them.
             'side-effect',
-            {
-              newlinesBetween: 1,
-            },
+            { newlinesBetween: 1 },
             'side-effect-style',
             ...buildImportGroup('style'),
-            {
-              newlinesBetween: 1,
-            },
+            { newlinesBetween: 1 },
             ...buildImportGroup('builtin'),
-            {
-              newlinesBetween: 1,
-            },
+            { newlinesBetween: 1 },
             ...buildImportGroup('external'),
             ...buildImportGroup('subpath'),
             ...buildImportGroup('internal'),
-            {
-              newlinesBetween: 1,
-            },
+            { newlinesBetween: 1 },
             ...buildImportGroup('parent'),
             ...buildImportGroup('sibling'),
             ...buildImportGroup('index'),
@@ -689,23 +573,16 @@ const config: Config[] = defineConfig([
       ],
       'perfectionist/sort-named-exports': [
         'error',
-        {
-          groups: ['type-export', 'value-export'],
-        },
+        { groups: ['type-export', 'value-export'] },
       ],
       'perfectionist/sort-named-imports': [
         'error',
-        {
-          groups: ['type-import', 'value-import'],
-        },
+        { groups: ['type-import', 'value-import'] },
       ],
       'perfectionist/sort-object-types': ['error', typeLikeSortOptions],
       'perfectionist/sort-objects': [
         'error',
-        {
-          groups: ['property', 'method'],
-          partitionByComputedKey: true,
-        },
+        { groups: ['property', 'method'], partitionByComputedKey: true },
       ],
       'perfectionist/sort-sets': 'error',
       'perfectionist/sort-switch-case': 'error',
@@ -716,20 +593,10 @@ const config: Config[] = defineConfig([
       'prefer-numeric-literals': 'error',
       'prefer-object-has-own': 'error',
       'prefer-object-spread': 'error',
-      'prefer-regex-literals': [
-        'error',
-        {
-          disallowRedundantWrapping: true,
-        },
-      ],
+      'prefer-regex-literals': ['error', { disallowRedundantWrapping: true }],
       'prefer-template': 'error',
       'require-atomic-updates': 'error',
-      'require-unicode-regexp': [
-        'error',
-        {
-          requireFlag: 'v',
-        },
-      ],
+      'require-unicode-regexp': ['error', { requireFlag: 'v' }],
       'symbol-description': 'error',
       'unicode-bom': 'error',
       // Config-driven comment vocabulary with no invariant to encode.
@@ -742,9 +609,7 @@ const config: Config[] = defineConfig([
       'unicorn/consistent-destructuring': 'error',
       'unicorn/consistent-function-style': [
         'error',
-        {
-          default: 'arrow-function',
-        },
+        { default: 'arrow-function' },
       ],
       'unicorn/custom-error-definition': 'error',
       // Owned by `@typescript-eslint/naming-convention`.
@@ -790,20 +655,10 @@ const config: Config[] = defineConfig([
       'unicorn/prefer-iterator-concat': 'off',
       // Stricter than the v72 default: varying-base member accesses stay
       // reported so the shared shape is factored out.
-      'unicorn/prefer-minimal-ternary': [
-        'error',
-        {
-          checkVaryingBase: true,
-        },
-      ],
+      'unicorn/prefer-minimal-ternary': ['error', { checkVaryingBase: true }],
       // Stricter than the v72 default (see
       // `prefer-global-number-constants` above).
-      'unicorn/prefer-number-properties': [
-        'error',
-        {
-          checkNaN: true,
-        },
-      ],
+      'unicorn/prefer-number-properties': ['error', { checkNaN: true }],
       // Requires Node.js 24 (`RegExp.escape`).
       'unicorn/prefer-regexp-escape': 'off',
       'unicorn/prefer-short-arrow-method': 'error',
@@ -815,18 +670,8 @@ const config: Config[] = defineConfig([
       // Config-driven string vocabulary with no invariant to encode.
       'unicorn/string-content': 'off',
       'unicorn/try-complexity': 'error',
-      'use-isnan': [
-        'error',
-        {
-          enforceForIndexOf: true,
-        },
-      ],
-      'valid-typeof': [
-        'error',
-        {
-          requireStringLiterals: true,
-        },
-      ],
+      'use-isnan': ['error', { enforceForIndexOf: true }],
+      'valid-typeof': ['error', { requireStringLiterals: true }],
       yoda: 'error',
     },
     settings: {
@@ -851,12 +696,7 @@ const config: Config[] = defineConfig([
     rules: {
       // Config loaders (eslint, vitest, prettier) consume default exports.
       'import-x/no-default-export': 'off',
-      'import-x/prefer-default-export': [
-        'error',
-        {
-          target: 'any',
-        },
-      ],
+      'import-x/prefer-default-export': ['error', { target: 'any' }],
     },
   },
   {
@@ -868,10 +708,7 @@ const config: Config[] = defineConfig([
       'json/sort-keys': [
         'error',
         'asc',
-        {
-          caseSensitive: true,
-          natural: true,
-        },
+        { caseSensitive: true, natural: true },
       ],
       'json/top-level-interop': 'error',
     },
@@ -880,9 +717,7 @@ const config: Config[] = defineConfig([
     extends: [markdown.configs.recommended],
     files: ['**/*.md'],
     language: 'markdown/gfm',
-    plugins: {
-      unicorn,
-    },
+    plugins: { unicorn },
     rules: {
       'markdown/fenced-code-meta': 'error',
       'markdown/no-bare-urls': 'error',
@@ -890,9 +725,7 @@ const config: Config[] = defineConfig([
       'markdown/no-html': 'error',
       'markdown/no-missing-atx-heading-space': [
         'error',
-        {
-          checkClosedHeadings: true,
-        },
+        { checkClosedHeadings: true },
       ],
       'markdown/no-missing-label-refs': [
         'error',
@@ -902,23 +735,10 @@ const config: Config[] = defineConfig([
       ],
       'markdown/no-missing-link-fragments': [
         'error',
-        {
-          allowPattern: '',
-          ignoreCase: false,
-        },
+        { allowPattern: '', ignoreCase: false },
       ],
-      'markdown/no-space-in-emphasis': [
-        'error',
-        {
-          checkStrikethrough: true,
-        },
-      ],
-      'markdown/table-column-count': [
-        'error',
-        {
-          checkMissingCells: true,
-        },
-      ],
+      'markdown/no-space-in-emphasis': ['error', { checkStrikethrough: true }],
+      'markdown/table-column-count': ['error', { checkMissingCells: true }],
       'unicorn/expiring-todo-comments': 'error',
       'unicorn/no-empty-file': 'error',
       'unicorn/no-missing-local-resource': 'error',
@@ -927,12 +747,7 @@ const config: Config[] = defineConfig([
   {
     files: ['CHANGELOG.md'],
     rules: {
-      'markdown/no-duplicate-headings': [
-        'error',
-        {
-          checkSiblingsOnly: true,
-        },
-      ],
+      'markdown/no-duplicate-headings': ['error', { checkSiblingsOnly: true }],
     },
   },
   {
@@ -944,9 +759,7 @@ const config: Config[] = defineConfig([
         'error',
         {
           argsIgnorePattern: '^_context$',
-          enableAutofixRemoval: {
-            imports: true,
-          },
+          enableAutofixRemoval: { imports: true },
         },
       ],
       // The replacement methods must be `function` expressions: the
@@ -961,9 +774,7 @@ const config: Config[] = defineConfig([
     // `ignoreNumericLiteralTypes` does not cover literal types nested
     // inside object type annotations (typescript-eslint rule limitation).
     files: ['src/facades/classic-flags.ts'],
-    rules: {
-      '@typescript-eslint/no-magic-numbers': 'off',
-    },
+    rules: { '@typescript-eslint/no-magic-numbers': 'off' },
   },
   {
     files: ['src/temporal.ts'],
@@ -984,10 +795,7 @@ const config: Config[] = defineConfig([
       // module import by design.
       '@typescript-eslint/no-shadow': [
         'error',
-        {
-          allow: ['expect', 'Intl', 'Temporal'],
-          builtinGlobals: true,
-        },
+        { allow: ['expect', 'Intl', 'Temporal'], builtinGlobals: true },
       ],
       // Owned by `vitest/unbound-method`, the mock-aware port.
       '@typescript-eslint/unbound-method': 'off',
@@ -996,37 +804,17 @@ const config: Config[] = defineConfig([
       'max-lines-per-function': 'off',
       'max-statements': 'off',
       // Mock builders nest factories.
-      'unicorn/max-nested-calls': [
-        'error',
-        {
-          max: 4,
-        },
-      ],
+      'unicorn/max-nested-calls': ['error', { max: 4 }],
       // Without options the rule is a no-op; the suite uses `.each` exclusively.
       'vitest/consistent-each-for': [
         'error',
-        {
-          describe: 'each',
-          it: 'each',
-          suite: 'each',
-          test: 'each',
-        },
+        { describe: 'each', it: 'each', suite: 'each', test: 'each' },
       ],
       'vitest/consistent-test-filename': 'error',
-      'vitest/consistent-test-it': [
-        'error',
-        {
-          fn: 'it',
-        },
-      ],
+      'vitest/consistent-test-it': ['error', { fn: 'it' }],
       'vitest/consistent-vitest-vi': 'error',
       'vitest/hoisted-apis-on-top': 'error',
-      'vitest/max-nested-describe': [
-        'error',
-        {
-          max: 3,
-        },
-      ],
+      'vitest/max-nested-describe': ['error', { max: 3 }],
       'vitest/no-alias-methods': 'error',
       'vitest/no-conditional-in-test': 'error',
       'vitest/no-conditional-tests': 'error',
@@ -1071,20 +859,14 @@ const config: Config[] = defineConfig([
       'vitest/require-awaited-expect-poll': 'error',
       'vitest/require-mock-type-parameters': [
         'error',
-        {
-          checkImportFunctions: true,
-        },
+        { checkImportFunctions: true },
       ],
       'vitest/require-to-throw-message': 'error',
       'vitest/require-top-level-describe': 'error',
       'vitest/unbound-method': 'error',
       'vitest/warn-todo': 'error',
     },
-    settings: {
-      vitest: {
-        typecheck: true,
-      },
-    },
+    settings: { vitest: { typecheck: true } },
   },
   {
     // Scoped: without `files`, this block applied to every file and
@@ -1092,12 +874,7 @@ const config: Config[] = defineConfig([
     extends: [ymlConfigs.standard, ymlConfigs.prettier],
     files: ['**/*.{yaml,yml}'],
     rules: {
-      'yml/file-extension': [
-        'error',
-        {
-          extension: 'yml',
-        },
-      ],
+      'yml/file-extension': ['error', { extension: 'yml' }],
       'yml/key-name-casing': [
         'error',
         {
@@ -1111,11 +888,7 @@ const config: Config[] = defineConfig([
       'yml/sort-keys': [
         'error',
         {
-          order: {
-            caseSensitive: true,
-            natural: true,
-            type: 'asc',
-          },
+          order: { caseSensitive: true, natural: true, type: 'asc' },
           pathPattern: String.raw`^(?!jobs\.\w+\.steps\[\d+\]).*$`,
         },
         {
@@ -1138,11 +911,7 @@ const config: Config[] = defineConfig([
       'yml/sort-sequence-values': [
         'error',
         {
-          order: {
-            caseSensitive: true,
-            natural: true,
-            type: 'asc',
-          },
+          order: { caseSensitive: true, natural: true, type: 'asc' },
           pathPattern: '^.*$',
         },
       ],

--- a/prettier.config.ts
+++ b/prettier.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from 'prettier'
 
 const config: Config = {
+  objectWrap: 'collapse',
   plugins: ['prettier-plugin-packagejson'],
   semi: false,
   singleQuote: true,

--- a/src/api/classic.ts
+++ b/src/api/classic.ts
@@ -546,9 +546,7 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
   }: {
     postData: ClassicHolidayModePostData
   }): Promise<ClassicFailureData | ClassicSuccessData> {
-    return this.requestData('post', '/HolidayMode/Update', {
-      data: postData,
-    })
+    return this.requestData('post', '/HolidayMode/Update', { data: postData })
   }
 
   /**

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -337,9 +337,7 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
   public async updateOverheatProtection(
     postData: HomeOverheatProtectionPostData,
   ): Promise<void> {
-    await this.requestData('post', OVERHEAT_PROTECTION_PATH, {
-      data: postData,
-    })
+    await this.requestData('post', OVERHEAT_PROTECTION_PATH, { data: postData })
   }
 
   /**
@@ -550,9 +548,7 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
   }: LoginCredentials): Promise<void> {
     const request = {
       credentials: { password, username },
-      ...(this.abortSignal !== undefined && {
-        abortSignal: this.abortSignal,
-      }),
+      ...(this.abortSignal !== undefined && { abortSignal: this.abortSignal }),
     }
     try {
       await this.#exchangeAndStoreTokens(request)

--- a/src/api/token-auth.ts
+++ b/src/api/token-auth.ts
@@ -31,10 +31,7 @@ const REDIRECT_STATUS_MAX = 400
  * Options for {@link authRequest}.
  */
 interface AuthRequestOptions {
-  config: {
-    headers: Record<string, string>
-    data?: string
-  }
+  config: { headers: Record<string, string>; data?: string }
   jar: CookieJar
   method: string
   url: string

--- a/src/decorators/classic-update-devices.ts
+++ b/src/decorators/classic-update-devices.ts
@@ -47,10 +47,7 @@ export const classicUpdateDevices =
   ({
     kind = 'payload',
     type,
-  }: {
-    kind?: UpdatePatchKind
-    type?: ClassicDeviceType
-  } = {}) =>
+  }: { kind?: UpdatePatchKind; type?: ClassicDeviceType } = {}) =>
   <TArgs extends readonly unknown[]>(
     target: (...args: TArgs) => Promise<void>,
     _context: ClassMethodDecoratorContext,

--- a/src/entities/classic-registry.ts
+++ b/src/entities/classic-registry.ts
@@ -78,12 +78,7 @@ const syncDeviceModel = (
 const createDeviceModel = (device: ClassicListDeviceAny): ClassicDeviceAny =>
   new ClassicDevice(device)
 
-const level = {
-  building: 0,
-  child: 1,
-  grandchild: 2,
-  great_grandchild: 3,
-}
+const level = { building: 0, child: 1, grandchild: 2, great_grandchild: 3 }
 
 const stampDevices = function* (
   devices: readonly ClassicDeviceZone[],

--- a/src/facades/classic-area.ts
+++ b/src/facades/classic-area.ts
@@ -21,9 +21,7 @@ export class ClassicAreaFacade extends BaseZoneFacade<ClassicArea> {
 
   protected readonly tableName = 'ClassicArea'
 
-  protected get model(): {
-    getById: (id: number) => ClassicArea | undefined
-  } {
+  protected get model(): { getById: (id: number) => ClassicArea | undefined } {
     return this.registry.areas
   }
 }

--- a/src/facades/classic-base-device.ts
+++ b/src/facades/classic-base-device.ts
@@ -344,9 +344,7 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
   public async getEnergy(
     query?: ReportQuery,
   ): Promise<Result<ClassicEnergyData<T>>> {
-    return this.api.getEnergy<T>({
-      postData: this.#buildReportPostData(query),
-    })
+    return this.api.getEnergy<T>({ postData: this.#buildReportPostData(query) })
   }
 
   public async getEnergyReport(

--- a/src/facades/classic-base.ts
+++ b/src/facades/classic-base.ts
@@ -132,9 +132,7 @@ export abstract class ClassicBaseFacade<
 
   protected abstract readonly holidayModeLocation: keyof ClassicHolidayModeLocation
 
-  protected abstract readonly model: {
-    getById: (id: number) => T | undefined
-  }
+  protected abstract readonly model: { getById: (id: number) => T | undefined }
 
   protected abstract readonly tableName: ClassicSettingsParams['tableName']
 
@@ -469,9 +467,6 @@ export abstract class ClassicBaseFacade<
   }
 
   async #getZoneHolidayMode(): Promise<Result<ClassicHolidayModeData>> {
-    return this.#getBaseHolidayMode({
-      id: this.id,
-      tableName: this.tableName,
-    })
+    return this.#getBaseHolidayMode({ id: this.id, tableName: this.tableName })
   }
 }

--- a/src/facades/classic-floor.ts
+++ b/src/facades/classic-floor.ts
@@ -21,9 +21,7 @@ export class ClassicFloorFacade extends BaseZoneFacade<ClassicFloor> {
 
   protected readonly tableName = 'ClassicFloor'
 
-  protected get model(): {
-    getById: (id: number) => ClassicFloor | undefined
-  } {
+  protected get model(): { getById: (id: number) => ClassicFloor | undefined } {
     return this.registry.floors
   }
 }

--- a/src/facades/home-report.ts
+++ b/src/facades/home-report.ts
@@ -122,11 +122,7 @@ const mergeChunkDatasets = (
   }
   return pointsById
     .entries()
-    .map(([id, points]) => ({
-      data: points.values().toArray(),
-      id,
-      label: id,
-    }))
+    .map(([id, points]) => ({ data: points.values().toArray(), id, label: id }))
     .toArray()
 }
 

--- a/src/http/client.ts
+++ b/src/http/client.ts
@@ -231,10 +231,7 @@ export class HttpClient {
         {
           config: {
             data: config.data,
-            headers: {
-              ...this.#defaultHeaders,
-              ...config.headers,
-            },
+            headers: { ...this.#defaultHeaders, ...config.headers },
             method: config.method ?? 'GET',
             params: config.params,
             url: config.url,

--- a/src/types/classic-generic.ts
+++ b/src/types/classic-generic.ts
@@ -442,10 +442,7 @@ export interface ClassicLoginPostData {
  * Operation-mode breakdown returned by `Report/GetOperationModeLog2` — one `{Key,Value}` entry per mode.
  * @category Types
  */
-export type ClassicOperationModeLogData = {
-  Key: string
-  Value: number
-}[]
+export type ClassicOperationModeLogData = { Key: string; Value: number }[]
 
 /**
  * Approximate latitude/longitude bucket carried alongside `Latitude`/

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -47,10 +47,7 @@ export const ok = <T>(value: T): Success<T> => ({ ok: true, value })
  * @returns A `{ ok: false, error }` failure outcome.
  * @category Types
  */
-export const err = (error: ApiRequestError): Failure => ({
-  error,
-  ok: false,
-})
+export const err = (error: ApiRequestError): Failure => ({ error, ok: false })
 
 /**
  * Transform the success branch of a {@link Result} while passing the

--- a/src/types/utility.ts
+++ b/src/types/utility.ts
@@ -8,9 +8,7 @@
  * @template T - Input shape whose optional properties admit `undefined`.
  * @category Types
  */
-export type Resolved<T> = {
-  [K in keyof T]-?: Exclude<T[K], undefined>
-}
+export type Resolved<T> = { [K in keyof T]-?: Exclude<T[K], undefined> }
 
 /**
  * Optional form of `T` whose properties may also be explicitly
@@ -21,6 +19,4 @@ export type Resolved<T> = {
  * @template T - Exact shape being widened into a tolerant input.
  * @category Types
  */
-export type UndefinedTolerant<T> = {
-  [K in keyof T]?: T[K] | undefined
-}
+export type UndefinedTolerant<T> = { [K in keyof T]?: T[K] | undefined }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,12 +48,8 @@ const getLabelFormatters = (
     return cached
   }
   const cache: LabelFormatterCache = {
-    dayOfWeek: new Intl.DateTimeFormat(locale, {
-      weekday: 'short',
-    }),
-    month: new Intl.DateTimeFormat(locale, {
-      month: 'short',
-    }),
+    dayOfWeek: new Intl.DateTimeFormat(locale, { weekday: 'short' }),
+    month: new Intl.DateTimeFormat(locale, { month: 'short' }),
   }
   formatterCacheByLocale.set(key, cache)
   return cache

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -32,10 +32,7 @@ export const ClassicLoginDataSchema: z.ZodType<ClassicLoginData> =
   z.looseObject({
     ErrorId: z.number().nullable().optional(),
     LoginData: z
-      .looseObject({
-        ContextKey: z.string(),
-        Expiry: z.string(),
-      })
+      .looseObject({ ContextKey: z.string(), Expiry: z.string() })
       .nullable(),
     LoginMinutes: z.number().nullable().optional(),
   })
@@ -44,9 +41,7 @@ export const ClassicLoginDataSchema: z.ZodType<ClassicLoginData> =
  * Home OIDC /connect/par response.
  */
 export const HomeParResponseSchema: z.ZodType<{ request_uri: string }> =
-  z.looseObject({
-    request_uri: z.string().min(1),
-  })
+  z.looseObject({ request_uri: z.string().min(1) })
 
 /**
  * Home OIDC /connect/token response.

--- a/tests/classic-fixtures.ts
+++ b/tests/classic-fixtures.ts
@@ -411,23 +411,25 @@ export const createMockClassicApi = (
       .fn<ClassicAPIAdapter['updatePower']>()
       .mockResolvedValue(true),
     updateValues: cast(
-      vi.fn<ClassicAPIAdapter['updateValues']>().mockResolvedValue(
-        mock<ClassicSetDeviceDataAta>({
-          DeviceType: ClassicDeviceType.Ata,
-          EffectiveFlags: 0x1,
-          LastCommunication: '',
-          NextCommunication: '',
-          NumberOfFanSpeeds: 5,
-          Offline: false,
-          OperationMode: ClassicOperationMode.heat,
-          Power: true,
-          RoomTemperature: 22,
-          SetFanSpeed: 3,
-          SetTemperature: 24,
-          VaneHorizontal: 0,
-          VaneVertical: 0,
-        }),
-      ),
+      vi
+        .fn<ClassicAPIAdapter['updateValues']>()
+        .mockResolvedValue(
+          mock<ClassicSetDeviceDataAta>({
+            DeviceType: ClassicDeviceType.Ata,
+            EffectiveFlags: 0x1,
+            LastCommunication: '',
+            NextCommunication: '',
+            NumberOfFanSpeeds: 5,
+            Offline: false,
+            OperationMode: ClassicOperationMode.heat,
+            Power: true,
+            RoomTemperature: 22,
+            SetFanSpeed: 3,
+            SetTemperature: 24,
+            VaneHorizontal: 0,
+            VaneVertical: 0,
+          }),
+        ),
     ),
     ...overrides,
   })

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -89,10 +89,7 @@ export function mock(value: unknown = {}): unknown {
  */
 export const createMockHttpClient = (
   baseURL: string,
-): {
-  client: HttpClient
-  requestSpy: MockInstance<HttpClient['request']>
-} => {
+): { client: HttpClient; requestSpy: MockInstance<HttpClient['request']> } => {
   const client = new HttpClient({ baseURL, timeout: 30_000 })
   return { client, requestSpy: vi.spyOn(client, 'request') }
 }
@@ -136,11 +133,7 @@ export const mockResponse = (
   data: unknown
   headers: Record<string, string | string[]>
   status: number
-} => ({
-  data,
-  headers,
-  status,
-})
+} => ({ data, headers, status })
 
 // The Response constructor rejects a non-null body on the "null body"
 // statuses defined in the Fetch spec. Listed explicitly so mocked

--- a/tests/integration/api-lifecycle.test.ts
+++ b/tests/integration/api-lifecycle.test.ts
@@ -140,16 +140,18 @@ describe('api lifecycle', () => {
     // Captures building → floor → area → device hierarchy shape
     // without being brittle on device-data fields.
     expect(
-      api.registry.getBuildings().map(({ floors, name }) => ({
-        floors: floors.map(({ areas, name: floorName }) => ({
-          areas: areas.map(({ devices, name: areaName }) => ({
-            devices: devices.map(({ name: deviceName }) => deviceName),
-            name: areaName,
+      api.registry
+        .getBuildings()
+        .map(({ floors, name }) => ({
+          floors: floors.map(({ areas, name: floorName }) => ({
+            areas: areas.map(({ devices, name: areaName }) => ({
+              devices: devices.map(({ name: deviceName }) => deviceName),
+              name: areaName,
+            })),
+            name: floorName,
           })),
-          name: floorName,
+          name,
         })),
-        name,
-      })),
     ).toMatchInlineSnapshot(`
       [
         {
@@ -202,10 +204,7 @@ describe('api lifecycle', () => {
       if (config.url === '/Login/ClientLogin3') {
         return {
           data: {
-            LoginData: {
-              ContextKey: 'ctx-123',
-              Expiry: '2099-12-31T00:00:00',
-            },
+            LoginData: { ContextKey: 'ctx-123', Expiry: '2099-12-31T00:00:00' },
           },
           headers: {},
           status: 200,
@@ -229,10 +228,7 @@ describe('api lifecycle', () => {
       if (config.url === '/Login/ClientLogin3') {
         return {
           data: {
-            LoginData: {
-              ContextKey: 'ctx-abc',
-              Expiry: '2099-12-31T00:00:00',
-            },
+            LoginData: { ContextKey: 'ctx-abc', Expiry: '2099-12-31T00:00:00' },
           },
           headers: {},
           status: 200,

--- a/tests/integration/registry-facades.test.ts
+++ b/tests/integration/registry-facades.test.ts
@@ -265,10 +265,7 @@ describe('registry + facade manager integration', () => {
     await facade.updatePower(false)
 
     expect(api.updatePower).toHaveBeenCalledWith({
-      postData: {
-        DeviceIds: [1001, 1002, 1003],
-        Power: false,
-      },
+      postData: { DeviceIds: [1001, 1002, 1003], Power: false },
     })
   })
 

--- a/tests/unit/base-api.test.ts
+++ b/tests/unit/base-api.test.ts
@@ -216,11 +216,7 @@ describe('baseAPI shared request pipeline', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     mockTemporalNowInstant()
-    mockRequest.mockResolvedValue({
-      data: {},
-      headers: {},
-      status: 200,
-    })
+    mockRequest.mockResolvedValue({ data: {}, headers: {}, status: 200 })
     api = new TestAPI()
   })
 
@@ -431,16 +427,9 @@ describe('baseAPI shared request pipeline', () => {
     it('emits onRequestStart and onRequestComplete pair', async () => {
       const onRequestStart = vi.fn<(event: RequestStartEvent) => void>()
       const onRequestComplete = vi.fn<(event: RequestCompleteEvent) => void>()
-      const events: LifecycleEvents = {
-        onRequestComplete,
-        onRequestStart,
-      }
+      const events: LifecycleEvents = { onRequestComplete, onRequestStart }
       api = new TestAPI({ events })
-      mockRequest.mockResolvedValue({
-        data: {},
-        headers: {},
-        status: 200,
-      })
+      mockRequest.mockResolvedValue({ data: {}, headers: {}, status: 200 })
 
       await api.callRequest('get', '/data')
 
@@ -533,36 +522,22 @@ describe('baseAPI shared request pipeline', () => {
   describe('dispatch with non-object headers', () => {
     it('handles non-object headers value gracefully', async () => {
       api.getAuthHeadersMock.mockReturnValue({ 'X-Auth': 'tok' })
-      mockRequest.mockResolvedValue({
-        data: {},
-        headers: {},
-        status: 200,
-      })
+      mockRequest.mockResolvedValue({ data: {}, headers: {}, status: 200 })
 
       // Pass a non-object headers value (e.g. a string) to cover the
       // non-object branch of dispatch's headers merge
-      await api.callDispatch('get', '/data', {
-        headers: cast('not-an-object'),
-      })
+      await api.callDispatch('get', '/data', { headers: cast('not-an-object') })
 
       expect(mockRequest).toHaveBeenCalledWith(
-        expect.objectContaining({
-          headers: { 'X-Auth': 'tok' },
-        }),
+        expect.objectContaining({ headers: { 'X-Auth': 'tok' } }),
       )
     })
 
     it('merges object headers with auth headers', async () => {
       api.getAuthHeadersMock.mockReturnValue({ 'X-Auth': 'tok' })
-      mockRequest.mockResolvedValue({
-        data: {},
-        headers: {},
-        status: 200,
-      })
+      mockRequest.mockResolvedValue({ data: {}, headers: {}, status: 200 })
 
-      await api.callDispatch('get', '/data', {
-        headers: { 'X-Custom': 'val' },
-      })
+      await api.callDispatch('get', '/data', { headers: { 'X-Custom': 'val' } })
 
       expect(mockRequest).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1302,11 +1277,7 @@ describe('logOut', () => {
 
   it('deletes the keys outright when the host delegates unset', () => {
     const { settingManager, unsetSpy } = createSettingStore(
-      {
-        loginBackoffUntil: '123',
-        password: 'p',
-        username: 'u',
-      },
+      { loginBackoffUntil: '123', password: 'p', username: 'u' },
       { hasUnset: true },
     )
     const api = new TestAPI({ settingManager })

--- a/tests/unit/classic-api.test.ts
+++ b/tests/unit/classic-api.test.ts
@@ -449,10 +449,7 @@ describe('mELCloud Classic API', () => {
         await api.updateValues({
           postData: mock<
             ClassicSetDevicePostData<typeof ClassicDeviceType.Ata>
-          >({
-            DeviceID: toClassicDeviceId(1),
-            EffectiveFlags: 1,
-          }),
+          >({ DeviceID: toClassicDeviceId(1), EffectiveFlags: 1 }),
           type,
         })
 
@@ -711,10 +708,7 @@ describe('mELCloud Classic API', () => {
       const api = await createApi({ password: 'pass', username: 'user' })
       mockRequest.mockResolvedValue(
         wrap([
-          errorEntry({
-            ErrorMessage: 'Mystery',
-            StartDate: 'not-a-real-date',
-          }),
+          errorEntry({ ErrorMessage: 'Mystery', StartDate: 'not-a-real-date' }),
         ]),
       )
       const result = await api.getErrorLog({}, [1])
@@ -836,9 +830,7 @@ describe('mELCloud Classic API', () => {
 
       expect(mockRequest).toHaveBeenCalledWith(
         expect.objectContaining({
-          headers: matchObject({
-            'X-MitsContextKey': 'my-ctx',
-          }),
+          headers: matchObject({ 'X-MitsContextKey': 'my-ctx' }),
         }),
       )
     })
@@ -853,10 +845,7 @@ describe('mELCloud Classic API', () => {
 
       // Login goes through #dispatch which sends empty headers when contextKey is ''
       expect(mockRequest).toHaveBeenCalledWith(
-        expect.objectContaining({
-          headers: {},
-          url: '/Login/ClientLogin3',
-        }),
+        expect.objectContaining({ headers: {}, url: '/Login/ClientLogin3' }),
       )
     })
 
@@ -876,9 +865,7 @@ describe('mELCloud Classic API', () => {
 
       expect(mockRequest).toHaveBeenCalledWith(
         expect.objectContaining({
-          headers: matchObject({
-            'X-MitsContextKey': 'newest',
-          }),
+          headers: matchObject({ 'X-MitsContextKey': 'newest' }),
           url: '/Device/Get',
         }),
       )
@@ -899,18 +886,13 @@ describe('mELCloud Classic API', () => {
 
       expect(mockRequest).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: matchObject({
-            Email: 'user',
-            Password: 'pass',
-          }),
+          data: matchObject({ Email: 'user', Password: 'pass' }),
           url: '/Login/ClientLogin3',
         }),
       )
       expect(mockRequest).toHaveBeenCalledWith(
         expect.objectContaining({
-          headers: matchObject({
-            'X-MitsContextKey': 'fresh',
-          }),
+          headers: matchObject({ 'X-MitsContextKey': 'fresh' }),
           url: '/Device/Get',
         }),
       )
@@ -935,9 +917,7 @@ describe('mELCloud Classic API', () => {
       )
       expect(mockRequest).toHaveBeenCalledWith(
         expect.objectContaining({
-          headers: matchObject({
-            'X-MitsContextKey': 'fresh',
-          }),
+          headers: matchObject({ 'X-MitsContextKey': 'fresh' }),
         }),
       )
     })
@@ -956,9 +936,7 @@ describe('mELCloud Classic API', () => {
 
       expect(mockRequest).toHaveBeenCalledWith(
         expect.objectContaining({
-          headers: matchObject({
-            'X-MitsContextKey': 'valid',
-          }),
+          headers: matchObject({ 'X-MitsContextKey': 'valid' }),
         }),
       )
     })
@@ -1005,9 +983,7 @@ describe('mELCloud Classic API', () => {
         }
         return wrap({ value: 'retried' })
       })
-      const result = await api.getValues({
-        params: { buildingId: 1, id: 1 },
-      })
+      const result = await api.getValues({ params: { buildingId: 1, id: 1 } })
 
       expect(okValue(result)).toStrictEqual({ value: 'retried' })
     })
@@ -1032,9 +1008,7 @@ describe('mELCloud Classic API', () => {
         })
       })
 
-      const result = await api.getValues({
-        params: { buildingId: 1, id: 1 },
-      })
+      const result = await api.getValues({ params: { buildingId: 1, id: 1 } })
 
       expect(result.ok).toBe(false)
       expect(!result.ok && result.error.kind).toBe('unauthorized')
@@ -1051,9 +1025,7 @@ describe('mELCloud Classic API', () => {
       // An error with no response — e.g. network/TLS failure
       mockRequest.mockRejectedValueOnce(new Error('connect ECONNREFUSED'))
 
-      const result = await api.getValues({
-        params: { buildingId: 1, id: 1 },
-      })
+      const result = await api.getValues({ params: { buildingId: 1, id: 1 } })
 
       expect(result.ok).toBe(false)
       expect(!result.ok && result.error.kind).toBe('network')

--- a/tests/unit/classic-atw-zones.test.ts
+++ b/tests/unit/classic-atw-zones.test.ts
@@ -37,11 +37,7 @@ const createAtwRegistry = (data: ClassicListDeviceDataAtw): ClassicRegistry => {
     classicBuildingData({ HMDefined: true, Location: 0, TimeZone: 1 }),
   ])
   registry.syncDevices([
-    classicAtwDevice({
-      AreaID: null,
-      Device: data,
-      FloorID: null,
-    }),
+    classicAtwDevice({ AreaID: null, Device: data, FloorID: null }),
   ])
   return registry
 }

--- a/tests/unit/classic-facades.test.ts
+++ b/tests/unit/classic-facades.test.ts
@@ -192,27 +192,29 @@ const atwSetValuesResponse = (
   overrides: Record<string, unknown> = {},
 ): Partial<ClassicAPIAdapter> => ({
   updateValues: cast(
-    vi.fn<ClassicAPIAdapter['updateValues']>().mockResolvedValue(
-      mock<ClassicSetDeviceDataAtw>({
-        DeviceType: ClassicDeviceType.Atw,
-        EffectiveFlags: 0x1,
-        ForcedHotWaterMode: false,
-        LastCommunication: '',
-        NextCommunication: '',
-        Offline: false,
-        OperationModeZone1: 0,
-        OperationModeZone2: 0,
-        Power: true,
-        SetCoolFlowTemperatureZone1: 20,
-        SetCoolFlowTemperatureZone2: 20,
-        SetHeatFlowTemperatureZone1: 40,
-        SetHeatFlowTemperatureZone2: 40,
-        SetTankWaterTemperature: 50,
-        SetTemperatureZone1: 22,
-        SetTemperatureZone2: 22,
-        ...overrides,
-      }),
-    ),
+    vi
+      .fn<ClassicAPIAdapter['updateValues']>()
+      .mockResolvedValue(
+        mock<ClassicSetDeviceDataAtw>({
+          DeviceType: ClassicDeviceType.Atw,
+          EffectiveFlags: 0x1,
+          ForcedHotWaterMode: false,
+          LastCommunication: '',
+          NextCommunication: '',
+          Offline: false,
+          OperationModeZone1: 0,
+          OperationModeZone2: 0,
+          Power: true,
+          SetCoolFlowTemperatureZone1: 20,
+          SetCoolFlowTemperatureZone2: 20,
+          SetHeatFlowTemperatureZone1: 40,
+          SetHeatFlowTemperatureZone2: 40,
+          SetTankWaterTemperature: 50,
+          SetTemperatureZone1: 22,
+          SetTemperatureZone2: 22,
+          ...overrides,
+        }),
+      ),
   ),
 })
 
@@ -367,11 +369,7 @@ describe('building facade frost protection', () => {
   it('sets frost protection', async () => {
     const { api, facade } = createBuildingFacade()
     await facade.getFrostProtection()
-    await facade.updateFrostProtection({
-      isEnabled: true,
-      max: 14,
-      min: 6,
-    })
+    await facade.updateFrostProtection({ isEnabled: true, max: 14, min: 6 })
 
     expect(api.updateFrostProtection).toHaveBeenCalledWith(expect.any(Object))
   })
@@ -404,11 +402,7 @@ describe('building facade frost protection', () => {
   it('clamps frost protection temperatures', async () => {
     const { api, facade } = createBuildingFacade()
     await facade.getFrostProtection()
-    await facade.updateFrostProtection({
-      isEnabled: true,
-      max: 2,
-      min: 1,
-    })
+    await facade.updateFrostProtection({ isEnabled: true, max: 2, min: 1 })
     const call = vi.mocked(api.updateFrostProtection).mock.lastCall?.[0]
 
     expect(call).toBeDefined()
@@ -422,11 +416,7 @@ describe('building facade frost protection', () => {
   it('enforces minimum gap between min and max temperatures', async () => {
     const { api, facade } = createBuildingFacade()
     await facade.getFrostProtection()
-    await facade.updateFrostProtection({
-      isEnabled: true,
-      max: 15,
-      min: 14,
-    })
+    await facade.updateFrostProtection({ isEnabled: true, max: 15, min: 14 })
     const call = vi.mocked(api.updateFrostProtection).mock.lastCall?.[0]
 
     expect(call).toBeDefined()
@@ -875,27 +865,29 @@ describe('ata device facade', () => {
 
   it('builds the ATA energy report with per-mode series in kWh', async () => {
     const { api, facade } = createAtaFacade({
-      getEnergy: vi.fn<ClassicAPIAdapter['getEnergy']>().mockResolvedValue(
-        ok(
-          mock<ClassicEnergyDataAta>({
-            Auto: [0, 0],
-            Cooling: [0.5, 1],
-            Dry: [0, 0],
-            Fan: [0, 0],
-            Heating: [0, 0],
-            Labels: [0, 1],
-            LabelType: 4,
-            Other: [0, 0],
-            TotalAutoConsumed: 0,
-            TotalCoolingConsumed: 1.5,
-            TotalDryConsumed: 0,
-            TotalFanConsumed: 0,
-            TotalHeatingConsumed: 0,
-            TotalOtherConsumed: 0,
-            UsageDisclaimerPercentages: '100',
-          }),
+      getEnergy: vi
+        .fn<ClassicAPIAdapter['getEnergy']>()
+        .mockResolvedValue(
+          ok(
+            mock<ClassicEnergyDataAta>({
+              Auto: [0, 0],
+              Cooling: [0.5, 1],
+              Dry: [0, 0],
+              Fan: [0, 0],
+              Heating: [0, 0],
+              Labels: [0, 1],
+              LabelType: 4,
+              Other: [0, 0],
+              TotalAutoConsumed: 0,
+              TotalCoolingConsumed: 1.5,
+              TotalDryConsumed: 0,
+              TotalFanConsumed: 0,
+              TotalHeatingConsumed: 0,
+              TotalOtherConsumed: 0,
+              UsageDisclaimerPercentages: '100',
+            }),
+          ),
         ),
-      ),
       locale: 'en-US',
     })
 
@@ -921,27 +913,29 @@ describe('ata device facade', () => {
 
   it('rebuilds multi-day energy labels as dates', async () => {
     const { facade } = createAtaFacade({
-      getEnergy: vi.fn<ClassicAPIAdapter['getEnergy']>().mockResolvedValue(
-        ok(
-          mock<ClassicEnergyDataAta>({
-            Auto: [0, 0, 0, 0, 0, 0, 0],
-            Cooling: [1, 1, 1, 1, 1, 1, 1],
-            Dry: [0, 0, 0, 0, 0, 0, 0],
-            Fan: [0, 0, 0, 0, 0, 0, 0],
-            Heating: [0, 0, 0, 0, 0, 0, 0],
-            Labels: [1, 2, 3, 4, 5, 6, 0],
-            LabelType: 4,
-            Other: [0, 0, 0, 0, 0, 0, 0],
-            TotalAutoConsumed: 0,
-            TotalCoolingConsumed: 7,
-            TotalDryConsumed: 0,
-            TotalFanConsumed: 0,
-            TotalHeatingConsumed: 0,
-            TotalOtherConsumed: 0,
-            UsageDisclaimerPercentages: '100',
-          }),
+      getEnergy: vi
+        .fn<ClassicAPIAdapter['getEnergy']>()
+        .mockResolvedValue(
+          ok(
+            mock<ClassicEnergyDataAta>({
+              Auto: [0, 0, 0, 0, 0, 0, 0],
+              Cooling: [1, 1, 1, 1, 1, 1, 1],
+              Dry: [0, 0, 0, 0, 0, 0, 0],
+              Fan: [0, 0, 0, 0, 0, 0, 0],
+              Heating: [0, 0, 0, 0, 0, 0, 0],
+              Labels: [1, 2, 3, 4, 5, 6, 0],
+              LabelType: 4,
+              Other: [0, 0, 0, 0, 0, 0, 0],
+              TotalAutoConsumed: 0,
+              TotalCoolingConsumed: 7,
+              TotalDryConsumed: 0,
+              TotalFanConsumed: 0,
+              TotalHeatingConsumed: 0,
+              TotalOtherConsumed: 0,
+              UsageDisclaimerPercentages: '100',
+            }),
+          ),
         ),
-      ),
       locale: 'fr-FR',
     })
 
@@ -964,31 +958,30 @@ describe('ata device facade', () => {
   })
 
   it('lowers Z-suffixed report bounds to wall-clock in the display timezone', async () => {
-    const getEnergy = vi.fn<ClassicAPIAdapter['getEnergy']>().mockResolvedValue(
-      ok(
-        mock<ClassicEnergyDataAta>({
-          Auto: [0, 0],
-          Cooling: [0.5, 1],
-          Dry: [0, 0],
-          Fan: [0, 0],
-          Heating: [0, 0],
-          Labels: [0, 1],
-          LabelType: 0,
-          Other: [0, 0],
-          TotalAutoConsumed: 0,
-          TotalCoolingConsumed: 1.5,
-          TotalDryConsumed: 0,
-          TotalFanConsumed: 0,
-          TotalHeatingConsumed: 0,
-          TotalOtherConsumed: 0,
-          UsageDisclaimerPercentages: '100',
-        }),
-      ),
-    )
-    const { facade } = createAtaFacade({
-      getEnergy,
-      timezone: 'Europe/Paris',
-    })
+    const getEnergy = vi
+      .fn<ClassicAPIAdapter['getEnergy']>()
+      .mockResolvedValue(
+        ok(
+          mock<ClassicEnergyDataAta>({
+            Auto: [0, 0],
+            Cooling: [0.5, 1],
+            Dry: [0, 0],
+            Fan: [0, 0],
+            Heating: [0, 0],
+            Labels: [0, 1],
+            LabelType: 0,
+            Other: [0, 0],
+            TotalAutoConsumed: 0,
+            TotalCoolingConsumed: 1.5,
+            TotalDryConsumed: 0,
+            TotalFanConsumed: 0,
+            TotalHeatingConsumed: 0,
+            TotalOtherConsumed: 0,
+            UsageDisclaimerPercentages: '100',
+          }),
+        ),
+      )
+    const { facade } = createAtaFacade({ getEnergy, timezone: 'Europe/Paris' })
 
     // `new Date().toISOString()` output must not crash the Temporal
     // Plain parsing — the instants lower to Paris wall-clock instead.
@@ -1008,27 +1001,29 @@ describe('ata device facade', () => {
 
   it('formats a one-day energy report with clock labels', async () => {
     const { facade } = createAtaFacade({
-      getEnergy: vi.fn<ClassicAPIAdapter['getEnergy']>().mockResolvedValue(
-        ok(
-          mock<ClassicEnergyDataAta>({
-            Auto: [0, 0],
-            Cooling: [0.2, 0.3],
-            Dry: [0, 0],
-            Fan: [0, 0],
-            Heating: [0, 0],
-            Labels: [9, 10],
-            LabelType: 0,
-            Other: [0, 0],
-            TotalAutoConsumed: 0,
-            TotalCoolingConsumed: 0.5,
-            TotalDryConsumed: 0,
-            TotalFanConsumed: 0,
-            TotalHeatingConsumed: 0,
-            TotalOtherConsumed: 0,
-            UsageDisclaimerPercentages: '100',
-          }),
+      getEnergy: vi
+        .fn<ClassicAPIAdapter['getEnergy']>()
+        .mockResolvedValue(
+          ok(
+            mock<ClassicEnergyDataAta>({
+              Auto: [0, 0],
+              Cooling: [0.2, 0.3],
+              Dry: [0, 0],
+              Fan: [0, 0],
+              Heating: [0, 0],
+              Labels: [9, 10],
+              LabelType: 0,
+              Other: [0, 0],
+              TotalAutoConsumed: 0,
+              TotalCoolingConsumed: 0.5,
+              TotalDryConsumed: 0,
+              TotalFanConsumed: 0,
+              TotalHeatingConsumed: 0,
+              TotalOtherConsumed: 0,
+              UsageDisclaimerPercentages: '100',
+            }),
+          ),
         ),
-      ),
       locale: 'fr-FR',
     })
 
@@ -1315,27 +1310,29 @@ describe('atw device facade', () => {
   it('builds the ATW energy report with consumed and produced series', async () => {
     // Pin the label locale: the runner's default is not ours.
     const { facade } = createAtwFacade({
-      getEnergy: vi.fn<ClassicAPIAdapter['getEnergy']>().mockResolvedValue(
-        ok(
-          mock<ClassicEnergyDataAtw>({
-            Cooling: [0, 0],
-            CoP: [2.5, null],
-            Heating: [5.1, 4.9],
-            HotWater: [2.5, 2.6],
-            Labels: [12, 13],
-            LabelType: 1,
-            ProducedCooling: [0, 0],
-            ProducedHeating: [15.2, 14.8],
-            ProducedHotWater: [6.1, 6.2],
-            TotalCoolingConsumed: 0,
-            TotalCoolingProduced: 0,
-            TotalHeatingConsumed: 10,
-            TotalHeatingProduced: 30,
-            TotalHotWaterConsumed: 5.1,
-            TotalHotWaterProduced: 12.3,
-          }),
+      getEnergy: vi
+        .fn<ClassicAPIAdapter['getEnergy']>()
+        .mockResolvedValue(
+          ok(
+            mock<ClassicEnergyDataAtw>({
+              Cooling: [0, 0],
+              CoP: [2.5, null],
+              Heating: [5.1, 4.9],
+              HotWater: [2.5, 2.6],
+              Labels: [12, 13],
+              LabelType: 1,
+              ProducedCooling: [0, 0],
+              ProducedHeating: [15.2, 14.8],
+              ProducedHotWater: [6.1, 6.2],
+              TotalCoolingConsumed: 0,
+              TotalCoolingProduced: 0,
+              TotalHeatingConsumed: 10,
+              TotalHeatingProduced: 30,
+              TotalHotWaterConsumed: 5.1,
+              TotalHotWaterProduced: 12.3,
+            }),
+          ),
         ),
-      ),
       locale: 'fr-FR',
     })
 
@@ -1396,9 +1393,7 @@ describe('atw device facade', () => {
         SetTemperatureZone2: 10,
       }),
     )
-    await facade.updateValues({
-      SetTemperatureZone1: cast(null),
-    })
+    await facade.updateValues({ SetTemperatureZone1: cast(null) })
     const call = vi.mocked(api.updateValues).mock.lastCall?.[0]
 
     expect(call).toBeDefined()

--- a/tests/unit/decorators.test.ts
+++ b/tests/unit/decorators.test.ts
@@ -29,10 +29,7 @@ const createMockFacade = (
 ): {
   devices: { type: ClassicDeviceType; update: ReturnType<typeof vi.fn> }[]
   id: number
-} => ({
-  devices,
-  id,
-})
+} => ({ devices, id })
 
 const decorateUpdateDevices = (
   target: (...args: unknown[]) => Promise<void>,
@@ -49,11 +46,7 @@ const ataFlags = {
   VaneVertical: 0x10,
 }
 
-const ervFlags = {
-  Power: 0x1,
-  SetFanSpeed: 0x8,
-  VentilationMode: 0x4,
-}
+const ervFlags = { Power: 0x1, SetFanSpeed: 0x8, VentilationMode: 0x4 }
 
 const createAtaSetData = (
   overrides: Partial<ClassicSetDeviceDataAta> = {},
@@ -155,11 +148,7 @@ const setupFetchDevices = (
 
 describe(fetchDevices, () => {
   it.each([
-    {
-      first: 'fetch' as const,
-      label: 'default (before)',
-      options: undefined,
-    },
+    { first: 'fetch' as const, label: 'default (before)', options: undefined },
     {
       first: 'fetch' as const,
       label: 'when=before',

--- a/tests/unit/home-api.test.ts
+++ b/tests/unit/home-api.test.ts
@@ -281,9 +281,7 @@ const setupSuccessfulLogin = (): void => {
     .mockResolvedValueOnce(
       mockFetchResponse(
         '',
-        {
-          location: 'https://auth.melcloudhome.com/ExternalLogin/Callback',
-        },
+        { location: 'https://auth.melcloudhome.com/ExternalLogin/Callback' },
         302,
       ),
     )
@@ -372,10 +370,7 @@ describe('melcloud home API', () => {
 
     it('exposes the configured locale and timezone for chart rendering', async () => {
       setupSuccessfulLogin()
-      const api = await createApi({
-        locale: 'fr-FR',
-        timezone: 'Europe/Paris',
-      })
+      const api = await createApi({ locale: 'fr-FR', timezone: 'Europe/Paris' })
 
       expect(api.locale).toBe('fr-FR')
       expect(api.timezone).toBe('Europe/Paris')
@@ -495,10 +490,7 @@ describe('melcloud home API', () => {
       setupSuccessfulLogin()
       const api = await createApi()
       setupSuccessfulLogin()
-      await api.authenticate({
-        password: 'new-pass',
-        username: 'new@test.com',
-      })
+      await api.authenticate({ password: 'new-pass', username: 'new@test.com' })
 
       expect(api.isAuthenticated()).toBe(true)
     })
@@ -744,10 +736,7 @@ describe('melcloud home API', () => {
       mockRequest
         .mockResolvedValueOnce(mockResponse('', {}, 200))
         .mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
-      await api.updateValues('device-1', {
-        operationMode: 'Heat',
-        power: true,
-      })
+      await api.updateValues('device-1', { operationMode: 'Heat', power: true })
 
       expect(mockRequest).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -916,9 +905,7 @@ describe('melcloud home API', () => {
 
       expect(result).toStrictEqual({ ok: true, value: mockErrorLog })
       expect(mockRequest).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          url: '/monitor/ataunit/device-1/errorlog',
-        }),
+        expect.objectContaining({ url: '/monitor/ataunit/device-1/errorlog' }),
       )
     })
 
@@ -1101,10 +1088,7 @@ describe('melcloud home API', () => {
       mockRequest
         .mockResolvedValueOnce(mockResponse('', {}, 200))
         .mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
-      await api.updateValues('atw-1', {
-        power: false,
-        setTemperatureZone1: 20,
-      })
+      await api.updateValues('atw-1', { power: false, setTemperatureZone1: 20 })
 
       expect(mockRequest).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1158,9 +1142,7 @@ describe('melcloud home API', () => {
       api.registry.syncDevices([typedHomeAtwDeviceData({ id: 'atw-1' })])
 
       await expect(
-        api.updateValues('atw-1', {
-          operationModeZone1: cast('HeatCurve'),
-        }),
+        api.updateValues('atw-1', { operationModeZone1: cast('HeatCurve') }),
       ).rejects.toThrow('Unknown ATW zone mode: HeatCurve')
     })
 
@@ -1171,10 +1153,7 @@ describe('melcloud home API', () => {
       mockRequest
         .mockResolvedValueOnce(mockResponse('', {}, 200))
         .mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
-      await api.updateValues('atw-1', {
-        operationModeZone2: null,
-        power: true,
-      })
+      await api.updateValues('atw-1', { operationModeZone2: null, power: true })
 
       expect(mockRequest).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1247,9 +1226,7 @@ describe('melcloud home API', () => {
       await api.getErrorLog('atw-1')
 
       expect(mockRequest).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          url: '/monitor/atwunit/atw-1/errorlog',
-        }),
+        expect.objectContaining({ url: '/monitor/atwunit/atw-1/errorlog' }),
       )
     })
 
@@ -1289,9 +1266,7 @@ describe('melcloud home API', () => {
       })
 
       expect(mockRequest).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          url: '/report/v1/internaltemperatures',
-        }),
+        expect.objectContaining({ url: '/report/v1/internaltemperatures' }),
       )
     })
 
@@ -2328,10 +2303,7 @@ describe('melcloud home API', () => {
 
       // Now explicitly authenticate → clears old tokens first
       setupSuccessfulLogin()
-      await api.authenticate({
-        password: 'new-pass',
-        username: 'new@test.com',
-      })
+      await api.authenticate({ password: 'new-pass', username: 'new@test.com' })
 
       const tokenCalls = setSpy.mock.calls.filter(
         ([key]) => key === 'accessToken',

--- a/tests/unit/home-ata-group.test.ts
+++ b/tests/unit/home-ata-group.test.ts
@@ -229,9 +229,7 @@ describe('home device ata facade group', () => {
     const [model] = ataModels(api)
     const facade = new HomeDeviceAtaFacade(api, mock(model))
 
-    await facade.updateGroupState({
-      OperationMode: ClassicOperationMode.cool,
-    })
+    await facade.updateGroupState({ OperationMode: ClassicOperationMode.cool })
 
     expect(api.updateValues).toHaveBeenCalledWith('device-1', {
       operationMode: 'Cool',

--- a/tests/unit/home-device-ata-facade.test.ts
+++ b/tests/unit/home-device-ata-facade.test.ts
@@ -164,10 +164,7 @@ describe('home device ata facade', () => {
     it('should read temperatures as numbers', () => {
       const facade = new HomeDeviceAtaFacade(
         createApi(),
-        createModel({
-          RoomTemperature: '21.5',
-          SetTemperature: '20',
-        }),
+        createModel({ RoomTemperature: '21.5', SetTemperature: '20' }),
       )
 
       expect(facade.roomTemperature).toBe(21.5)
@@ -272,9 +269,7 @@ describe('home device ata facade', () => {
 
       await facade.updatePower()
 
-      expect(api.updateValues).toHaveBeenCalledWith('device-1', {
-        power: true,
-      })
+      expect(api.updateValues).toHaveBeenCalledWith('device-1', { power: true })
     })
 
     it('powers off when passed false', async () => {
@@ -392,9 +387,7 @@ describe('home device ata facade', () => {
       )
       await facade.updateValues({ power: true })
 
-      expect(api.updateValues).toHaveBeenCalledWith('device-1', {
-        power: true,
-      })
+      expect(api.updateValues).toHaveBeenCalledWith('device-1', { power: true })
     })
 
     it('should pass through temperature for unknown operation mode', async () => {

--- a/tests/unit/home-device-atw-facade.test.ts
+++ b/tests/unit/home-device-atw-facade.test.ts
@@ -247,11 +247,7 @@ describe('home device atw facade', () => {
         label: 'any other operation mode',
         settings: { OperationMode: 'Cooling' },
       },
-      {
-        expected: 'idle',
-        label: 'absent operation mode',
-        settings: {},
-      },
+      { expected: 'idle', label: 'absent operation mode', settings: {} },
     ])(
       'derives the hot-water operational state ($label)',
       ({ expected, settings }) => {
@@ -374,9 +370,7 @@ describe('home device atw facade', () => {
 
       await facade.updatePower(false)
 
-      expect(api.updateValues).toHaveBeenCalledWith('atw-1', {
-        power: false,
-      })
+      expect(api.updateValues).toHaveBeenCalledWith('atw-1', { power: false })
     })
   })
 

--- a/tests/unit/http-client.test.ts
+++ b/tests/unit/http-client.test.ts
@@ -168,9 +168,7 @@ describe(HttpClient, () => {
 
     await expect(
       createClient().request({ url: '/boom' }),
-    ).rejects.toMatchObject({
-      config: { method: 'GET' },
-    })
+    ).rejects.toMatchObject({ config: { method: 'GET' } })
   })
 
   it('throws HttpError on non-2xx with body, headers, status, and config', async () => {
@@ -373,11 +371,7 @@ describe(HttpClient, () => {
   it('forwards the configured dispatcher into fetch', async () => {
     // Sentinel object — runtime shape is the only thing fetch inspects.
     const dispatcher = { sentinel: true }
-    const client = new HttpClient({
-      baseURL: BASE_URL,
-      dispatcher,
-      timeout: 0,
-    })
+    const client = new HttpClient({ baseURL: BASE_URL, dispatcher, timeout: 0 })
     mockFetch.mockResolvedValueOnce(mockFetchResponse({}, {}, 200))
 
     await client.request({ url: '/d' })

--- a/tests/unit/observability.test.ts
+++ b/tests/unit/observability.test.ts
@@ -142,10 +142,8 @@ describe('api call response data', () => {
 
 const parseLog = (
   value: string,
-): {
-  headers: Record<string, unknown>
-  requestData: Record<string, unknown>
-} => cast(JSON.parse(value))
+): { headers: Record<string, unknown>; requestData: Record<string, unknown> } =>
+  cast(JSON.parse(value))
 
 describe('sensitive data redaction', () => {
   it('redacts credentials in request data', () => {
@@ -197,9 +195,7 @@ describe('sensitive data redaction', () => {
   })
 
   it('redacts Cookie header in request data', () => {
-    const config = createConfig({
-      headers: { Cookie: 'session=xyz' },
-    })
+    const config = createConfig({ headers: { Cookie: 'session=xyz' } })
     const call = new APICallRequestData(config)
     const { headers } = parseLog(call.toString())
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,5 @@
 {
-  "compilerOptions": {
-    "rootDir": "src"
-  },
+  "compilerOptions": { "rootDir": "src" },
   "extends": "./tsconfig.json",
   "include": ["src"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,14 +6,9 @@ const config: ViteUserConfig = defineConfig({
   plugins: [
     swc.vite({
       jsc: {
-        parser: {
-          decorators: true,
-          syntax: 'typescript',
-        },
+        parser: { decorators: true, syntax: 'typescript' },
         target: 'es2024',
-        transform: {
-          decoratorVersion: '2022-03',
-        },
+        transform: { decoratorVersion: '2022-03' },
       },
     }),
   ],


### PR DESCRIPTION
Tool-owned styling: Prettier ≥ 3.5's `objectWrap: "collapse"` folds every object literal that fits the print width — from here on, a line break inside an object only ever means the line was too long. One-time whole-tree reformat; the option (merged into `prettier.config.ts`, house options preserved) keeps it true mechanically. Full suite green; the CLI-generated outputs (`app.json`-class files) are untouched — a `validate`→`format` cycle was verified stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3
