### PR TITLE
chore: release 47.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "47.1.0",
+  "version": "47.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "47.1.0",
+      "version": "47.1.1",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "47.1.0",
+  "version": "47.1.1",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",


### PR DESCRIPTION
Patch: `getTemperatureRange` is now declared on the `ClassicDeviceAtaFacade` interface, so the cross-dialect setpoint-bounds read is reachable from both API families. Strictly additive — the method was already implemented on the class, nothing was removed or moved.

Ships with `tests/types/facade-surface.ts`, which fails typecheck if a public class member ever goes unpublished again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3