### PR TITLE
chore(release): 47.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "47.0.1",
+  "version": "47.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "47.0.1",
+      "version": "47.1.0",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "47.0.1",
+  "version": "47.1.0",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",


### PR DESCRIPTION
Release 47.1.0: cross-dialect ATA temperature bounds — `TemperatureRange`, `AtaTemperatureBounds`, `rangeForClassicMode`, `rangeForHomeMode`, plus `getTemperatureRange()` on both ATA facades and `temperatureStep` on the Home one. Pure addition; the one behavior change (an unknown Classic mode leaves the setpoint unclamped rather than throwing) aligns Classic with the documented Home contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3