### PR TITLE
docs: pin the shared flow-temp wire bit and drop a redundant ignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,1 @@
-/.claude/
 /README.md

--- a/src/facades/classic-flags.ts
+++ b/src/facades/classic-flags.ts
@@ -35,7 +35,13 @@ export const classicAtaFlags: {
 >
 
 /**
- * `EffectiveFlags` bitfield values for ATW update payloads — one bit per updatable field.
+ * `EffectiveFlags` bitfield values for ATW update payloads — one bit per
+ * updatable field, except the four flow-temperature setpoints, which
+ * share a single wire bit (verified against the live wire): MELCloud
+ * acknowledges any of them with the same flag, and the tank setpoint's
+ * flag carries that bit too. A bitwise membership test therefore
+ * matches the whole group together — harmless, since the patched
+ * values all come from the same response.
  */
 export const classicAtwFlags: {
   readonly ForcedHotWaterMode: 0x1_00_00


### PR DESCRIPTION
Two follow-ups from the round-2 review triage. (1) The four ATW flow-temperature setpoints deliberately carry the same `EffectiveFlags` bit — owner-confirmed live-wire behavior, and the tank setpoint's flag contains that bit too; the new comment keeps the collision from ever reading as a copy-paste typo, and notes why the grouped bitwise match stays harmless (all patched values come from the same response). (2) `/.claude/` in `.prettierignore` duplicated `.gitignore`, which prettier 3 folds into its default `--ignore-path` — proven empirically in the app repos; same dedup lands in the four siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3