### PR TITLE
build: adopt configs 1.3.2

### DIFF
--- a/.github/actions/setup-node-and-install/action.yml
+++ b/.github/actions/setup-node-and-install/action.yml
@@ -33,7 +33,7 @@ runs:
         echo "::error::setup-node-and-install: 'npm-token' input is required when 'install' is 'true' (GitHub Packages auth)."
         exit 1
       shell: bash
-    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         # `''` is falsy in expressions, so `cond && '' || x` can never
         # yield the empty string — the condition must be inverted so

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,13 @@ updates:
       actions:
         patterns:
           - '*'
+    # One version covers both @olivierzal/configs channels, and only the
+    # npm one is driven here: a workflow-ref bump on its own would face
+    # the pin check against an npm pin that has not moved, and each of
+    # the two pull requests would block the other. The npm bump carries
+    # the refs along instead.
+    ignore:
+      - dependency-name: OlivierZal/configs
     package-ecosystem: github-actions
     schedule:
       interval: weekly

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
+    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
 name: Audit
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       packages: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
+    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
     with:
       run-docs: true
       run-lint-package: true

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
+    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
 name: claude-code-review
 on:
   pull_request:

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -17,13 +17,23 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
+    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
     with:
       repo-guidance: >-
         Twin discipline: several source and test files here are
         byte-identical twins of heatzy-api's. If your fix touches one,
         say so in a PR comment so the sibling receives the same change —
         the twins must never drift silently.
+
+        Two channels, one version: when the bump is
+        `@olivierzal/configs`, move the reusable-workflow refs under
+        .github/workflows to the tag matching the new npm pin, in the
+        same commit — the pin check fails otherwise. Resolve that tag's
+        commit rather than guessing it, and keep every version comment
+        at the end of its line. If the release changes lint policy —
+        new or stricter rules, a naming default, a runtime floor — stop
+        there and leave the pull request red: each repository
+        classifies its own violations, and that is a human call.
       verify-commands: '`npm run format`, `npm run lint`, `npm run typecheck`, `npm test`, `npm run docs`, and `npm run lint:package`'
 name: Claude Dependabot Fix
 on:

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -6,7 +6,7 @@ jobs:
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
+    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
 name: claude-issue-triage
 on:
   issues:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
+    uses: OlivierZal/configs/.github/workflows/claude.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
 name: claude
 on:
   # No pull_request_review(_comment): Copilot auto-review fires them as a

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: OlivierZal/configs/.github/workflows/dependabot.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
+    uses: OlivierZal/configs/.github/workflows/dependabot.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
 name: dependabot
 on:
   pull_request: {}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ jobs:
       packages: read
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       # The install pulls @olivierzal/configs from GitHub Packages,
@@ -19,8 +19,8 @@ jobs:
           npm-token: ${{ secrets.GITHUB_TOKEN }}
       - run: npm run build
       - run: npm run docs
-      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
-      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: docs
     timeout-minutes: 15
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
     timeout-minutes: 10
 name: Generate & deploy docs
 on:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ jobs:
   pr_title:
     permissions:
       pull-requests: read
-    uses: OlivierZal/configs/.github/workflows/pr-title.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
+    uses: OlivierZal/configs/.github/workflows/pr-title.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
 name: pr-title
 on:
   pull_request:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       packages: write
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-node-and-install
@@ -25,7 +25,7 @@ jobs:
           scope: '@olivierzal'
       # Publish the exact tarball we attest.
       - run: npm pack
-      - uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373
+      - uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: '*.tgz'
       - env:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: OlivierZal/configs/.github/workflows/zizmor.yml@6932d7af8f2c21600bd7dc945062fe1a66d7db26 # v1.3.0
+    uses: OlivierZal/configs/.github/workflows/zizmor.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
 name: zizmor
 on:
   merge_group: {}

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,5 +1,23 @@
+import { namingConventionEntries } from '@olivierzal/configs/eslint'
 import { library } from '@olivierzal/configs/eslint/library'
 import { type Config, defineConfig } from 'eslint/config'
+
+// The layers that speak to MELCloud: the wire types and their zod
+// mirror, the HTTP clients, the facades that read and write those
+// fields, and the maps that translate them. The rest of the library —
+// entities, errors, observability, resilience, the time helpers — is
+// ours alone and takes the strict core.
+const wireSpeakingFiles = [
+  'src/api/**/*.ts',
+  'src/constants.ts',
+  'src/decorators/**/*.ts',
+  'src/enum-mappings.ts',
+  'src/facades/**/*.ts',
+  'src/http/**/*.ts',
+  'src/types/**/*.ts',
+  'src/utils.ts',
+  'src/validation/**/*.ts',
+]
 
 const config: Config[] = defineConfig([
   {
@@ -7,36 +25,54 @@ const config: Config[] = defineConfig([
     // code — outside the lint scope by decision, like the build outputs.
     ignores: ['coverage/', 'dist/', 'docs/', 'scripts/'],
   },
-  ...library({
-    wireNamingEntries: [
-      // Branded types use __brand as a phantom sentinel — universal TS
-      // convention.
-      {
-        filter: { match: true, regex: '^__brand$' },
-        format: null,
-        selector: 'typeProperty',
-      },
-      // MELCloud Classic names every field in PascalCase, and the Home
-      // report keys its series in UPPER_SNAKE (`HOT_WATER`); both are
-      // read and written verbatim. Header names carry hyphens and stay
-      // with the quoted-key exemption instead.
-      {
-        filter: { match: true, regex: '^[A-Z][A-Za-z0-9_]*$' },
-        format: ['PascalCase', 'UPPER_CASE'],
-        selector: ['objectLiteralProperty', 'typeProperty'],
-      },
-      // Three snake_case vocabularies meet here, none of them ours: the
-      // OAuth 2.0/PKCE parameters (`grant_type`, `code_verifier`), the
-      // Home wire fields (`outside_temperature`), and the Homey
-      // capability enum values the app passes straight through
-      // (`very_fast`, `flow_cool`).
-      {
-        filter: { match: true, regex: '^[a-z][a-z0-9]*(_[a-z0-9]+)+$' },
-        format: null,
-        selector: ['objectLiteralProperty', 'typeProperty'],
-      },
-    ],
-  }),
+  ...library(),
+  {
+    // These vocabularies are what the protocols impose on the modules
+    // that speak them, so they are granted there and nowhere else: a
+    // name of our own invention outside this list meets the core and
+    // is caught, instead of being waved through by a shape it merely
+    // resembles.
+    files: wireSpeakingFiles,
+    rules: {
+      '@typescript-eslint/naming-convention': [
+        'error',
+        ...namingConventionEntries({
+          // Mirrors the library preset's own filter: `device` types
+          // include `false` as a sentinel without being a flag.
+          booleanFilter: { match: false, regex: '^device$' },
+          extraEntries: [
+            // Branded types use __brand as a phantom sentinel —
+            // universal TS convention.
+            {
+              filter: { match: true, regex: '^__brand$' },
+              format: null,
+              selector: 'typeProperty',
+            },
+            // MELCloud Classic names every field in PascalCase, and the
+            // Home report keys its series in UPPER_SNAKE (`HOT_WATER`);
+            // both are read and written verbatim. Header names carry
+            // hyphens and stay with the quoted-key exemption instead.
+            {
+              filter: { match: true, regex: '^[A-Z][A-Za-z0-9_]*$' },
+              format: ['PascalCase', 'UPPER_CASE'],
+              selector: ['objectLiteralProperty', 'typeProperty'],
+            },
+            // Three snake_case vocabularies meet here, none of them
+            // ours: the OAuth 2.0/PKCE parameters (`grant_type`,
+            // `code_verifier`), the Home wire fields
+            // (`outside_temperature`), and the Homey capability enum
+            // values the app passes straight through (`very_fast`,
+            // `flow_cool`).
+            {
+              filter: { match: true, regex: '^[a-z][a-z0-9]*(_[a-z0-9]+)+$' },
+              format: null,
+              selector: ['objectLiteralProperty', 'typeProperty'],
+            },
+          ],
+        }),
+      ],
+    },
+  },
   {
     // Bitfield enumeration: `EffectiveFlags` hex values are the file's
     // entire purpose. `no-magic-numbers` would flag every entry, and

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@olivierzal/configs": "1.3.0",
+        "@olivierzal/configs": "1.3.2",
         "@types/node": "^26.1.1",
         "@typescript/native": "npm:typescript@^7.0.2",
         "@vitest/coverage-v8": "^4.1.10",
@@ -586,9 +586,9 @@
       }
     },
     "node_modules/@olivierzal/configs": {
-      "version": "1.3.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.3.0/63ba02ae09575a48d7b0f9a88126384fa6e3ba25",
-      "integrity": "sha512-sM500YwFYAcME61eQ9Vvh5c1Aqued7DnjSeNF+qlATcq5wzbp5ZMmWFaPhJT1Lg67yiU/3a41SZgvu64OGqfzw==",
+      "version": "1.3.2",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.3.2/94ed0534c00c3e137c73e8d6847b05ed8bfb16d5",
+      "integrity": "sha512-4oVJhxYUXt/14UBxXBxexDhtiqxZXK3RDEy7l12H2vFJ6QTcVKk3NHG1a7cQuAC24ykb6K4PcoHjQJQboqtEDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@olivierzal/configs": "1.3.0",
+    "@olivierzal/configs": "1.3.2",
     "@types/node": "^26.1.1",
     "@typescript/native": "npm:typescript@^7.0.2",
     "@vitest/coverage-v8": "^4.1.10",


### PR DESCRIPTION
Exact-pin bump 1.3.1 → 1.3.2 with the workflow refs moved to the matching tag in the same commit — 1.3.2 ships a pin check that fails on any SHA-pinned `uses:` without a version comment, so the comments land here too, each tag resolved against its upstream rather than assumed.

Dependabot stops proposing the workflow-ref side of `@olivierzal/configs`: with the check enforcing that both channels name one version, a lone ref bump and a lone npm bump would each be red and block the other. The npm bump now carries the refs, which is what the enriched `repo-guidance` tells the fixer to do — and to stop, leaving the PR red, when the release changes lint policy.

The three wire naming exemptions become file-scoped. They were repo-wide, so any PascalCase or snake_case name of our own invention passed anywhere — the hole that let `cooling_min` and `day_of_week` sit unnoticed until 1.3.0. They now cover the layers that speak to MELCloud (wire types and their zod mirror, the HTTP clients, the facades, the translation maps); the transport-agnostic core — entities, errors, observability, resilience, the time helpers — takes the strict core back, as does any module added later. Proven by mutation: `my_own_key` and `MyOwnField` in `src/entities/base.ts` are both rejected under the new scope and were both accepted under the old one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3