### PR TITLE
docs: pin the whole-codebase zero-duplication standard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,10 +194,12 @@ is on: no runtime enums, no parameter properties, no runtime namespaces.
   not — verify claims against sources before acting either way. Resolve
   the thread once settled; none left dangling.
 - SonarCloud must be spotless for a PR to merge: quality gate green,
-  zero open issues on its analysis, and 100 % coverage (within the
-  exclusions `sonar-project.properties` declares). A Sonar finding is
-  handled like a lint error — the code adapts, or the divergence is
-  settled as a documented verdict — never merged over.
+  zero open issues on its analysis, 100 % coverage (within the
+  exclusions `sonar-project.properties` declares), and 0 % duplicated
+  lines on the WHOLE codebase — new and old alike, not just the gate's
+  new-code window. A Sonar finding is handled like a lint error — the
+  code adapts (duplication refactors into a shared module), or the
+  divergence is settled as a documented verdict — never merged over.
 - GitHub merge queue is impossible here: the repo is user-owned and the
   feature is org-only (verified via API — no ruleset payload enables it).
   Dependabot PRs auto-merge via `gh pr merge --auto`; the `merge_group`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,12 +193,16 @@ is on: no runtime enums, no parameter properties, no runtime namespaces.
   change when the point holds, or with a reasoned reply when it does
   not — verify claims against sources before acting either way. Resolve
   the thread once settled; none left dangling.
-- SonarCloud must be spotless for a PR to merge: quality gate green,
-  zero open issues on its analysis, 100 % coverage (within the
-  exclusions `sonar-project.properties` declares), and 0 % duplicated
-  lines on the WHOLE codebase — new and old alike, not just the gate's
-  new-code window. A Sonar finding is handled like a lint error — the
-  code adapts (duplication refactors into a shared module), or the
+- SonarCloud must be spotless for a PR to merge — and the quality gate
+  passing is necessary, NOT sufficient: the free-tier gate tolerates
+  3 % duplication on new code, lets code smells through, and cannot be
+  customized, so the real bar is ours, held in review. That bar is
+  zero on BOTH windows — new code and overall alike: zero open issues
+  of every kind (bugs, code smells, vulnerabilities) across the whole
+  project, 0 % duplicated lines across the whole codebase, and 100 %
+  coverage (within the exclusions `sonar-project.properties`
+  declares). A Sonar finding is handled like a lint error — the code
+  adapts (duplication refactors into a shared module), or the
   divergence is settled as a documented verdict — never merged over.
 - GitHub merge queue is impossible here: the repo is user-owned and the
   feature is org-only (verified via API — no ruleset payload enables it).


### PR DESCRIPTION
Session-cleanup review before the major release. The one change: the SonarCloud doctrine paragraph now states Olivier's standard — 0 % duplicated lines over the WHOLE codebase (new and old alike), duplication refactored into shared modules, never excluded.

Everything else audited and cleared, with evidence:
- **History-narrating comments**: none — every comment the session added to `src/` is in intent/constraint form; the flow-temp shared-bit note states the owner-verified wire fact without narrating the review; the CHANGELOG's "was/no longer" wording is changelog-appropriate.
- **CHANGELOG `[Unreleased]`**: exhaustive against the real three-barrel export diff since v45.1.0 (`/classic` + `/home` + root additions, `NetworkError` removal, facade-interface resolution, predicates removal, both security-adjacent fixes). Internal removals (RateLimitGate members, resilience-barrel trim) are correctly absent — not published surface (`exports`: `.`, `/classic`, `/constants`, `/home`).
- **Session mirrors**: the nested-object redaction test (depth ≥ 2) and the sleep abort-listener detach test (`getEventListeners`) are present and match heatzy-api's final shapes.
- **Ghosts**: all six `intentionallyNotExported` entries alive in source under the two-family rationale; all 15 `tests/helpers.ts` exports have consumers; no orphan config entries.
- **Publish-readiness**: format, lint 0, typecheck, coverage 100 %, typedoc, publint — all green on this branch; nothing blocks the major bump (kept for the release wave).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3