### PR TITLE
feat!: rename the label-type and cooling-minimum constants

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -16,17 +16,6 @@ const config: Config[] = defineConfig([
         format: null,
         selector: 'typeProperty',
       },
-      // Constant names of ours that predate the strict core and sit on
-      // the published surface: renaming them breaks consumers, so it is
-      // decided as its own release.
-      {
-        filter: {
-          match: true,
-          regex: '^(cooling_min|day_of_week|month_of_year)$',
-        },
-        format: null,
-        selector: 'objectLiteralProperty',
-      },
       // MELCloud Classic names every field in PascalCase, and the Home
       // report keys its series in UPPER_SNAKE (`HOT_WATER`); both are
       // read and written verbatim. Header names carry hyphens and stay

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -103,9 +103,9 @@ export type ClassicHorizontal =
  * @category Constants
  */
 export const ClassicLabelType = {
-  day_of_week: 4,
+  dayOfWeek: 4,
   month: 2,
-  month_of_year: 3,
+  monthOfYear: 3,
   raw: 1,
   time: 0,
 } as const
@@ -315,7 +315,7 @@ export const ClassicTemperature = {
   /**
    * Minimum target temperature when the device is in a cooling-capable mode.
    */
-  cooling_min: 16,
+  coolingMin: 16,
   /**
    * Maximum target temperature across all modes.
    */

--- a/src/facades/classic-base-device.ts
+++ b/src/facades/classic-base-device.ts
@@ -113,7 +113,7 @@ const toEnergyReportLabels = (
   return {
     labels: labels.map((label) =>
       String(
-        label === 0 && labelType === ClassicLabelType.day_of_week
+        label === 0 && labelType === ClassicLabelType.dayOfWeek
           ? ISO_SUNDAY
           : label,
       ),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -166,7 +166,7 @@ const buildLabelFormatters = (
 ): Record<ClassicLabelType, (label: string) => string> => {
   const formatters = getLabelFormatters(locale)
   return {
-    [ClassicLabelType.day_of_week]: (label) =>
+    [ClassicLabelType.dayOfWeek]: (label) =>
       formatters.dayOfWeek.format(
         new Temporal.PlainDate(DAY_OF_WEEK_BASE_YEAR, 1, Number(label)),
       ),
@@ -174,7 +174,7 @@ const buildLabelFormatters = (
       formatters.month.format(
         new Temporal.PlainDate(MONTH_NAME_BASE_YEAR, Number(label), 1),
       ),
-    [ClassicLabelType.month_of_year]: (label): string => {
+    [ClassicLabelType.monthOfYear]: (label): string => {
       const year = Math.floor(Number(label) / YEAR_MONTH_DIVISOR)
       const month = Number(label) % YEAR_MONTH_DIVISOR
 

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -448,8 +448,8 @@ const ClassicLabelTypeSchema = z.union([
   z.literal(ClassicLabelType.time),
   z.literal(ClassicLabelType.raw),
   z.literal(ClassicLabelType.month),
-  z.literal(ClassicLabelType.month_of_year),
-  z.literal(ClassicLabelType.day_of_week),
+  z.literal(ClassicLabelType.monthOfYear),
+  z.literal(ClassicLabelType.dayOfWeek),
 ])
 
 /**

--- a/tests/unit/utils-extended.test.ts
+++ b/tests/unit/utils-extended.test.ts
@@ -59,11 +59,11 @@ describe.concurrent('formatLabels (via getChartLineOptions)', () => {
     expect(result.labels).toStrictEqual(['12:00', '13:00'])
   })
 
-  it('formats day_of_week labels', () => {
+  it('formats dayOfWeek labels', () => {
     const data = {
       ...baseReportData,
       Labels: ['1', '2', '3'],
-      LabelType: ClassicLabelType.day_of_week,
+      LabelType: ClassicLabelType.dayOfWeek,
     }
     const result = getChartLineOptions(data, {
       legend: ['Series 1'],
@@ -92,11 +92,11 @@ describe.concurrent('formatLabels (via getChartLineOptions)', () => {
     expect(result.labels[2]).toBe('Dec')
   })
 
-  it('formats month_of_year labels', () => {
+  it('formats monthOfYear labels', () => {
     const data = {
       ...baseReportData,
       Labels: ['202401', '202412'],
-      LabelType: ClassicLabelType.month_of_year,
+      LabelType: ClassicLabelType.monthOfYear,
     }
     const result = getChartLineOptions(data, {
       legend: ['Series 1'],


### PR DESCRIPTION
Three published constants carried snake_case names that are **our own vocabulary**, not any wire's — the naming doctrine renames those rather than excusing them, and the 1.3.0 lint adoption could only defer them because they sit on the published surface.

| Before | After |
| --- | --- |
| `ClassicLabelType.day_of_week` | `ClassicLabelType.dayOfWeek` |
| `ClassicLabelType.month_of_year` | `ClassicLabelType.monthOfYear` |
| `ClassicTemperature.cooling_min` | `ClassicTemperature.coolingMin` |

**Breaking**: `cooling_min` is read by com.melcloud's ATA group widget, which adopts the major right after. The eslint overlay drops the narrow entry that kept the three names visible and deletable — its whole purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3