### PR TITLE
build: adopt @olivierzal/configs 1.10.1

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@e4c76f47b2966e2329aa85a94e9794dde64c1c40 # v1.10.0
 name: Audit
 on:
   push:

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@e4c76f47b2966e2329aa85a94e9794dde64c1c40 # v1.10.0
+    uses: OlivierZal/configs/.github/workflows/reusable-audit.yml@347191e7498bdc6fcd9907963f0fa6e7b2f55f4b # v1.10.1
 name: Audit
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       packages: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@e4c76f47b2966e2329aa85a94e9794dde64c1c40 # v1.10.0
     with:
       # Coverage (and Sonar) runs on the fleet's Node major — measured
       # 22.20/22.23 on-device (2026-08) — instead of floating with

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       packages: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@e4c76f47b2966e2329aa85a94e9794dde64c1c40 # v1.10.0
+    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@347191e7498bdc6fcd9907963f0fa6e7b2f55f4b # v1.10.1
     with:
       # Coverage (and Sonar) runs on the fleet's Node major — measured
       # 22.20/22.23 on-device (2026-08) — instead of floating with

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@e4c76f47b2966e2329aa85a94e9794dde64c1c40 # v1.10.0
+    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@347191e7498bdc6fcd9907963f0fa6e7b2f55f4b # v1.10.1
 name: claude-code-review
 on:
   pull_request:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@e4c76f47b2966e2329aa85a94e9794dde64c1c40 # v1.10.0
 name: claude-code-review
 on:
   pull_request:

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@e4c76f47b2966e2329aa85a94e9794dde64c1c40 # v1.10.0
     with:
       repo-guidance: >-
         Twin discipline: several source and test files here are

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@e4c76f47b2966e2329aa85a94e9794dde64c1c40 # v1.10.0
+    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@347191e7498bdc6fcd9907963f0fa6e7b2f55f4b # v1.10.1
     with:
       repo-guidance: >-
         Twin discipline: several source and test files here are

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -6,7 +6,7 @@ jobs:
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@e4c76f47b2966e2329aa85a94e9794dde64c1c40 # v1.10.0
+    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@347191e7498bdc6fcd9907963f0fa6e7b2f55f4b # v1.10.1
 name: claude-issue-triage
 on:
   issues:

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -6,7 +6,7 @@ jobs:
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@e4c76f47b2966e2329aa85a94e9794dde64c1c40 # v1.10.0
 name: claude-issue-triage
 on:
   issues:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude.yml@e4c76f47b2966e2329aa85a94e9794dde64c1c40 # v1.10.0
+    uses: OlivierZal/configs/.github/workflows/claude.yml@347191e7498bdc6fcd9907963f0fa6e7b2f55f4b # v1.10.1
 name: claude
 on:
   # No pull_request_review(_comment): Copilot auto-review fires them as a

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/claude.yml@e4c76f47b2966e2329aa85a94e9794dde64c1c40 # v1.10.0
 name: claude
 on:
   # No pull_request_review(_comment): Copilot auto-review fires them as a

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: OlivierZal/configs/.github/workflows/dependabot.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/dependabot.yml@e4c76f47b2966e2329aa85a94e9794dde64c1c40 # v1.10.0
 name: dependabot
 on:
   pull_request: {}

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: OlivierZal/configs/.github/workflows/dependabot.yml@e4c76f47b2966e2329aa85a94e9794dde64c1c40 # v1.10.0
+    uses: OlivierZal/configs/.github/workflows/dependabot.yml@347191e7498bdc6fcd9907963f0fa6e7b2f55f4b # v1.10.1
 name: dependabot
 on:
   pull_request: {}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ jobs:
   pr_title:
     permissions:
       pull-requests: read
-    uses: OlivierZal/configs/.github/workflows/pr-title.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/pr-title.yml@e4c76f47b2966e2329aa85a94e9794dde64c1c40 # v1.10.0
 name: pr-title
 on:
   pull_request:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ jobs:
   pr_title:
     permissions:
       pull-requests: read
-    uses: OlivierZal/configs/.github/workflows/pr-title.yml@e4c76f47b2966e2329aa85a94e9794dde64c1c40 # v1.10.0
+    uses: OlivierZal/configs/.github/workflows/pr-title.yml@347191e7498bdc6fcd9907963f0fa6e7b2f55f4b # v1.10.1
 name: pr-title
 on:
   pull_request:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: OlivierZal/configs/.github/workflows/zizmor.yml@262b014bfa89bca8ff1bf8799b50a95f8552b3f2 # v1.6.0
+    uses: OlivierZal/configs/.github/workflows/zizmor.yml@e4c76f47b2966e2329aa85a94e9794dde64c1c40 # v1.10.0
 name: zizmor
 on:
   merge_group: {}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: OlivierZal/configs/.github/workflows/zizmor.yml@e4c76f47b2966e2329aa85a94e9794dde64c1c40 # v1.10.0
+    uses: OlivierZal/configs/.github/workflows/zizmor.yml@347191e7498bdc6fcd9907963f0fa6e7b2f55f4b # v1.10.1
 name: zizmor
 on:
   merge_group: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@olivierzal/configs": "1.6.0",
+        "@olivierzal/configs": "1.10.0",
         "@types/node": "^26.1.2",
         "@typescript/native": "npm:typescript@^7.0.2",
         "@vitest/coverage-v8": "^4.1.10",
@@ -586,9 +586,9 @@
       }
     },
     "node_modules/@olivierzal/configs": {
-      "version": "1.6.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.6.0/474d9fe4cb9ff56cee39a9e62660cb26f9fd71ed",
-      "integrity": "sha512-l+JqAg4eXdPjQFxRKqK1jZg86ki67MAVqJq6wesx5ZrKULic+NDMG0UNT+zf3dC0He+6Jh/rpvZPdxYWlpO6nw==",
+      "version": "1.10.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.10.0/227d6e7094db7936ee59c4e594fad9ab58eca486",
+      "integrity": "sha512-2XokXwPPKuNFJ0ATjRhutR0/ErvtXVavP6aBy3suf9PNEZ5Zztnm3PBmIs7cm2sz81EdgTzIQnRm4hxki5UEug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@olivierzal/configs": "1.10.0",
+        "@olivierzal/configs": "1.10.1",
         "@types/node": "^26.1.2",
         "@typescript/native": "npm:typescript@^7.0.2",
         "@vitest/coverage-v8": "^4.1.10",
@@ -586,9 +586,9 @@
       }
     },
     "node_modules/@olivierzal/configs": {
-      "version": "1.10.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.10.0/227d6e7094db7936ee59c4e594fad9ab58eca486",
-      "integrity": "sha512-2XokXwPPKuNFJ0ATjRhutR0/ErvtXVavP6aBy3suf9PNEZ5Zztnm3PBmIs7cm2sz81EdgTzIQnRm4hxki5UEug==",
+      "version": "1.10.1",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/1.10.1/31b5b140d6125acdbf3496cd2a525a531679d7e0",
+      "integrity": "sha512-SFgDPZyO9JvnOGJ6dX0y8gYkNbMbHcWxcyVt/GdsafQzlbcqM53f+JM7+V8ETl4fts647LhYNgTBu40d5F0+rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@olivierzal/configs": "1.10.0",
+    "@olivierzal/configs": "1.10.1",
     "@types/node": "^26.1.2",
     "@typescript/native": "npm:typescript@^7.0.2",
     "@vitest/coverage-v8": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@olivierzal/configs": "1.6.0",
+    "@olivierzal/configs": "1.10.0",
     "@types/node": "^26.1.2",
     "@typescript/native": "npm:typescript@^7.0.2",
     "@vitest/coverage-v8": "^4.1.10",


### PR DESCRIPTION
Moves both delivery channels together, as `check-pins.sh` requires: the npm pin and all nine workflow refs land on `v1.10.0` (`e4c76f4`).

## What this brings

- **Coverage-leg guard** (1.8.0) — fails the `check` job when `coverage-node-version` names no leg of the matrix. Verified locally against this repo's values: it passes on `'22'`, and rejects a typo with exit 1.
- **Sonar gate** (1.9.0) — new `ci / Sonar` context that reads the metrics themselves on both windows instead of the free-tier quality gate status.
- **Audit gate** (1.10.0) — floor lowered to `low` with named, expiring exceptions. This repo is clean today, so no `audit-exceptions` block is needed.

## Matrix

Kept at the reusable default (`["22", "latest", "lts/*"]`), which reproduces this repo's current legs verbatim — **no required status check changes name, so no ruleset moves with this bump**. The apps pinned a fleet minor because they deploy to measured hardware; a library's contract is its `engines` range, which is a separate question raised in review.

## Piloting

This is the first consumer to adopt the Sonar and audit gates, which were validated only inside `configs` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3