### PR TITLE
fix: persist credentials only once the server accepts them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Credentials are persisted only once the server accepts them.** `authenticate()` used to write the attempted username/password to the settings store and wipe the persisted session before the sign-in round-trip, so a mistyped login overwrote the working stored pair and tore down a live session. A rejected or failed attempt now leaves both untouched (the login backoff still arms); on success the session is replaced wholesale — the `doAuthenticate` hooks wipe before storing, so nothing from a previous account survives, including a refresh token the token response happens to omit.
+
 ## [46.0.0] - 2026-08-06
 
 ### Changed
@@ -460,6 +466,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[unreleased]: https://github.com/OlivierZal/melcloud-api/compare/46.0.0...HEAD
 [46.0.0]: https://github.com/OlivierZal/melcloud-api/compare/45.1.0...46.0.0
 [45.1.0]: https://github.com/OlivierZal/melcloud-api/compare/45.0.2...45.1.0
 [45.0.2]: https://github.com/OlivierZal/melcloud-api/compare/45.0.1...45.0.2

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -328,6 +328,14 @@ export abstract class BaseAPI implements Disposable {
    */
   protected abstract clearRegistry(): void
 
+  /**
+   * Subclass hook: one protocol-specific sign-in round-trip. On
+   * success it must replace the persisted session WHOLESALE — wipe via
+   * {@link clearPersistedSession} before storing the fresh artifacts —
+   * so nothing from a previous account (a context, a refresh token the
+   * response happens to omit) survives an accepted login. On failure
+   * it must leave every store untouched and throw.
+   */
   protected abstract doAuthenticate(
     credentials: LoginCredentials,
   ): Promise<void>
@@ -393,21 +401,26 @@ export abstract class BaseAPI implements Disposable {
    *
    * Use {@link resumeSession} for a best-effort restore from
    * persisted credentials that logs + swallows errors.
+   *
+   * Credentials are persisted only once the server accepts them: a
+   * rejected attempt leaves the stored pair and any live session
+   * untouched (the backoff still arms and the error still surfaces).
    * @param credentials - Explicit username/password.
    * @throws {@link AuthenticationError} when the server refuses the credentials.
    */
   public async authenticate(credentials: LoginCredentials): Promise<void> {
     const epoch = this.#logOutEpoch
-    this.applyCredentials(credentials.username, credentials.password)
-    // Explicit login starts from a clean slate — enforced here so no
-    // subclass can forget it (mirrors the post-auth sync below).
-    this.clearPersistedSession()
     try {
       await this.doAuthenticate(credentials)
     } catch (error) {
       this.#armLoginBackoff(error)
       throw error
     }
+    // Only a server-accepted pair reaches the settings store: writing
+    // it earlier would let a mistyped attempt overwrite working
+    // credentials. The session store needs no touch here — the
+    // `doAuthenticate` contract replaces it wholesale on success.
+    this.applyCredentials(credentials.username, credentials.password)
     await this.#finishLogin(epoch)
   }
 
@@ -423,11 +436,12 @@ export abstract class BaseAPI implements Disposable {
    * one registry sync, which exercises the persisted session without
    * touching it — and only if that still leaves us unauthenticated, the
    * best-effort {@link resumeSession} fallback. The order matters:
-   * `resumeSession` goes through {@link authenticate}, which wipes the
-   * persisted session before re-logging in, so probing with it first
-   * would sign out a user whose tokens were merely unexercised (a
-   * boot-time context fetch that lost the network reads unauthenticated
-   * while a perfectly valid refresh token sits in storage).
+   * `resumeSession` runs a full sign-in, which spends a real login
+   * attempt (server-side throttle counters, the local backoff on a
+   * rejection) and replaces a session that may have been merely
+   * unexercised (a boot-time context fetch that lost the network reads
+   * unauthenticated while a perfectly valid refresh token sits in
+   * storage).
    * @returns `true` when a session is usable afterwards.
    */
   public async ensureAuthenticated(): Promise<boolean> {

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -310,9 +310,10 @@ export abstract class BaseAPI implements Disposable {
   /**
    * Subclass hook: clear every persisted session credential (tokens,
    * context keys, expiry — whatever the API persists). Ownership is
-   * deliberately narrow: the base {@link authenticate} template wipes
-   * before an explicit login, the reactive-401 path
-   * ({@link reauthenticate}) wipes after the server rejected the
+   * deliberately narrow: {@link doAuthenticate} wipes on a SUCCESSFUL
+   * explicit login just before storing the fresh artifacts (so a failed
+   * attempt leaves the previous session untouched), the reactive-401
+   * path ({@link reauthenticate}) wipes after the server rejected the
    * credential, and {@link logOut} wipes on an explicit sign-out.
    * Nothing else may clear — in particular the {@link tryReuseSession}
    * probe, where a transient failure is indistinguishable from a

--- a/src/api/classic.ts
+++ b/src/api/classic.ts
@@ -649,8 +649,11 @@ export class ClassicAPI extends BaseAPI implements ClassicAPIAdapter {
           )
         : new AuthenticationError('MELCloud Classic rejected the credentials')
     }
-    // Credentials are already persisted by `authenticate` before this
-    // hook runs; only the session artifacts are stored here.
+    // Wholesale session replacement (the `doAuthenticate` contract):
+    // wipe before storing so no artifact of a previous session
+    // survives; `authenticate` persists the accepted credentials after
+    // this hook returns.
+    this.clearPersistedSession()
     this.contextKey = loginData.ContextKey
     this.expiry = loginData.Expiry
   }

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -697,6 +697,12 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
     request: Parameters<typeof performTokenAuth>[0],
   ): Promise<void> {
     const tokens = await performTokenAuth(request)
+    // Wholesale session replacement (the `doAuthenticate` contract):
+    // wipe before storing so nothing from a previous account survives —
+    // the stale context/user, or a refresh token `#storeTokens` keeps
+    // when the response omits one. The refresh path must NOT wipe: a
+    // renewal extends the same session.
+    this.clearPersistedSession()
     this.#storeTokens(tokens)
   }
 

--- a/tests/unit/base-api.test.ts
+++ b/tests/unit/base-api.test.ts
@@ -1183,9 +1183,9 @@ describe('ensureAuthenticated', () => {
 
     await expect(api.ensureAuthenticated()).resolves.toBe(true)
 
-    // The decisive assertion: authenticate() wipes the persisted session
-    // before logging in, so a session that is merely unexercised must be
-    // restored by the sync alone.
+    // The decisive assertion: a full sign-in spends a real login
+    // attempt and replaces the persisted session, so a session that is
+    // merely unexercised must be restored by the sync alone.
     expect(api.syncRegistryMock).toHaveBeenCalledTimes(1)
     expect(api.doAuthenticateMock).not.toHaveBeenCalled()
     expect(api.clearPersistedSessionMock).not.toHaveBeenCalled()

--- a/tests/unit/classic-api.test.ts
+++ b/tests/unit/classic-api.test.ts
@@ -499,7 +499,9 @@ describe('mELCloud Classic API', () => {
       const isResumed = await api.resumeSession()
 
       expect(isResumed).toBe(false)
-      expect(api.isAuthenticated()).toBe(false)
+      // The failed attempt leaves the live session standing: nothing
+      // is cleared before the server verdict.
+      expect(api.isAuthenticated()).toBe(true)
       expect(logger.error).toHaveBeenCalledWith(
         '[Classic]',
         'Session resume failed:',
@@ -941,10 +943,12 @@ describe('mELCloud Classic API', () => {
       )
     })
 
-    it('clears persisted session when server rejects login', async () => {
+    it('keeps the stored credentials and session when the server rejects a login', async () => {
       const { setSpy, settingManager } = createSettingStore({
         contextKey: 'old-ctx',
         expiry: '2030-12-31T00:00:00',
+        password: 'good-pass',
+        username: 'good-user',
       })
       mockLoginAndList()
       const api = await createApi({ settingManager })
@@ -952,11 +956,33 @@ describe('mELCloud Classic API', () => {
       mockRequest.mockResolvedValueOnce(wrap({ LoginData: null }))
 
       await expect(
-        api.authenticate({ password: 'wrong', username: 'user' }),
+        api.authenticate({ password: 'wrong', username: 'typo-user' }),
       ).rejects.toThrow(AuthenticationError)
 
-      expect(setSpy).toHaveBeenCalledWith('contextKey', '')
-      expect(setSpy).toHaveBeenCalledWith('expiry', '')
+      // A mistyped attempt must neither overwrite the working stored
+      // pair nor wipe the live session — only the backoff persists.
+      expect(settingManager.get('username')).toBe('good-user')
+      expect(settingManager.get('password')).toBe('good-pass')
+      expect(settingManager.get('contextKey')).toBe('old-ctx')
+      expect(setSpy).not.toHaveBeenCalledWith('contextKey', '')
+      expect(setSpy).not.toHaveBeenCalledWith('expiry', '')
+    })
+
+    it('persists the accepted credentials and replaces the session on success', async () => {
+      const { settingManager } = createSettingStore({
+        contextKey: 'old-ctx',
+        expiry: '2020-01-01T00:00:00',
+        password: 'old-pass',
+        username: 'old-user',
+      })
+      mockLoginAndList('new-ctx', '2030-12-31T00:00:00')
+      const api = await createApi({ settingManager })
+
+      await api.authenticate({ password: 'new-pass', username: 'new-user' })
+
+      expect(settingManager.get('username')).toBe('new-user')
+      expect(settingManager.get('password')).toBe('new-pass')
+      expect(settingManager.get('contextKey')).toBe('new-ctx')
     })
 
     it('retries with re-authentication on 401', async () => {

--- a/tests/unit/home-api.test.ts
+++ b/tests/unit/home-api.test.ts
@@ -471,7 +471,7 @@ describe('melcloud home API', () => {
       ).rejects.toThrow(AuthenticationError)
     })
 
-    it('should clear user state on re-authentication', async () => {
+    it('should keep the user state when a re-authentication attempt fails', async () => {
       setupSuccessfulLogin()
       const api = await createApi()
 
@@ -483,7 +483,10 @@ describe('melcloud home API', () => {
         api.authenticate({ password: 'wrong', username: 'u@t.com' }),
       ).rejects.toThrow('network')
 
-      expect(api.user).toBeNull()
+      // Nothing is persisted or cleared before the server verdict, so
+      // a failed attempt leaves the live session and its context whole.
+      expect(api.user).not.toBeNull()
+      expect(api.isAuthenticated()).toBe(true)
     })
 
     it('should re-authenticate with new credentials', async () => {
@@ -535,6 +538,20 @@ describe('melcloud home API', () => {
   })
 
   describe('user retrieval', () => {
+    // The Home mirror of Classic's "no context key header for login
+    // path": an instance with no session at all dispatches bare.
+    it('should send no bearer header before any session exists', async () => {
+      const { settingManager } = createSettingStore({})
+      const api = await createFromPersistedStore(settingManager)
+      mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
+
+      await api.getUser()
+
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ headers: {}, url: '/context' }),
+      )
+    })
+
     it('should return the user on success', async () => {
       setupSuccessfulLogin()
       const api = await createApi()


### PR DESCRIPTION
Olivier's on-device report, root-caused to a defect predating this session (the ordering dates back to the `BaseAPI` factoring): `authenticate()` persisted the attempted username/password and wiped the persisted session BEFORE the sign-in round-trip, so a mistyped login overwrote the working stored pair and tore down a live session.

**One deviation from the planned design, forced by verification**: moving `clearPersistedSession()` after `doAuthenticate` as planned would have wiped the session the hooks just stored — both `doAuthenticate` implementations persist the fresh artifacts themselves (Classic `contextKey`/`expiry`, Home via `#storeTokens`). The wholesale replacement is therefore now the HOOK's contract (documented on the abstract): wipe via `clearPersistedSession` immediately before storing, on success only. This also closes a cross-account hole the old pre-clear used to cover: `#storeTokens` keeps the previous refresh token when a token response omits one, so without the in-hook wipe a fresh login could inherit the prior account's refresh token. The Home refresh path deliberately does not wipe — a renewal extends the same session.

Failure now leaves everything untouched (backoff still arms, error still surfaces); `ensureAuthenticated`'s probe-first rationale is restated in its still-true form (a full sign-in spends a real login attempt and replaces a reusable session). Three old-order test pins rewritten to the new contract, a success pin added, plus the Home mirror of Classic's bare-header pin (the old pre-clear was what exercised that branch) — **mutation-verified: the three rewritten pins fail under the old ordering**, including the exact reported scenario (good stored pair + mistyped attempt ⇒ store keeps the good pair). CHANGELOG `[Unreleased]` reborn with the entry.

heatzy-api carries the same shape and needs the mirror fix (sibling-probe doctrine) — separate wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3