### PR TITLE
build: adopt configs 1.6.0

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
+    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
 name: Audit
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,12 @@ jobs:
       packages: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
+    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
     with:
+      # Coverage (and Sonar) runs on the fleet's Node major — measured
+      # 22.20/22.23 on-device (2026-08) — instead of floating with
+      # lts/*, which jumps majors ahead of the fleet.
+      coverage-node-version: '22'
       run-docs: true
       run-lint-package: true
 name: CI

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
+    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
 name: claude-code-review
 on:
   pull_request:

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
+    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
     with:
       repo-guidance: >-
         Twin discipline: several source and test files here are

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -6,7 +6,7 @@ jobs:
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
+    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
 name: claude-issue-triage
 on:
   issues:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
+    uses: OlivierZal/configs/.github/workflows/claude.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
 name: claude
 on:
   # No pull_request_review(_comment): Copilot auto-review fires them as a

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: OlivierZal/configs/.github/workflows/dependabot.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
+    uses: OlivierZal/configs/.github/workflows/dependabot.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
 name: dependabot
 on:
   pull_request: {}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ jobs:
   pr_title:
     permissions:
       pull-requests: read
-    uses: OlivierZal/configs/.github/workflows/pr-title.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
+    uses: OlivierZal/configs/.github/workflows/pr-title.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
 name: pr-title
 on:
   pull_request:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: OlivierZal/configs/.github/workflows/zizmor.yml@2acd68afe1a72f8bfdabdab88ba18f213b2927db # v1.4.0
+    uses: OlivierZal/configs/.github/workflows/zizmor.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
 name: zizmor
 on:
   merge_group: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@olivierzal/configs": "1.4.0",
+        "@olivierzal/configs": "1.6.0",
         "@types/node": "^26.1.2",
         "@typescript/native": "npm:typescript@^7.0.2",
         "@vitest/coverage-v8": "^4.1.10",
@@ -586,9 +586,9 @@
       }
     },
     "node_modules/@olivierzal/configs": {
-      "version": "1.4.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.4.0/07e9e8d271a240cd92725d86d7a7b2519954032f",
-      "integrity": "sha512-arD6N/2vLTTz7AWE228fZR1EP3AFUa21i4xmATGBGhRbpXDySbsxE0cQVjMpbLXXqlqXzPgQztp55frwM/mF/Q==",
+      "version": "1.6.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.6.0/474d9fe4cb9ff56cee39a9e62660cb26f9fd71ed",
+      "integrity": "sha512-l+JqAg4eXdPjQFxRKqK1jZg86ki67MAVqJq6wesx5ZrKULic+NDMG0UNT+zf3dC0He+6Jh/rpvZPdxYWlpO6nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@olivierzal/configs": "1.4.0",
+    "@olivierzal/configs": "1.6.0",
     "@types/node": "^26.1.2",
     "@typescript/native": "npm:typescript@^7.0.2",
     "@vitest/coverage-v8": "^4.1.10",


### PR DESCRIPTION
Exact-pin bump 1.4.0 → 1.6.0, skipping the stillborn 1.5.0 (its device floor was reverted by decision — 1.6.0 is functionally identical to 1.4.0 plus the plugin-refusal ledger). All 9 stub refs move to `262b014b # v1.6.0`, check-pins green (16 refs / 12 files). One deliberate CI change: `coverage-node-version: '22'` pins the coverage/Sonar leg to the fleet's measured Node major instead of floating with `lts/*` (which jumps to 24 in October) — closing what is closable consumer-side of the `n`-ledger trigger A; minor-level pinning would require a matrix change in the reusable and is deferred there. No runtime code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3