### PR TITLE
chore(release): 46.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [46.0.0] - 2026-08-06
 
 ### Changed
 
@@ -460,7 +460,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
-[unreleased]: https://github.com/OlivierZal/melcloud-api/compare/45.1.0...HEAD
+[46.0.0]: https://github.com/OlivierZal/melcloud-api/compare/45.1.0...46.0.0
 [45.1.0]: https://github.com/OlivierZal/melcloud-api/compare/45.0.2...45.1.0
 [45.0.2]: https://github.com/OlivierZal/melcloud-api/compare/45.0.1...45.0.2
 [45.0.1]: https://github.com/OlivierZal/melcloud-api/compare/45.0.0...45.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "45.1.0",
+  "version": "46.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "45.1.0",
+      "version": "46.0.0",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "45.1.0",
+  "version": "46.0.0",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",


### PR DESCRIPTION
Major release: the round-2 breaking surface (facade interfaces published over classes, `NetworkError` and the Classic type predicates gone, HTTP/transport types published) plus the security fix (nested-object log redaction), the sleep listener leak, the monotonic retry window and the barrel completions — the full ledger is the CHANGELOG's [46.0.0] section, verified line by line against the barrel diff since 45.1.0. Publishing flow: merge, then `gh release create v46.0.0` fires `publish.yml`; the com.melcloud exact-pin adoption PR follows once its working tree frees up (credentials wave in flight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3