### PR TITLE
refactor: publish the reachable HTTP and transport types

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,0 @@
-/README.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
+  "js/ts.tsdk.path": "node_modules/@typescript/native",
   "sonarlint.connectedMode.project": {
     "connectionId": "olivierzal",
     "projectKey": "OlivierZal_melcloud-api"
-  },
-  "typescript.native-preview.tsdk": "node_modules/@typescript/native"
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - `/home` barrel: the missing `DeviceFacadeAny`, `isAtaFacade`/`isAtwFacade` guards, `FrostProtectionPostData`, `HolidayModePostData`, `OverheatProtectionPostData`, `ProtectionUnits`, `ReportAnnotation`, `ReportTrigger`, and the dialect-neutral `fetchDevices`/`syncDevices` decorators.
 - `/classic` barrel: the missing `BaseListDevice`, `BuildingOwner`, `DevicePermissions` and `QuantizedCoordinates` types.
+- Root barrel: `HttpStatus`, `HttpErrorRequestConfig` and `TransportConfig` — reachable from public members (`HttpError.config`, `BaseAPIConfig.transport`, `error.response.status` narrowing), so consumers can now name them.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ if (!result.ok) {
       // re-authenticate before retrying
       break
     default:
-    // network / server / validation — log and skip
+      // network / server / validation — log and skip
+      break
   }
   return
 }

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ if (!result.ok) {
       // re-authenticate before retrying
       break
     default:
-      // network / server / validation — log and skip
+    // network / server / validation — log and skip
   }
   return
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -24,6 +24,7 @@ export type {
   RequestStartEvent,
   SettingManager,
   SyncCallback,
+  TransportConfig,
 } from './types.ts'
 
 export { BaseAPI } from './base.ts'

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -321,7 +321,7 @@ export type SyncCallback = (params?: {
  * {@link HttpClient} instance — the SDK either reuses your wired client
  * (with its own dispatcher, headers, timeout) or builds a fetch-backed
  * default whose timeout you can tweak via `timeoutMs`.
- * @internal
+ * @category Configuration
  */
 export type TransportConfig =
   | HttpClient

--- a/src/http/errors.ts
+++ b/src/http/errors.ts
@@ -1,6 +1,6 @@
 /**
  * Snapshot of the request that triggered an {@link HttpError}.
- * @internal
+ * @category HTTP
  */
 export interface HttpErrorRequestConfig {
   readonly data?: unknown

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -3,6 +3,7 @@ export type {
   HttpRequestConfig,
   HttpResponse,
 } from './client.ts'
+export type { HttpErrorRequestConfig } from './errors.ts'
 
 export { HttpClient, readHeaders } from './client.ts'
 export { HttpError, isHttpError } from './errors.ts'

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,6 +148,7 @@ export {
   type RequestStartEvent,
   type SettingManager,
   type SyncCallback,
+  type TransportConfig,
   ClassicAPI,
   HomeAPI,
 } from './api/index.ts'
@@ -253,10 +254,12 @@ export {
 } from './facades/index.ts'
 export {
   type HttpClientConfig,
+  type HttpErrorRequestConfig,
   type HttpRequestConfig,
   type HttpResponse,
   HttpClient,
   HttpError,
+  HttpStatus,
   isHttpError,
 } from './http/index.ts'
 export {

--- a/typedoc.config.js
+++ b/typedoc.config.js
@@ -31,14 +31,17 @@ const config = {
   hostedBaseUrl: 'https://olivierzal.github.io/melcloud-api/',
   includeVersion: true,
   intentionallyNotExported: [
-    // Internal infrastructure leaked through public type signatures
-    // (also tagged `@internal` in source).
+    // Type-level machinery behind published aliases — consumers name
+    // the alias (`ClassicModel`, the branded ids, the per-type data
+    // aliases), never the helper; the id brand stays unnameable so ids
+    // cannot be minted outside the SDK.
     'BaseModel',
     'Brand',
     'DeviceDataMapping',
+    // Parameters of SDK-internal wiring (facade construction, registry
+    // sync, the update decorator) that consumers never call; tagged
+    // `@internal` in source.
     'HomeAtaFacadeResolver',
-    'HttpErrorRequestConfig',
-    'TransportConfig',
     'TypedHomeDeviceData',
     'UpdatePatchKind',
   ],


### PR DESCRIPTION
Surface-parity pass with heatzy-api, plus the repo chores.

**Published** — `HttpStatus`, `HttpErrorRequestConfig` (`@internal` dropped, exported through `http/index.ts`) and `TransportConfig` (`@internal` dropped) from the root barrel: all three are reachable from public members (`HttpError.config`, `BaseAPIConfig.transport`, status narrowing on `error.response.status`), so consumers can now name what they already hold. CHANGELOG `[Unreleased]` extended (additions, non-breaking).

**Typedoc ledger audited empirically** (list stripped, warnings collected): the six remaining `intentionallyNotExported` entries are all live and deliberate — `BaseModel`/`Brand`/`DeviceDataMapping` are type machinery behind published aliases (consumers name `ClassicModel`, the branded ids, the per-type data aliases; the brand stays unnameable so ids cannot be minted outside the SDK), and `HomeAtaFacadeResolver`/`TypedHomeDeviceData`/`UpdatePatchKind` are parameters of SDK-internal wiring tagged `@internal`. The ledger comment now says which is which. `npm run docs`: 0 warnings.

**Chores** — `/README.md` un-ignored from prettier: the earlier zero-diff measurement was an artifact of the ignore itself; unignored, the real drift was one comment indent inside a TS code fence, normalized here. The emptied `.prettierignore` is deleted. `.vscode/settings.json`: `typescript.native-preview.tsdk` → `js/ts.tsdk.path` (deprecation notice), re-sorted per json/sort-keys.

**Mirror probe (read-clamp vs raw-write, heatzy-api's Glow asymmetry)** — no counterpart found: this SDK clamps on WRITE (`#clampSetTemperature` ATA, `#clampSetpoints` ATW, `clampFrostProtection`) and reads the raw wire truth, so the write-35-read-30 round-trip lie cannot occur. Classic writes are neither read- nor write-clamped (symmetric raw, bounded by the consumer manifest UI) — no asymmetry either.

Suite: format, lint, typecheck, coverage 100 %, typedoc (0 warnings), publint — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3