### PR TITLE
build: adopt configs 1.4.0

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
+    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
 name: Audit
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       packages: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
+    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
     with:
       run-docs: true
       run-lint-package: true

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
+    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
 name: claude-code-review
 on:
   pull_request:

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
+    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
     with:
       repo-guidance: >-
         Twin discipline: several source and test files here are

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -6,7 +6,7 @@ jobs:
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
+    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
 name: claude-issue-triage
 on:
   issues:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
+    uses: OlivierZal/configs/.github/workflows/claude.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
 name: claude
 on:
   # No pull_request_review(_comment): Copilot auto-review fires them as a

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: OlivierZal/configs/.github/workflows/dependabot.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
+    uses: OlivierZal/configs/.github/workflows/dependabot.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
 name: dependabot
 on:
   pull_request: {}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ jobs:
   pr_title:
     permissions:
       pull-requests: read
-    uses: OlivierZal/configs/.github/workflows/pr-title.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
+    uses: OlivierZal/configs/.github/workflows/pr-title.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
 name: pr-title
 on:
   pull_request:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: OlivierZal/configs/.github/workflows/zizmor.yml@1ecb998b42be945b6963d3a76370b145cf637370 # v1.3.2
+    uses: OlivierZal/configs/.github/workflows/zizmor.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
 name: zizmor
 on:
   merge_group: {}

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,23 +1,5 @@
-import { namingConventionEntries } from '@olivierzal/configs/eslint'
 import { library } from '@olivierzal/configs/eslint/library'
 import { type Config, defineConfig } from 'eslint/config'
-
-// The layers that speak to MELCloud: the wire types and their zod
-// mirror, the HTTP clients, the facades that read and write those
-// fields, and the maps that translate them. The rest of the library —
-// entities, errors, observability, resilience, the time helpers — is
-// ours alone and takes the strict core.
-const wireSpeakingFiles = [
-  'src/api/**/*.ts',
-  'src/constants.ts',
-  'src/decorators/**/*.ts',
-  'src/enum-mappings.ts',
-  'src/facades/**/*.ts',
-  'src/http/**/*.ts',
-  'src/types/**/*.ts',
-  'src/utils.ts',
-  'src/validation/**/*.ts',
-]
 
 const config: Config[] = defineConfig([
   {
@@ -25,54 +7,54 @@ const config: Config[] = defineConfig([
     // code — outside the lint scope by decision, like the build outputs.
     ignores: ['coverage/', 'dist/', 'docs/', 'scripts/'],
   },
-  ...library(),
-  {
-    // These vocabularies are what the protocols impose on the modules
-    // that speak them, so they are granted there and nowhere else: a
-    // name of our own invention outside this list meets the core and
-    // is caught, instead of being waved through by a shape it merely
-    // resembles.
-    files: wireSpeakingFiles,
-    rules: {
-      '@typescript-eslint/naming-convention': [
-        'error',
-        ...namingConventionEntries({
-          // Mirrors the library preset's own filter: `device` types
-          // include `false` as a sentinel without being a flag.
-          booleanFilter: { match: false, regex: '^device$' },
-          extraEntries: [
-            // Branded types use __brand as a phantom sentinel —
-            // universal TS convention.
-            {
-              filter: { match: true, regex: '^__brand$' },
-              format: null,
-              selector: 'typeProperty',
-            },
-            // MELCloud Classic names every field in PascalCase, and the
-            // Home report keys its series in UPPER_SNAKE (`HOT_WATER`);
-            // both are read and written verbatim. Header names carry
-            // hyphens and stay with the quoted-key exemption instead.
-            {
-              filter: { match: true, regex: '^[A-Z][A-Za-z0-9_]*$' },
-              format: ['PascalCase', 'UPPER_CASE'],
-              selector: ['objectLiteralProperty', 'typeProperty'],
-            },
-            // Three snake_case vocabularies meet here, none of them
-            // ours: the OAuth 2.0/PKCE parameters (`grant_type`,
-            // `code_verifier`), the Home wire fields
-            // (`outside_temperature`), and the Homey capability enum
-            // values the app passes straight through (`very_fast`,
-            // `flow_cool`).
-            {
-              filter: { match: true, regex: '^[a-z][a-z0-9]*(_[a-z0-9]+)+$' },
-              format: null,
-              selector: ['objectLiteralProperty', 'typeProperty'],
-            },
-          ],
-        }),
-      ],
-    },
-  },
+  ...library({
+    wireNamingEntries: [
+      // Branded types use __brand as a phantom sentinel — universal TS
+      // convention.
+      {
+        filter: { match: true, regex: '^__brand$' },
+        format: null,
+        selector: 'typeProperty',
+      },
+      // MELCloud Classic names every field in PascalCase, and the Home
+      // report keys its series in UPPER_SNAKE (`HOT_WATER`); both are
+      // read and written verbatim. Header names carry hyphens and stay
+      // with the quoted-key exemption instead.
+      {
+        filter: { match: true, regex: '^[A-Z][A-Za-z0-9_]*$' },
+        format: ['PascalCase', 'UPPER_CASE'],
+        selector: ['objectLiteralProperty', 'typeProperty'],
+      },
+      // Three snake_case vocabularies meet here, none of them ours:
+      // the OAuth 2.0/PKCE parameters (`grant_type`, `code_verifier`),
+      // the Home wire fields (`outside_temperature`), and the Homey
+      // capability enum values the app passes straight through
+      // (`very_fast`, `flow_cool`).
+      {
+        filter: { match: true, regex: '^[a-z][a-z0-9]*(_[a-z0-9]+)+$' },
+        format: null,
+        selector: ['objectLiteralProperty', 'typeProperty'],
+      },
+    ],
+    // The layers that speak to MELCloud: the wire types and their zod
+    // mirror, the HTTP clients, the facades that read and write those
+    // fields, and the maps that translate them. The rest of the
+    // library — entities, errors, observability, resilience, the time
+    // helpers — is ours alone and takes the strict core, so a name of
+    // our own invention there is caught instead of being waved through
+    // by a shape it merely resembles.
+    wireNamingFiles: [
+      'src/api/**/*.ts',
+      'src/constants.ts',
+      'src/decorators/**/*.ts',
+      'src/enum-mappings.ts',
+      'src/facades/**/*.ts',
+      'src/http/**/*.ts',
+      'src/types/**/*.ts',
+      'src/utils.ts',
+      'src/validation/**/*.ts',
+    ],
+  }),
   {
     // Bitfield enumeration: `EffectiveFlags` hex values are the file's
     // entire purpose. `no-magic-numbers` would flag every entry, and

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@olivierzal/configs": "1.3.2",
+        "@olivierzal/configs": "1.4.0",
         "@types/node": "^26.1.2",
         "@typescript/native": "npm:typescript@^7.0.2",
         "@vitest/coverage-v8": "^4.1.10",
@@ -586,9 +586,9 @@
       }
     },
     "node_modules/@olivierzal/configs": {
-      "version": "1.3.2",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.3.2/94ed0534c00c3e137c73e8d6847b05ed8bfb16d5",
-      "integrity": "sha512-4oVJhxYUXt/14UBxXBxexDhtiqxZXK3RDEy7l12H2vFJ6QTcVKk3NHG1a7cQuAC24ykb6K4PcoHjQJQboqtEDw==",
+      "version": "1.4.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.4.0/07e9e8d271a240cd92725d86d7a7b2519954032f",
+      "integrity": "sha512-arD6N/2vLTTz7AWE228fZR1EP3AFUa21i4xmATGBGhRbpXDySbsxE0cQVjMpbLXXqlqXzPgQztp55frwM/mF/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@olivierzal/configs": "1.3.2",
+    "@olivierzal/configs": "1.4.0",
     "@types/node": "^26.1.2",
     "@typescript/native": "npm:typescript@^7.0.2",
     "@vitest/coverage-v8": "^4.1.10",


### PR DESCRIPTION
Pin and stub refs move to 1.4.0, and the overlay stops re-deriving the family naming policy.

Scoping the wire vocabulary by file used to mean overriding `naming-convention` in a `files:` block — and since that rule's option array replaces rather than merges, the overlay had to rebuild the whole array, including the family's own `booleanFilter`. 1.4.0's `wireNamingFiles` moves that emission into the preset: this repo now names its wire layers and never the policy.

Proven iso where it matters: `eslint --print-config` is byte-identical before and after on a wire module (`src/types/classic-ata.ts`), on a non-wire core module (`src/entities/base.ts`) and on `eslint.config.ts`.

One measured divergence, in test files only, reported rather than glossed: the preset propagates the wire entries into the tests block by design (doubles mirror payloads verbatim), so three entries are added there and none removed. Its entire practical effect is that `__brand` becomes legal as a *type* property in tests — one error before, none after. Object-literal names do not loosen: `_leading` and `__brand` in an object literal are still rejected, as is any non-conforming name.

Scoping still holds outside the wire layers: `MyOwnField` and `my_own_key` planted in `src/entities/base.ts` are both rejected, while the full lint stays green on all 607 legitimate wire names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3
