### PR TITLE
fix: publish the shared temperature range on the Classic ATA facade

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,13 @@ is on: no runtime enums, no parameter properties, no runtime namespaces.
   (Sunday = 0) unlike the 1-based ISO labels of `Report/*`. ATA Home
   daily energy buckets are watt-hours and idle days are omitted
   entirely; ATW buckets are kWh.
+- Setpoint-increment fields exist on BOTH wires — Home `hasHalfDegrees`
+  (ATA and ATW capabilities) and Classic
+  `CanSetTemperatureIncrementOverride` (a device PERMISSION, never a
+  step declaration) — and are deliberately neither exposed by the
+  facades nor consumed: Homey does not derive a capability's step from
+  them, so a reading would reach no actionable consumer. Their absence
+  from the public surface is a verdict, not a gap.
 
 ## Tooling boundary (@olivierzal/configs)
 

--- a/src/facades/classic-types.ts
+++ b/src/facades/classic-types.ts
@@ -11,6 +11,7 @@ import type {
 import type { AvailabilityAware, Identifiable } from '../entities/types.ts'
 import type { HolidayModeState, HolidayModeUpdate } from '../holiday-mode.ts'
 import type { ProtectionState, ProtectionUpdate } from '../protection.ts'
+import type { TemperatureRange } from '../temperature-range.ts'
 import type {
   ClassicEnergyData,
   ClassicGetDeviceData,
@@ -25,7 +26,11 @@ import type {
   Hour,
   Result,
 } from '../types/index.ts'
-import { type ClassicLabelType, ClassicDeviceType } from '../constants.ts'
+import {
+  type ClassicLabelType,
+  type ClassicOperationMode,
+  ClassicDeviceType,
+} from '../constants.ts'
 import type {
   ReportChartLineOptions,
   ReportChartPieOptions,
@@ -56,6 +61,16 @@ export interface ClassicDeviceAtaFacade extends ClassicDeviceFacade<
    * Read this device's current state projected as a group state.
    */
   readonly getGroup: () => Promise<Result<ClassicGroupState>>
+  /**
+   * Setpoint bounds enforced for an operation mode — the cross-dialect
+   * read: a caller needs no knowledge of which API backs the device.
+   * @param mode - Operation mode to resolve; defaults to the active one.
+   * @returns The interval, or `null` for a mode outside the known
+   * vocabulary (the setpoint then goes unclamped).
+   */
+  readonly getTemperatureRange: (
+    mode?: ClassicOperationMode,
+  ) => TemperatureRange | null
   /**
    * Apply a group state to this device.
    */

--- a/tests/types/facade-surface.ts
+++ b/tests/types/facade-surface.ts
@@ -1,0 +1,68 @@
+/**
+ * Classic facades publish INTERFACES, not their implementation classes:
+ * the classes carry `#`-private members, which would make the published
+ * names non-assignable to what the SDK returns (see `facades/index.ts`).
+ * The cost of that choice is a hand-kept mirror — a public member added
+ * to a class is invisible to consumers until someone re-declares it.
+ *
+ * `getTemperatureRange` shipped that way in 47.1.0: implemented on the
+ * class, absent from the interface, and only a consumer's `TS2551` found
+ * it. These assertions turn that class of gap into a typecheck failure
+ * naming the missing member.
+ * @packageDocumentation
+ */
+import type { ClassicDeviceType } from '../../src/constants.ts'
+import type { ClassicBuildingFacade as BuildingClass } from '../../src/facades/classic-building.ts'
+import type { ClassicDeviceAtaFacade as AtaClass } from '../../src/facades/classic-device-ata.ts'
+import type { ClassicDeviceAtwHasZone2Facade as Zone2Class } from '../../src/facades/classic-device-atw-dual-zone.ts'
+import type { ClassicDeviceAtwFacade as AtwClass } from '../../src/facades/classic-device-atw.ts'
+import type { ClassicDeviceErvFacade as ErvClass } from '../../src/facades/classic-device-erv.ts'
+import type {
+  ClassicDeviceAtaFacade as AtaInterface,
+  ClassicDeviceAtwFacade as AtwInterface,
+  ClassicBuildingFacade as BuildingInterface,
+  ClassicDeviceFacade,
+  ClassicDeviceAtwHasZone2Facade as Zone2Interface,
+} from '../../src/facades/classic-types.ts'
+
+/**
+ * Fails to instantiate when the mirror has drifted, and the compiler
+ * error names the members left unpublished.
+ * @template TMembers - The gap, expected empty.
+ */
+type NothingUnpublished<TMembers extends never> = TMembers
+
+/**
+ * Public members a class carries but its published interface omits.
+ * `#`-private members never reach `keyof`, so only the surface consumers
+ * could reasonably expect is compared.
+ * @template TClass - The implementation class.
+ * @template TInterface - The interface published under the same name.
+ */
+type UnpublishedMembers<TClass, TInterface> = Exclude<
+  keyof TClass,
+  keyof TInterface
+>
+
+export type AtaSurface = NothingUnpublished<
+  UnpublishedMembers<AtaClass, AtaInterface>
+>
+
+export type AtwSurface = NothingUnpublished<
+  UnpublishedMembers<AtwClass, AtwInterface>
+>
+
+export type BuildingSurface = NothingUnpublished<
+  UnpublishedMembers<BuildingClass, BuildingInterface>
+>
+
+export type ErvSurface = NothingUnpublished<
+  UnpublishedMembers<
+    ErvClass,
+    ClassicDeviceFacade<typeof ClassicDeviceType.Erv>
+  >
+>
+
+export type Zone2Surface = NothingUnpublished<
+  UnpublishedMembers<Zone2Class, Zone2Interface>
+>


### PR DESCRIPTION
`getTemperatureRange` shipped in 47.1.0 implemented on `ClassicDeviceAtaFacade` the class, but absent from the interface of the same name — and the interface is what `facades/index.ts` publishes, what `createFacade` returns, and what `isClassicAtaFacade` narrows to. The cross-dialect read was therefore reachable on Home only; a Classic caller got `TS2551: Property 'getTemperatureRange' does not exist`. Found by com.melcloud's ATA group widget, which reverted rather than cast over it.

The declaration is added, mirroring the class signature and its JSDoc.

**Sweep**: every other Classic facade was checked class-against-interface — ATW, zone 2, ERV and building carry no unpublished members. This was the only gap.

**Guard**: `tests/types/facade-surface.ts` asserts, per facade, that no public member of a class is missing from its published interface. Removing the new declaration fails typecheck with `TS2344: Type '"getTemperatureRange"' does not satisfy the constraint 'never'` — the error names the member. Verified by mutation.

Why this class of defect exists at all: Classic publishes interfaces rather than classes because the classes carry `#`-private members (documented in `facades/index.ts`). The cost is a hand-kept mirror; the guard makes drift a compiler error instead of a consumer's discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3