### PR TITLE
docs: factualize the u-flag note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,10 +131,7 @@ where even reads need auth).
 - Shipped regexes stay on the `u` flag — the es2024 `v` flag is a
   parse-time SyntaxError on Homey Pro 2016-2019 (Node < 20) and killed
   the consuming app at boot (2026-08 crash report). The overlay pins
-  `require-unicode-regexp` to `u`; the complete node device-floor
-  decision (post-Node-18 APIs) is pending an installed-base
-  measurement — do not widen shipped code to newer runtime APIs
-  meanwhile.
+  `require-unicode-regexp` to `u`.
 
 - Code adapts to the rules, never the reverse. Never add a disable — not
   inline, not through config options or ignore regexes: refactor until the

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -65,9 +65,9 @@ const config: Config[] = defineConfig([
   },
   {
     // Shipped regexes stay on the `u` flag: the es2024 `v` flag is a
-    // parse-time SyntaxError on Homey Pro 2016-2019 (Node < 20), which
-    // killed the consuming app at boot (2026-08 crash report). The full
-    // node device-floor policy is pending an installed-base measurement.
+    // parse-time SyntaxError on older Homey Pro (2016-2019) firmware
+    // (pre-Node-20 runtime) — it killed the consuming app at boot
+    // there (2026-08 crash report).
     files: ['src/**/*.ts'],
     rules: { 'require-unicode-regexp': ['error', { requireFlag: 'u' }] },
   },


### PR DESCRIPTION
The u-flag verdict's rationale no longer references a pending measurement — the product decision landed: shipped regexes stay on `u` because older Homey Pro (2016-2019) firmware runs a pre-Node-20 runtime where the `v` flag is a parse-time SyntaxError. Comment and CLAUDE.md aligned with the decision, nothing shipped changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3