### PR TITLE
chore(release): 47.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "46.0.1",
+  "version": "47.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "46.0.1",
+      "version": "47.0.0",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "46.0.1",
+  "version": "47.0.0",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",


### PR DESCRIPTION
Release 47.0.0 — breaking: three published constants renamed to the strict naming core (`day_of_week` → `dayOfWeek`, `month_of_year` → `monthOfYear`, `cooling_min` → `coolingMin`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3