### PR TITLE
feat: share the per-mode ATA temperature bounds across both APIs

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -50,6 +50,7 @@ const config: Config[] = defineConfig([
       'src/enum-mappings.ts',
       'src/facades/**/*.ts',
       'src/http/**/*.ts',
+      'src/temperature-range.ts',
       'src/types/**/*.ts',
       'src/utils.ts',
       'src/validation/**/*.ts',

--- a/src/facades/classic-device-ata.ts
+++ b/src/facades/classic-device-ata.ts
@@ -1,5 +1,10 @@
-import { ClassicDeviceType, ClassicOperationMode } from '../constants.ts'
+import { type ClassicOperationMode, ClassicDeviceType } from '../constants.ts'
 import { tolerateNoChanges } from '../errors/index.ts'
+import {
+  type AtaTemperatureBounds,
+  type TemperatureRange,
+  rangeForClassicMode,
+} from '../temperature-range.ts'
 import {
   type ClassicEnergyDataAta,
   type ClassicGroupState,
@@ -73,6 +78,26 @@ export class ClassicDeviceAtaFacade extends BaseDeviceFacade<
     'OutdoorTemperature',
   ]
 
+  // The dialect extractor: Classic spells the three advertised pairs in
+  // PascalCase, and the shared module resolves modes onto them.
+  get #bounds(): AtaTemperatureBounds {
+    const {
+      data: {
+        MaxTempAutomatic,
+        MaxTempCoolDry,
+        MaxTempHeat,
+        MinTempAutomatic,
+        MinTempCoolDry,
+        MinTempHeat,
+      },
+    } = this
+    return {
+      automatic: { max: MaxTempAutomatic, min: MinTempAutomatic },
+      coolDry: { max: MaxTempCoolDry, min: MinTempCoolDry },
+      heatFan: { max: MaxTempHeat, min: MinTempHeat },
+    }
+  }
+
   /**
    * Read this device's current state projected as a group state, treating
    * the device as a group of one: MELCloud's group endpoints only address
@@ -93,6 +118,19 @@ export class ClassicDeviceAtaFacade extends BaseDeviceFacade<
       VaneHorizontalDirection: data.VaneHorizontalDirection,
       VaneVerticalDirection: data.VaneVerticalDirection,
     })
+  }
+
+  /**
+   * Setpoint bounds enforced for an operation mode — the cross-dialect
+   * read: a caller needs no knowledge of which API backs the device.
+   * @param mode - Operation mode to resolve; defaults to the active one.
+   * @returns The interval, or `null` for a mode outside the known
+   * vocabulary (the setpoint then goes unclamped).
+   */
+  public getTemperatureRange(
+    mode: ClassicOperationMode = this.setData.OperationMode,
+  ): TemperatureRange | null {
+    return rangeForClassicMode(this.#bounds, mode)
   }
 
   /**
@@ -130,45 +168,9 @@ export class ClassicDeviceAtaFacade extends BaseDeviceFacade<
     if (value === undefined) {
       return {}
     }
-    const range = this.#getTargetTemperatureRange(operationMode)
-    return { SetTemperature: clampToRange(value, range) }
-  }
-
-  #getTargetTemperatureRange(operationMode = this.setData.OperationMode): {
-    max: number
-    min: number
-  } {
-    const {
-      data: {
-        MaxTempAutomatic: maxTemperatureAutomatic,
-        MaxTempCoolDry: maxTemperatureCoolDry,
-        MaxTempHeat: maxTemperatureHeatFan,
-        MinTempAutomatic: minTemperatureAutomatic,
-        MinTempCoolDry: minTemperatureCoolDry,
-        MinTempHeat: minTemperatureHeatFan,
-      },
-    } = this
+    const range = this.getTemperatureRange(operationMode)
     return {
-      [ClassicOperationMode.auto]: {
-        max: maxTemperatureAutomatic,
-        min: minTemperatureAutomatic,
-      },
-      [ClassicOperationMode.cool]: {
-        max: maxTemperatureCoolDry,
-        min: minTemperatureCoolDry,
-      },
-      [ClassicOperationMode.dry]: {
-        max: maxTemperatureCoolDry,
-        min: minTemperatureCoolDry,
-      },
-      [ClassicOperationMode.fan]: {
-        max: maxTemperatureHeatFan,
-        min: minTemperatureHeatFan,
-      },
-      [ClassicOperationMode.heat]: {
-        max: maxTemperatureHeatFan,
-        min: minTemperatureHeatFan,
-      },
-    }[operationMode]
+      SetTemperature: range === null ? value : clampToRange(value, range),
+    }
   }
 }

--- a/src/facades/home-device-ata.ts
+++ b/src/facades/home-device-ata.ts
@@ -13,6 +13,11 @@ import {
 } from '../enum-mappings.ts'
 import { NoChangesError, tolerateNoChanges } from '../errors/index.ts'
 import {
+  type AtaTemperatureBounds,
+  type TemperatureRange,
+  rangeForHomeMode,
+} from '../temperature-range.ts'
+import {
   type ClassicGroupState,
   type HomeAtaDeviceCapabilities,
   type HomeAtaDeviceData,
@@ -46,37 +51,24 @@ const KILOWATT_HOURS_PER_WATT_HOUR = 0.001
 
 const TEMPERATURE_UNIT = '°C'
 
-interface TemperatureRange {
-  max: number
-  min: number
-}
+// Half-degree units advertise it; the rest step by a whole degree.
+const HALF_DEGREE_STEP = 0.5
+const WHOLE_DEGREE_STEP = 1
 
-const coolDryRange = ({
-  maxTempCoolDry: max,
-  minTempCoolDry: min,
-}: HomeAtaDeviceCapabilities): TemperatureRange => ({ max, min })
-
-const heatFanRange = ({
-  maxTempHeat: max,
-  minTempHeat: min,
-}: HomeAtaDeviceCapabilities): TemperatureRange => ({ max, min })
-
-const temperatureRanges = new Map<
-  HomeOperationMode,
-  (capabilities: HomeAtaDeviceCapabilities) => TemperatureRange
->([
-  [
-    'Automatic',
-    ({ maxTempAutomatic: max, minTempAutomatic: min }): TemperatureRange => ({
-      max,
-      min,
-    }),
-  ],
-  ['Cool', coolDryRange],
-  ['Dry', coolDryRange],
-  ['Fan', heatFanRange],
-  ['Heat', heatFanRange],
-])
+// The dialect extractor: Home spells the three advertised pairs in
+// camelCase, and the shared module resolves modes onto them.
+const toBounds = ({
+  maxTempAutomatic,
+  maxTempCoolDry,
+  maxTempHeat,
+  minTempAutomatic,
+  minTempCoolDry,
+  minTempHeat,
+}: HomeAtaDeviceCapabilities): AtaTemperatureBounds => ({
+  automatic: { max: maxTempAutomatic, min: minTempAutomatic },
+  coolDry: { max: maxTempCoolDry, min: minTempCoolDry },
+  heatFan: { max: maxTempHeat, min: minTempHeat },
+})
 
 /**
  * Facade for a MELCloud Home ATA device. Provides typed access to device
@@ -158,6 +150,17 @@ export class HomeDeviceAtaFacade extends HomeBaseDeviceFacade<HomeAtaDeviceData>
    */
   public get setTemperature(): number {
     return this.settingNumber('SetTemperature')
+  }
+
+  /**
+   * Setpoint granularity in °C, from the unit's advertised
+   * half-degree capability.
+   * @returns `0.5` on half-degree units, `1` otherwise.
+   */
+  public get temperatureStep(): number {
+    return this.capabilities.hasHalfDegreeIncrements
+      ? HALF_DEGREE_STEP
+      : WHOLE_DEGREE_STEP
   }
 
   /**
@@ -260,6 +263,19 @@ export class HomeDeviceAtaFacade extends HomeBaseDeviceFacade<HomeAtaDeviceData>
   }
 
   /**
+   * Setpoint bounds enforced for an operation mode — the cross-dialect
+   * read: a caller needs no knowledge of which API backs the device.
+   * @param mode - Operation mode to resolve; defaults to the active one.
+   * @returns The interval, or `null` for a mode outside the known
+   * vocabulary (the setpoint then goes unclamped).
+   */
+  public getTemperatureRange(
+    mode: HomeOperationMode = this.operationMode,
+  ): TemperatureRange | null {
+    return rangeForHomeMode(toBounds(this.capabilities), mode)
+  }
+
+  /**
    * Fetches the temperature history as line chart data (trend-summary
    * report resampled on a regular grid) — the Home counterpart of the
    * Classic `getTemperatures` contract.
@@ -327,11 +343,10 @@ export class HomeDeviceAtaFacade extends HomeBaseDeviceFacade<HomeAtaDeviceData>
     if (value === undefined || value === null) {
       return {}
     }
-    const mode = operationMode ?? this.operationMode
-    const getRange = temperatureRanges.get(mode)
-    return getRange === undefined
-      ? { setTemperature: value }
-      : { setTemperature: clampToRange(value, getRange(this.capabilities)) }
+    const range = this.getTemperatureRange(operationMode ?? this.operationMode)
+    return {
+      setTemperature: range === null ? value : clampToRange(value, range),
+    }
   }
 
   // Typed reads of the enum-backed settings. The overloads deliberately

--- a/src/index.ts
+++ b/src/index.ts
@@ -271,5 +271,11 @@ export {
   OVERHEAT_PROTECTION_RANGE,
   PROTECTION_GAP,
 } from './protection.ts'
+export {
+  type AtaTemperatureBounds,
+  type TemperatureRange,
+  rangeForClassicMode,
+  rangeForHomeMode,
+} from './temperature-range.ts'
 export { Temporal } from './temporal.ts'
 export { err, mapResult, ok } from './types/index.ts'

--- a/src/temperature-range.ts
+++ b/src/temperature-range.ts
@@ -1,0 +1,97 @@
+import type { ClassicOperationMode } from './constants.ts'
+import {
+  type HomeOperationMode,
+  operationModeFromClassic,
+} from './enum-mappings.ts'
+
+// Per-mode ATA setpoint bounds: the cross-dialect surface both APIs
+// advertise under different spellings, and the single place where the
+// five operation modes collapse onto the three ranges the hardware
+// actually distinguishes.
+
+/**
+ * The three intervals an ATA unit advertises, whichever API describes
+ * it. Both dialects publish exactly these pairs; only the field
+ * spelling differs, so each facade supplies them and the resolution
+ * below is shared.
+ * @category Facades
+ */
+export interface AtaTemperatureBounds {
+  /**
+   * Bounds enforced in automatic mode.
+   */
+  readonly automatic: TemperatureRange
+  /**
+   * Bounds shared by cooling and drying.
+   */
+  readonly coolDry: TemperatureRange
+  /**
+   * Bounds shared by heating and fan.
+   */
+  readonly heatFan: TemperatureRange
+}
+
+/**
+ * A setpoint interval in °C, inclusive on both ends — the cross-dialect
+ * read twin of the raw bounds each API advertises: Classic maps its
+ * `MinTemp*`/`MaxTemp*` wire fields onto it, Home its camelCase
+ * `minTemp*`/`maxTemp*` capabilities.
+ * @category Facades
+ */
+export interface TemperatureRange {
+  /**
+   * Highest settable temperature, in °C.
+   */
+  readonly max: number
+  /**
+   * Lowest settable temperature, in °C.
+   */
+  readonly min: number
+}
+
+// Keyed on the Home vocabulary because the Classic side already has a
+// total bijection onto it (`operationModeFromClassic`): one table, both
+// dialects, no second grouping to drift out of step.
+const BOUNDS_KEY_BY_MODE: Record<
+  HomeOperationMode,
+  keyof AtaTemperatureBounds
+> = {
+  Automatic: 'automatic',
+  Cool: 'coolDry',
+  Dry: 'coolDry',
+  Fan: 'heatFan',
+  Heat: 'heatFan',
+}
+
+/**
+ * Resolves the bounds enforced for a Home operation mode.
+ * @param bounds - The unit's three advertised intervals.
+ * @param mode - The Home operation mode to resolve.
+ * @returns The interval for that mode, or `null` when the mode is
+ * outside the known vocabulary — unknown wire values pass through
+ * unclamped rather than borrowing another mode's bounds.
+ */
+export const rangeForHomeMode = (
+  bounds: AtaTemperatureBounds,
+  mode: HomeOperationMode,
+): TemperatureRange | null => {
+  const key = BOUNDS_KEY_BY_MODE[mode] as keyof AtaTemperatureBounds | undefined
+  return key === undefined ? null : bounds[key]
+}
+
+/**
+ * Resolves the bounds enforced for a Classic operation mode, through
+ * the same table the Home side uses.
+ * @param bounds - The unit's three advertised intervals.
+ * @param mode - The Classic operation mode to resolve.
+ * @returns The interval for that mode, or `null` when the mode is
+ * outside the known vocabulary.
+ */
+export const rangeForClassicMode = (
+  bounds: AtaTemperatureBounds,
+  mode: ClassicOperationMode,
+): TemperatureRange | null => {
+  const homeMode = operationModeFromClassic[mode] as
+    HomeOperationMode | undefined
+  return homeMode === undefined ? null : rangeForHomeMode(bounds, homeMode)
+}

--- a/tests/unit/classic-facades.test.ts
+++ b/tests/unit/classic-facades.test.ts
@@ -1188,6 +1188,34 @@ describe('ata device facade', () => {
     ).toBeGreaterThanOrEqual(10)
   })
 
+  it('passes the setpoint through for an unknown operation mode', async () => {
+    const { api, facade } = createAtaFacade()
+    await facade.updateValues(cast({ OperationMode: 99, SetTemperature: 50 }))
+    const call = vi.mocked(api.updateValues).mock.lastCall?.[0]
+
+    expect(call).toBeDefined()
+
+    expect(
+      mock<ClassicSetDevicePostData<typeof ClassicDeviceType.Ata>>(
+        defined(call).postData,
+      ).SetTemperature,
+    ).toBe(50)
+  })
+
+  it('reads the per-mode range from the device bounds', () => {
+    const { facade } = createAtaFacade()
+
+    expect(facade.getTemperatureRange(ClassicOperationMode.heat)).toStrictEqual(
+      { max: 31, min: 10 },
+    )
+
+    expect(facade.getTemperatureRange(ClassicOperationMode.cool)).toStrictEqual(
+      { max: 31, min: 16 },
+    )
+
+    expect(facade.getTemperatureRange(cast(99))).toBeNull()
+  })
+
   it('handles temperature clamping with operation mode change', async () => {
     const { api, facade } = createAtaFacade()
     await facade.updateValues({

--- a/tests/unit/home-device-ata-facade.test.ts
+++ b/tests/unit/home-device-ata-facade.test.ts
@@ -288,6 +288,59 @@ describe('home device ata facade', () => {
     })
   })
 
+  describe('temperature range and step', () => {
+    it('should read the per-mode range from the device capabilities', () => {
+      const facade = new HomeDeviceAtaFacade(
+        createApi(),
+        createModel(
+          { OperationMode: 'Heat' },
+          { maxTempHeat: 31, minTempHeat: 10 },
+        ),
+      )
+
+      expect(facade.getTemperatureRange()).toStrictEqual({ max: 31, min: 10 })
+
+      expect(facade.getTemperatureRange('Cool')).toStrictEqual({
+        max: 31,
+        min: 16,
+      })
+
+      expect(facade.getTemperatureRange(cast('Unknown'))).toBeNull()
+    })
+
+    // Mutation guard: the range follows the dialect fixture, so a bound
+    // changed at the source changes what consumers render.
+    it('should follow the advertised bounds', () => {
+      const facade = new HomeDeviceAtaFacade(
+        createApi(),
+        createModel(
+          { OperationMode: 'Heat' },
+          { maxTempHeat: 28, minTempHeat: 12 },
+        ),
+      )
+
+      expect(facade.getTemperatureRange()).toStrictEqual({ max: 28, min: 12 })
+    })
+
+    it('should step by a half degree when the unit advertises it', () => {
+      const facade = new HomeDeviceAtaFacade(
+        createApi(),
+        createModel({}, { hasHalfDegreeIncrements: true }),
+      )
+
+      expect(facade.temperatureStep).toBe(0.5)
+    })
+
+    it('should step by a whole degree otherwise', () => {
+      const facade = new HomeDeviceAtaFacade(
+        createApi(),
+        createModel({}, { hasHalfDegreeIncrements: false }),
+      )
+
+      expect(facade.temperatureStep).toBe(1)
+    })
+  })
+
   describe('temperature clamping', () => {
     it('should clamp temperature to heat range', async () => {
       const api = createApi()


### PR DESCRIPTION
Both APIs advertise the same three ATA setpoint intervals under different spellings — Classic `MinTemp*`/`MaxTemp*`, Home `minTemp*`/`maxTemp*` — and each facade carried its own mapping of the five operation modes onto them. Same semantics, two implementations, no shared surface: the duplication axis between the two dialects of one library.

`src/temperature-range.ts` now holds the cross-dialect types (`TemperatureRange`, `AtaTemperatureBounds`) and the single grouping table, keyed on the Home vocabulary because `operationModeFromClassic` already provides a total bijection from the Classic side — one table, both dialects, no second grouping to drift out of step. Each facade keeps only its dialect extractor.

Both ATA facades gain `getTemperatureRange(mode?)`, defaulting to the active mode: a caller reads the bounds without knowing which API backs the device. The Home facade also gains `temperatureStep`, resolved from the `hasHalfDegreeIncrements` capability the wire already advertises, so consumers stop guessing between 0.5 and 1.

One behavior change, in the direction of the documented Home contract: an out-of-vocabulary Classic mode now leaves the setpoint unclamped instead of indexing an object literal to `undefined` and throwing inside `clampToRange`. Both dialects now degrade identically.

Coverage stays at 100% on all four axes, with a mutation guard pinning the range to the advertised bounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3