### PR TITLE
ci: disable the npm cache on the publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-node-and-install
         with:
+          cache: none
           registry-url: https://npm.pkg.github.com
           scope: '@olivierzal'
       # Publish the exact tarball we attest.


### PR DESCRIPTION
The setup-node-and-install composite action's own input docs call for `cache: none` on release jobs — a poisoned npm cache is a credential-exfiltration vector where publish tokens live. The three Homey apps already do this; this repo's publish job did not. Raised by the Copilot review thread on homey-kit#2; the configs repo gets the same fix in a follow-up once its in-flight feature PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3