### PR TITLE
ci: support the cache input in the setup composite action

### DIFF
--- a/.github/actions/setup-node-and-install/action.yml
+++ b/.github/actions/setup-node-and-install/action.yml
@@ -1,5 +1,9 @@
-description: Set up Node.js with npm cache and install dependencies with hardened flags. Caller must run actions/checkout first — composite actions cannot reference local files before the repo is checked out.
+description: Set up Node.js and install dependencies with hardened flags. Caller must run actions/checkout first — composite actions cannot reference local files before the repo is checked out.
 inputs:
+  cache:
+    default: npm
+    description: actions/setup-node cache mode. Set to 'none' to disable (release jobs where cache poisoning is a credential-exfiltration concern).
+    required: false
   install:
     default: 'true'
     description: Whether to run `npm ci --ignore-scripts`. Set to 'false' for jobs that only need the source tree (no install).
@@ -19,7 +23,10 @@ runs:
   steps:
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       with:
-        cache: npm
+        # `''` is falsy in expressions, so `cond && '' || x` can never
+        # yield the empty string — the condition must be inverted so
+        # the falsy branch sits after `||`.
+        cache: ${{ inputs.cache != 'none' && inputs.cache || '' }}
         node-version: ${{ inputs.node-version }}
         registry-url: ${{ inputs.registry-url }}
         scope: ${{ inputs.scope }}


### PR DESCRIPTION
Completes #1686: the publish workflow passed `cache: none`, but this repo's local composite action had no `cache` input and hard-coded `cache: npm`, making it a no-op — caught by the Copilot review on heatzy-api#1188 (the twin copy had the same gap, fixed there in the same PR). This ports the family form of the input (com.melcloud/configs/homey-kit already carry it), byte-identical across the two libs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3