### PR TITLE
chore(release): 46.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [46.0.1] - 2026-08-06
 
 ### Fixed
 
@@ -466,7 +466,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
-[unreleased]: https://github.com/OlivierZal/melcloud-api/compare/46.0.0...HEAD
+[46.0.1]: https://github.com/OlivierZal/melcloud-api/compare/46.0.0...46.0.1
 [46.0.0]: https://github.com/OlivierZal/melcloud-api/compare/45.1.0...46.0.0
 [45.1.0]: https://github.com/OlivierZal/melcloud-api/compare/45.0.2...45.1.0
 [45.0.2]: https://github.com/OlivierZal/melcloud-api/compare/45.0.1...45.0.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "46.0.0",
+  "version": "46.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "46.0.0",
+      "version": "46.0.1",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "46.0.0",
+  "version": "46.0.1",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",


### PR DESCRIPTION
Patch: credentials are persisted only once the server accepts them — a failed explicit login leaves the stored pair and the persisted session untouched (Olivier's on-device report), and the wholesale session replacement is now the documented `doAuthenticate` hook contract, closing the cross-account refresh-token hole in passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3