### PR TITLE
fix: ship u-flag regexes so Homey Pro 2016-2019 can parse the library

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,14 @@ where even reads need auth).
 
 ## Lint doctrine
 
+- Shipped regexes stay on the `u` flag — the es2024 `v` flag is a
+  parse-time SyntaxError on Homey Pro 2016-2019 (Node < 20) and killed
+  the consuming app at boot (2026-08 crash report). The overlay pins
+  `require-unicode-regexp` to `u`; the complete node device-floor
+  decision (post-Node-18 APIs) is pending an installed-base
+  measurement — do not widen shipped code to newer runtime APIs
+  meanwhile.
+
 - Code adapts to the rules, never the reverse. Never add a disable — not
   inline, not through config options or ignore regexes: refactor until the
   rule passes (rename the binding, drop the unused parameter, restructure

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -63,6 +63,14 @@ const config: Config[] = defineConfig([
     files: ['src/facades/classic-flags.ts'],
     rules: { '@typescript-eslint/no-magic-numbers': 'off' },
   },
+  {
+    // Shipped regexes stay on the `u` flag: the es2024 `v` flag is a
+    // parse-time SyntaxError on Homey Pro 2016-2019 (Node < 20), which
+    // killed the consuming app at boot (2026-08 crash report). The full
+    // node device-floor policy is pending an installed-base measurement.
+    files: ['src/**/*.ts'],
+    rules: { 'require-unicode-regexp': ['error', { requireFlag: 'u' }] },
+  },
 ])
 
 export default config

--- a/src/api/token-auth.ts
+++ b/src/api/token-auth.ts
@@ -193,7 +193,7 @@ const authRequest = async ({
  * @returns The resolved form action URL, or `null` if not found.
  */
 const extractFormAction = (html: string): string | null => {
-  const match = /<form[^>]+action="(?<action>[^"]+)"/iv.exec(html)
+  const match = /<form[^>]+action="(?<action>[^"]+)"/iu.exec(html)
   const encoded = match?.groups?.action
   if (encoded === undefined) {
     return null
@@ -209,9 +209,9 @@ const extractFormAction = (html: string): string | null => {
  */
 const extractHiddenFields = (html: string): Record<string, string> =>
   Object.fromEntries(
-    html.matchAll(/<input[^>]+type="hidden"[^>]*>/giv).flatMap(([tag]) => {
-      const name = /name="(?<name>[^"]+)"/v.exec(tag)?.groups?.name
-      const value = /value="(?<value>[^"]*)"/v.exec(tag)?.groups?.value ?? ''
+    html.matchAll(/<input[^>]+type="hidden"[^>]*>/giu).flatMap(([tag]) => {
+      const name = /name="(?<name>[^"]+)"/u.exec(tag)?.groups?.name
+      const value = /value="(?<value>[^"]*)"/u.exec(tag)?.groups?.value ?? ''
       return name === undefined ? [] : [[name, value] as const]
     }),
   )
@@ -238,10 +238,10 @@ const extractRedirectUrl = (html: string, regex: RegExp): string | null => {
  * @returns The redirect URL if found, or `null`.
  */
 const extractPageRedirect = (html: string): string | null =>
-  extractRedirectUrl(html, /window\.location\s*=\s*['"](?<url>[^'"]+)/v) ??
+  extractRedirectUrl(html, /window\.location\s*=\s*['"](?<url>[^'"]+)/u) ??
   extractRedirectUrl(
     html,
-    /<meta[^>]+http-equiv="refresh"[^>]+content="[^"]*url=(?<url>[^"]+)/iv,
+    /<meta[^>]+http-equiv="refresh"[^>]+content="[^"]*url=(?<url>[^"]+)/iu,
   )
 
 /**
@@ -381,7 +381,7 @@ const par = async ({
 // `errorMessage` element when it refuses a submission.
 const refusedSubmissionMessage = (html: string): string => {
   const match =
-    /(?:id|class)="errorMessage[^"]*"[^>]*>(?<message>[^<]*)</v.exec(html)
+    /(?:id|class)="errorMessage[^"]*"[^>]*>(?<message>[^<]*)</u.exec(html)
   const reason = match?.groups?.message?.trim() ?? ''
   return reason === ''
     ? 'Credential submission was not redirected'

--- a/src/http/client.ts
+++ b/src/http/client.ts
@@ -63,7 +63,7 @@ const resolveUrl = (baseURL: string, url: string | undefined): string => {
   if (url === undefined || url === '') {
     return baseURL
   }
-  if (/^https?:/iv.test(url)) {
+  if (/^https?:/iu.test(url)) {
     return url
   }
   const resolved = new URL(


### PR DESCRIPTION
The eight shipped regex literals carried the es2024 `v` flag — a parse-time `SyntaxError: Invalid regular expression flags` on Homey Pro 2016-2019 (Node < 20), killing the consuming app at boot before any code ran (crash report received for com.melcloud v46.1.2, firmware 13.2.4). Present since 43.0.1 (the token-auth introduction).

All eight patterns are plain character classes — no `v`-specific syntax — so `u` is a drop-in: the full suite exercises every one of them at 100 % coverage and stays green. The overlay pins `require-unicode-regexp` to `u` for shipped code with the incident documented; the complete node device-floor policy (post-Node-18 APIs) deliberately waits for an installed-base measurement, per Olivier's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3