### PR TITLE
chore(release): 47.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "47.0.0",
+  "version": "47.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "47.0.0",
+      "version": "47.0.1",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "47.0.0",
+  "version": "47.0.1",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",


### PR DESCRIPTION
Release 47.0.1: shipped regexes move to the u flag so Homey Pro 2016-2019 (Node < 20) can parse the library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3