### PR TITLE
test: give every honest shape its type and document the one breach

### DIFF
--- a/tests/contracts/holiday-mode-state.test.ts
+++ b/tests/contracts/holiday-mode-state.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClassicAPIAdapter } from '../../src/api/classic-types.ts'
 import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
@@ -14,11 +14,12 @@ import {
   classicHolidayModeResponse,
   createMockClassicApi,
 } from '../classic-fixtures.ts'
-import { cast, defined, mock, okValue } from '../helpers.ts'
+import { defined, mock, okValue } from '../helpers.ts'
 import {
   homeAtwDevice,
   homeDevice,
   homeTestRegistry,
+  resetHomeDevices,
 } from '../home-fixtures.ts'
 
 /**
@@ -72,6 +73,8 @@ const describeHolidayModeStateContract = (
   ) => HolidayModeState | Promise<HolidayModeState | null> | null,
 ): void => {
   describe(`holidayModeState — ${name}`, () => {
+    beforeEach(resetHomeDevices)
+
     it.each(CASES)('round-trips a $label unchanged', async ({ state }) => {
       await expect(Promise.resolve(read(state))).resolves.toStrictEqual(state)
     })
@@ -112,7 +115,7 @@ describeHolidayModeStateContract('Classic zone', async (state) =>
 )
 
 const homeApi = (): HomeAPIAdapter =>
-  mock<HomeAPIAdapter>({ registry: cast(homeTestRegistry) })
+  mock<HomeAPIAdapter>({ registry: homeTestRegistry })
 
 const toHomeWire = (
   state: BoundedWindow | null,

--- a/tests/contracts/is-available.test.ts
+++ b/tests/contracts/is-available.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
 import { ClassicDeviceType } from '../../src/constants.ts'
@@ -16,8 +16,13 @@ import {
   classicFloorData,
   createMockClassicApi,
 } from '../classic-fixtures.ts'
-import { cast, defined, mock } from '../helpers.ts'
-import { homeDevice, homeTestRegistry } from '../home-fixtures.ts'
+import { defined, mock } from '../helpers.ts'
+import {
+  homeDevice,
+  homeTestRegistry,
+  pruneHomeDevice,
+  resetHomeDevices,
+} from '../home-fixtures.ts'
 
 // `isAvailable` answers one question on both dialects — has this unit
 // gone quiet for longer than the stale window? — from two different
@@ -52,6 +57,8 @@ const describeIsAvailableContract = (
   readPruned: () => boolean,
 ): void => {
   describe(`isAvailable — ${name}`, () => {
+    beforeEach(resetHomeDevices)
+
     it.each(CASES)(
       'reads a unit $label as isAvailable=$isAvailable',
       ({ isAvailable, silentHours }) => {
@@ -105,7 +112,7 @@ describeIsAvailableContract(
 )
 
 const homeApi = (): HomeAPIAdapter =>
-  mock<HomeAPIAdapter>({ registry: cast(homeTestRegistry) })
+  mock<HomeAPIAdapter>({ registry: homeTestRegistry })
 
 // Home expresses silence as a disconnection streak, so the clock is
 // moved rather than the payload; `isConnected` stays true for a unit
@@ -138,7 +145,7 @@ describeIsAvailableContract(
       homeApi(),
       homeDevice({ id: 'contract-available-pruned' }),
     )
-    homeTestRegistry.delete('contract-available-pruned')
+    pruneHomeDevice('contract-available-pruned')
     return facade.isAvailable
   },
 )

--- a/tests/contracts/no-changes.test.ts
+++ b/tests/contracts/no-changes.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClassicAPIAdapter } from '../../src/api/classic-types.ts'
 import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
@@ -16,7 +16,11 @@ import {
   createMockClassicApi,
 } from '../classic-fixtures.ts'
 import { cast, defined, mock } from '../helpers.ts'
-import { homeDevice, homeTestRegistry } from '../home-fixtures.ts'
+import {
+  homeDevice,
+  homeTestRegistry,
+  resetHomeDevices,
+} from '../home-fixtures.ts'
 
 // `updateValues` answers one question on both dialects — is there
 // anything to send? — and must answer it *before* the wire. A
@@ -63,6 +67,8 @@ const describeNoChangesContract = (
   attempt: (kind: 'realChange' | NoOpKind) => Attempt,
 ): void => {
   describe(`updateValues — ${name}`, () => {
+    beforeEach(resetHomeDevices)
+
     it.each(CASES)('refuses $label with NoChangesError', async ({ kind }) => {
       await expect(attempt(kind).write()).rejects.toThrow(NoChangesError)
     })
@@ -128,10 +134,7 @@ describeNoChangesContract('Home ATA device', (kind) => {
   const updateValues = vi
     .fn<HomeAPIAdapter['updateValues']>()
     .mockResolvedValue()
-  const api = mock<HomeAPIAdapter>({
-    registry: cast(homeTestRegistry),
-    updateValues,
-  })
+  const api = mock<HomeAPIAdapter>({ registry: homeTestRegistry, updateValues })
   const facade = new HomeDeviceAtaFacade(
     api,
     homeDevice({ id: `contract-no-changes-${kind}` }),

--- a/tests/contracts/protection-state.test.ts
+++ b/tests/contracts/protection-state.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClassicAPIAdapter } from '../../src/api/classic-types.ts'
 import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
@@ -14,11 +14,12 @@ import {
   classicFrostProtectionResponse,
   createMockClassicApi,
 } from '../classic-fixtures.ts'
-import { cast, defined, mock, okValue } from '../helpers.ts'
+import { defined, mock, okValue } from '../helpers.ts'
 import {
   homeAtwDevice,
   homeDevice,
   homeTestRegistry,
+  resetHomeDevices,
 } from '../home-fixtures.ts'
 
 // The neutral protection state is the same contract on both dialects, so
@@ -50,6 +51,8 @@ const describeProtectionStateContract = (
   ) => Promise<ProtectionState | null> | ProtectionState | null,
 ): void => {
   describe(`protectionState — ${name}`, () => {
+    beforeEach(resetHomeDevices)
+
     it.each(CASES)('round-trips a $label unchanged', async ({ state }) => {
       await expect(Promise.resolve(read(state))).resolves.toStrictEqual(state)
     })
@@ -87,7 +90,7 @@ describeProtectionStateContract('Classic zone', async (state) => {
 })
 
 const homeApi = (): HomeAPIAdapter =>
-  mock<HomeAPIAdapter>({ registry: cast(homeTestRegistry) })
+  mock<HomeAPIAdapter>({ registry: homeTestRegistry })
 
 const toHomeWire = (
   state: ProtectionState | null,
@@ -115,6 +118,8 @@ describeProtectionStateContract('Home ATW device', (state) => {
 })
 
 describe('protectionState — overheat shares the shape', () => {
+  beforeEach(resetHomeDevices)
+
   it('reads the overheat descriptor through the same contract', () => {
     const state = { isEnabled: true, max: 37, min: 35 }
     const facade = new HomeDeviceAtaFacade(

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -5,6 +5,13 @@ import type { Result } from '../src/types/index.ts'
 import { HttpClient, HttpError } from '../src/http/index.ts'
 import { Temporal } from '../src/temporal.ts'
 
+// Deliberate type-breach boundary — and the suite's only one: call
+// sites hand over values the compiled types rightly refuse (wire
+// payloads carrying fields the schema forbids, partial doubles
+// standing in for rich wire records) because that refusal is the
+// behavior under test. Prefer an honest shape where one exists
+// (`mock`, a typed `vi.fn` signature, a zod parse); reach for `cast`
+// only when the type error is the point.
 export function cast(value: unknown): never
 export function cast(value: unknown): unknown {
   return value

--- a/tests/home-fixtures.ts
+++ b/tests/home-fixtures.ts
@@ -1,4 +1,7 @@
-import type { TypedHomeDeviceData } from '../src/entities/home-registry.ts'
+import type {
+  HomeRegistry,
+  TypedHomeDeviceData,
+} from '../src/entities/home-registry.ts'
 import type {
   HomeAtaDeviceCapabilities,
   HomeAtaDeviceData,
@@ -12,7 +15,7 @@ import type {
 } from '../src/types/index.ts'
 import { HomeDeviceType } from '../src/constants.ts'
 import { HomeDevice } from '../src/entities/home-device.ts'
-import { mock } from './helpers.ts'
+import { cast, mock } from './helpers.ts'
 
 // Mid-range RSSI so derived signal-quality assertions land in a
 // predictable band without special-casing weak/strong values.
@@ -103,11 +106,30 @@ interface HomeDeviceFixtureOptions {
 // the facade-under-test's own device).
 const registeredHomeDevices = new Map<string, HomeDevice>()
 
-export const homeTestRegistry = {
-  delete: (id: string): boolean => registeredHomeDevices.delete(id),
+// Vitest isolates module state per FILE; within a file, entries would
+// otherwise accumulate across tests and an id reused by a later test
+// could resolve an earlier test's device. Every consumer builds its
+// devices inside test bodies and opens its describe with
+// `beforeEach(resetHomeDevices)`, keeping each test's registrations to
+// itself.
+export const resetHomeDevices = (): void => {
+  registeredHomeDevices.clear()
+}
+
+// Fixture-side control: drop a registered device so availability tests
+// can model a pruned id — pruning is the fixture's affair, not part of
+// the registry surface the facades consume.
+export const pruneHomeDevice = (id: string): boolean =>
+  registeredHomeDevices.delete(id)
+
+// The double implements exactly the resolution slice the facades under
+// test exercise (`getById`); the `cast` is this module's single
+// widening boundary to the adapter's `HomeRegistry` — extend the
+// double rather than widening a call site.
+export const homeTestRegistry: HomeRegistry = cast({
   getById: (id: string): HomeDevice | undefined =>
     registeredHomeDevices.get(id),
-}
+})
 
 const registerHomeDevice = <T extends HomeDevice>(device: T): T => {
   registeredHomeDevices.set(device.id, device)

--- a/tests/unit/decorators.test.ts
+++ b/tests/unit/decorators.test.ts
@@ -129,15 +129,13 @@ const setupFetchDevices = (
   options?: Parameters<typeof fetchDevices>[0],
 ): {
   fetchMock: ReturnType<typeof vi.fn<ClassicAPIAdapter['fetch']>>
-  target: ReturnType<typeof vi.fn<(...args: unknown[]) => Promise<never>>>
-  invoke: () => Promise<void>
+  target: ReturnType<typeof vi.fn<(...args: unknown[]) => Promise<unknown>>>
+  invoke: () => Promise<unknown>
 } => {
-  const fetchMock = vi
-    .fn<ClassicAPIAdapter['fetch']>()
-    .mockResolvedValue(cast([]))
+  const fetchMock = vi.fn<ClassicAPIAdapter['fetch']>().mockResolvedValue([])
   const target = vi
-    .fn<(...args: unknown[]) => Promise<never>>()
-    .mockResolvedValue(cast('result'))
+    .fn<(...args: unknown[]) => Promise<unknown>>()
+    .mockResolvedValue('result')
   const decorated = fetchDevices(options)(
     target,
     mock<ClassMethodDecoratorContext>(),
@@ -176,12 +174,10 @@ describe(fetchDevices, () => {
 
   it('prefers syncRegistry() over api.fetch() when both are exposed', async () => {
     const syncRegistry = vi.fn<() => Promise<void>>().mockResolvedValue()
-    const fetchMock = vi
-      .fn<ClassicAPIAdapter['fetch']>()
-      .mockResolvedValue(cast([]))
+    const fetchMock = vi.fn<ClassicAPIAdapter['fetch']>().mockResolvedValue([])
     const target = vi
-      .fn<(...args: unknown[]) => Promise<never>>()
-      .mockResolvedValue(cast('result'))
+      .fn<(...args: unknown[]) => Promise<unknown>>()
+      .mockResolvedValue('result')
     const decorated = fetchDevices({ when: 'after' })(
       target,
       mock<ClassMethodDecoratorContext>(),
@@ -198,8 +194,8 @@ describe(fetchDevices, () => {
 
   it('throws TypeError when host exposes neither syncRegistry nor api.fetch (when=before)', async () => {
     const target = vi
-      .fn<(...args: unknown[]) => Promise<never>>()
-      .mockResolvedValue(cast('result'))
+      .fn<(...args: unknown[]) => Promise<unknown>>()
+      .mockResolvedValue('result')
     const decorated = fetchDevices({ when: 'before' })(
       target,
       mock<ClassMethodDecoratorContext>(),
@@ -212,8 +208,8 @@ describe(fetchDevices, () => {
   it('logs and swallows when host exposes neither (when=after)', async () => {
     const logError = vi.fn<(...args: unknown[]) => void>()
     const target = vi
-      .fn<(...args: unknown[]) => Promise<never>>()
-      .mockResolvedValue(cast('result'))
+      .fn<(...args: unknown[]) => Promise<unknown>>()
+      .mockResolvedValue('result')
     const decorated = fetchDevices({ when: 'after' })(
       target,
       mock<ClassMethodDecoratorContext>(),
@@ -232,8 +228,8 @@ describe(fetchDevices, () => {
 
   it('logs via logger.error when when=after and sync throws', async () => {
     const target = vi
-      .fn<(...args: unknown[]) => Promise<never>>()
-      .mockResolvedValue(cast('result'))
+      .fn<(...args: unknown[]) => Promise<unknown>>()
+      .mockResolvedValue('result')
     const syncRegistry = vi
       .fn<() => Promise<void>>()
       .mockRejectedValue(new Error('sync boom'))
@@ -260,8 +256,8 @@ describe(syncDevices, () => {
   it('calls notifySync after the target method', async () => {
     const notifySync = vi.fn<SyncCallback>().mockResolvedValue()
     const target = vi
-      .fn<(...args: unknown[]) => Promise<never>>()
-      .mockResolvedValue(cast('result'))
+      .fn<(...args: unknown[]) => Promise<unknown>>()
+      .mockResolvedValue('result')
     const decorated = syncDevices()(target, mock<ClassMethodDecoratorContext>())
     const context = { notifySync }
     const result = await decorated.call(context)
@@ -273,8 +269,8 @@ describe(syncDevices, () => {
   it('passes type to notifySync', async () => {
     const notifySync = vi.fn<SyncCallback>().mockResolvedValue()
     const target = vi
-      .fn<(...args: unknown[]) => Promise<never>>()
-      .mockResolvedValue(cast('result'))
+      .fn<(...args: unknown[]) => Promise<unknown>>()
+      .mockResolvedValue('result')
     const decorated = syncDevices({ type: ClassicDeviceType.Ata })(
       target,
       mock<ClassMethodDecoratorContext>(),
@@ -287,8 +283,8 @@ describe(syncDevices, () => {
 
   it('works when notifySync is undefined', async () => {
     const target = vi
-      .fn<(...args: unknown[]) => Promise<never>>()
-      .mockResolvedValue(cast('result'))
+      .fn<(...args: unknown[]) => Promise<unknown>>()
+      .mockResolvedValue('result')
     const decorated = syncDevices()(target, mock<ClassMethodDecoratorContext>())
     const context = {}
     const result = await decorated.call(context)

--- a/tests/unit/home-device-ata-facade.test.ts
+++ b/tests/unit/home-device-ata-facade.test.ts
@@ -10,6 +10,8 @@ import {
   homeDevice,
   homeReportPoint,
   homeTestRegistry,
+  pruneHomeDevice,
+  resetHomeDevices,
 } from '../home-fixtures.ts'
 
 const createModel = (
@@ -32,11 +34,13 @@ const createApi = (overrides: Partial<HomeAPIAdapter> = {}): HomeAPIAdapter =>
     getErrorLog: vi.fn<HomeAPIAdapter['getErrorLog']>(),
     getSignal: vi.fn<HomeAPIAdapter['getSignal']>(),
     getTemperatures: vi.fn<HomeAPIAdapter['getTemperatures']>(),
-    registry: cast(homeTestRegistry),
+    registry: homeTestRegistry,
     updateValues: vi.fn<HomeAPIAdapter['updateValues']>().mockResolvedValue(),
   })
 
 describe('home device ata facade', () => {
+  beforeEach(resetHomeDevices)
+
   describe('protection accessors', () => {
     it('exposes frost protection and holiday mode from context', () => {
       const frostProtection = { active: false, enabled: true, max: 12, min: 6 }
@@ -123,7 +127,7 @@ describe('home device ata facade', () => {
 
       expect(facade.exists).toBe(true)
 
-      homeTestRegistry.delete('device-gone')
+      pruneHomeDevice('device-gone')
 
       expect(facade.exists).toBe(false)
       expect(facade.id).toBe('device-gone')

--- a/tests/unit/home-device-atw-facade.test.ts
+++ b/tests/unit/home-device-atw-facade.test.ts
@@ -10,6 +10,7 @@ import {
   homeAtwDevice,
   homeReportPoint,
   homeTestRegistry,
+  resetHomeDevices,
 } from '../home-fixtures.ts'
 
 const createModel = (
@@ -38,11 +39,13 @@ const createApi = (overrides: Partial<HomeAPIAdapter> = {}): HomeAPIAdapter =>
     getErrorLog: vi.fn<HomeAPIAdapter['getErrorLog']>(),
     getSignal: vi.fn<HomeAPIAdapter['getSignal']>(),
     getTemperatures: vi.fn<HomeAPIAdapter['getTemperatures']>(),
-    registry: cast(homeTestRegistry),
+    registry: homeTestRegistry,
     updateValues: vi.fn<HomeAPIAdapter['updateValues']>().mockResolvedValue(),
   })
 
 describe('home device atw facade', () => {
+  beforeEach(resetHomeDevices)
+
   describe('normalized modes', () => {
     it.each([
       ['CoolFlowTemperature', 'flow_cool'],

--- a/tests/unit/home-facade-manager.test.ts
+++ b/tests/unit/home-facade-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
 import type { HomeDevice } from '../../src/entities/home-device.ts'
@@ -17,6 +17,7 @@ import {
   homeAtwDevice,
   homeDevice,
   homeTestRegistry,
+  resetHomeDevices,
 } from '../home-fixtures.ts'
 
 const createModel = (): ReturnType<typeof homeDevice> =>
@@ -28,11 +29,13 @@ const createApi = (): HomeAPIAdapter =>
     getErrorLog: vi.fn<HomeAPIAdapter['getErrorLog']>(),
     getSignal: vi.fn<HomeAPIAdapter['getSignal']>(),
     getTemperatures: vi.fn<HomeAPIAdapter['getTemperatures']>(),
-    registry: cast(homeTestRegistry),
+    registry: homeTestRegistry,
     updateValues: vi.fn<HomeAPIAdapter['updateValues']>(),
   })
 
 describe('home facade manager', () => {
+  beforeEach(resetHomeDevices)
+
   it('returns null when no instance is provided', () => {
     const manager = new HomeFacadeManager(createApi())
 

--- a/tests/unit/observability.test.ts
+++ b/tests/unit/observability.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
 
 import { HttpError } from '../../src/http/index.ts'
 import {
@@ -6,7 +7,22 @@ import {
   APICallResponseData,
   createAPICallErrorData,
 } from '../../src/observability/index.ts'
-import { cast } from '../helpers.ts'
+import { defined } from '../helpers.ts'
+
+// `JSON.parse` returns `any`; the suite funnels every log line through
+// zod — the same boundary discipline the library applies to wire
+// payloads — so no parse site needs a cast.
+const jsonRecord = z.record(z.string(), z.unknown())
+
+const parseRecord = (value: string): Record<string, unknown> => {
+  const raw: unknown = JSON.parse(value)
+  return jsonRecord.parse(raw)
+}
+
+const parseRequestData = (value: string): string => {
+  const raw: unknown = JSON.parse(value)
+  return z.object({ requestData: z.string() }).parse(raw).requestData
+}
 
 interface TestRequestConfig {
   data?: unknown
@@ -68,7 +84,7 @@ describe('api call request data', () => {
     const data = new APICallRequestData(
       createConfig({ data: [{ password: 'secret', safe: 'ok' }] }),
     )
-    const parsed: Record<string, unknown> = cast(JSON.parse(data.toString()))
+    const parsed = parseRecord(data.toString())
 
     expect(parsed.requestData).toStrictEqual([
       { password: '******', safe: 'ok' },
@@ -81,7 +97,7 @@ describe('api call request data', () => {
         data: { body: { nested: { password: 'secret' }, safe: 'ok' } },
       }),
     )
-    const parsed: Record<string, unknown> = cast(JSON.parse(data.toString()))
+    const parsed = parseRecord(data.toString())
 
     expect(parsed.requestData).toStrictEqual({
       body: { nested: { password: '******' }, safe: 'ok' },
@@ -90,7 +106,7 @@ describe('api call request data', () => {
 
   it('serializes to JSON with logKeys', () => {
     const data = new APICallRequestData(createConfig())
-    const parsed: Record<string, unknown> = cast(JSON.parse(data.toString()))
+    const parsed = parseRecord(data.toString())
 
     expect(parsed.dataType).toBe('API request')
     expect(parsed.method).toBe('POST')
@@ -142,7 +158,7 @@ describe('api call response data', () => {
 
   it('serializes to JSON with logKeys', () => {
     const data = new APICallResponseData(createResponse(), createConfig())
-    const parsed: Record<string, unknown> = cast(JSON.parse(data.toString()))
+    const parsed = parseRecord(data.toString())
 
     expect(parsed.dataType).toBe('API response')
     expect(parsed.method).toBe('POST')
@@ -153,10 +169,18 @@ describe('api call response data', () => {
   })
 })
 
-const parseLog = (
-  value: string,
-): { headers: Record<string, unknown>; requestData: Record<string, unknown> } =>
-  cast(JSON.parse(value))
+// Request lines carry `requestData`, response lines `headers` — the
+// schema mirrors that division honestly and each site asserts the half
+// it reads is present.
+const logShape = z.object({
+  headers: jsonRecord.optional(),
+  requestData: jsonRecord.optional(),
+})
+
+const parseLog = (value: string): z.infer<typeof logShape> => {
+  const raw: unknown = JSON.parse(value)
+  return logShape.parse(raw)
+}
 
 describe('sensitive data redaction', () => {
   it('redacts credentials in request data', () => {
@@ -164,7 +188,7 @@ describe('sensitive data redaction', () => {
       data: { Email: 'user@example.com', Other: 'visible', Password: 's3cret' },
     })
     const call = new APICallRequestData(config)
-    const { requestData } = parseLog(call.toString())
+    const requestData = defined(parseLog(call.toString()).requestData)
 
     expect(requestData.Email).toBe('******')
     expect(requestData.Password).toBe('******')
@@ -179,7 +203,7 @@ describe('sensitive data redaction', () => {
       },
     })
     const call = new APICallRequestData(config)
-    const { headers } = parseLog(call.toString())
+    const headers = defined(parseLog(call.toString()).headers)
 
     expect(headers['X-MitsContextKey']).toBe('******')
     expect(headers['Content-Type']).toBe('application/json')
@@ -190,7 +214,7 @@ describe('sensitive data redaction', () => {
       headers: { 'set-cookie': ['session=abc123'], 'x-custom': 'visible' },
     })
     const call = new APICallResponseData(response)
-    const { headers } = parseLog(call.toString())
+    const headers = defined(parseLog(call.toString()).headers)
 
     expect(headers['set-cookie']).toBe('******')
     expect(headers['x-custom']).toBe('visible')
@@ -201,7 +225,7 @@ describe('sensitive data redaction', () => {
       data: { password: 'p@ss', username: 'admin' },
     })
     const call = new APICallRequestData(config)
-    const { requestData } = parseLog(call.toString())
+    const requestData = defined(parseLog(call.toString()).requestData)
 
     expect(requestData.password).toBe('******')
     expect(requestData.username).toBe('******')
@@ -210,7 +234,7 @@ describe('sensitive data redaction', () => {
   it('redacts Cookie header in request data', () => {
     const config = createConfig({ headers: { Cookie: 'session=xyz' } })
     const call = new APICallRequestData(config)
-    const { headers } = parseLog(call.toString())
+    const headers = defined(parseLog(call.toString()).headers)
 
     expect(headers.Cookie).toBe('******')
   })
@@ -225,8 +249,7 @@ describe('sensitive data redaction', () => {
       data: 'csrf=tok&password=s3cret&username=user%40example.com&extra=visible',
     })
     const call = new APICallRequestData(config)
-    const parsed: { requestData: string } = cast(JSON.parse(call.toString()))
-    const params = new URLSearchParams(parsed.requestData)
+    const params = new URLSearchParams(parseRequestData(call.toString()))
 
     expect(params.get('password')).toBe('******')
     expect(params.get('username')).toBe('******')
@@ -242,8 +265,7 @@ describe('sensitive data redaction', () => {
       data: 'password=one&password=two&after=kept',
     })
     const call = new APICallRequestData(config)
-    const parsed: { requestData: string } = cast(JSON.parse(call.toString()))
-    const params = new URLSearchParams(parsed.requestData)
+    const params = new URLSearchParams(parseRequestData(call.toString()))
 
     expect(params.getAll('password')).toStrictEqual(['******'])
     expect(params.get('after')).toBe('kept')
@@ -252,17 +274,15 @@ describe('sensitive data redaction', () => {
   it('passes through non-sensitive form-encoded strings unchanged', () => {
     const config = createConfig({ data: 'page=2&limit=50' })
     const call = new APICallRequestData(config)
-    const parsed: { requestData: string } = cast(JSON.parse(call.toString()))
 
-    expect(parsed.requestData).toBe('page=2&limit=50')
+    expect(parseRequestData(call.toString())).toBe('page=2&limit=50')
   })
 
   it('does not mutate plain strings that happen to lack `=`', () => {
     const config = createConfig({ data: 'just a sentence' })
     const call = new APICallRequestData(config)
-    const parsed: { requestData: string } = cast(JSON.parse(call.toString()))
 
-    expect(parsed.requestData).toBe('just a sentence')
+    expect(parseRequestData(call.toString())).toBe('just a sentence')
   })
 })
 
@@ -292,7 +312,7 @@ describe(createAPICallErrorData, () => {
       response: { data: {}, headers: {}, status: 504 },
     })
     const data = createAPICallErrorData(error)
-    const parsed: Record<string, unknown> = cast(JSON.parse(data.toString()))
+    const parsed = parseRecord(data.toString())
 
     expect(parsed.errorMessage).toBe('Timeout')
   })


### PR DESCRIPTION
The three deferred lots from the round-2 backlog, non-breaking by construction (tests and fixtures only — no published surface touched).

**cast() 71 → 45.** Three classes migrated to honest shapes: the seven `registry: cast(homeTestRegistry)` doubles now ride ONE typed fixture boundary (`homeTestRegistry: HomeRegistry`, the single documented cast inside the fixture); the decorator targets are typed `Promise<unknown>` — passthrough is the decorator's contract, so the casts and the `Promise<never>` laundering fall away (the one update-device sentinel keeps `never` + `cast`: feeding a sentinel through the decorator's typed signature is the deliberate breach) — and every `JSON.parse` site in the observability suite funnels through zod, the same boundary discipline the library applies to wire payloads (the schema also exposed an honest fact the old cast hid: request lines carry `requestData`, response lines `headers`). The 45 survivors are one documented class — wire payloads and partial doubles the compiled types rightly refuse, that refusal being the behavior under test — with the verdict written on the helper itself.

**Fixture hygiene.** `registeredHomeDevices` no longer accumulates across tests: every consuming suite opens its describe with `beforeEach(resetHomeDevices)` (vitest already isolates per file; this closes the within-file id-reuse window). Pruning moved off the registry double onto the fixture's own `pruneHomeDevice` — `HomeRegistry` has no `delete`, so the double no longer fakes one.

**`/constants` audit: clean.** The subpath ships `src/constants.ts` itself; a mechanical diff of its 22 exported names against the root barrel block shows full parity, docs categorized — nothing to change.

Flagged for a future major (untouched): none — all three lots landed without touching published surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3