### PR TITLE
chore(release): 48.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [48.0.0] - 2026-08-10
 
 ### Changed
 
@@ -472,7 +472,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
-[Unreleased]: https://github.com/OlivierZal/melcloud-api/compare/v47.1.1...HEAD
+[48.0.0]: https://github.com/OlivierZal/melcloud-api/compare/v47.1.1...v48.0.0
 [46.0.1]: https://github.com/OlivierZal/melcloud-api/compare/46.0.0...46.0.1
 [46.0.0]: https://github.com/OlivierZal/melcloud-api/compare/45.1.0...46.0.0
 [45.1.0]: https://github.com/OlivierZal/melcloud-api/compare/45.0.2...45.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "47.1.1",
+  "version": "48.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "47.1.1",
+      "version": "48.0.0",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "47.1.1",
+  "version": "48.0.0",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",


### PR DESCRIPTION
Releases the Node floor alignment merged in #1705.

**Major**: `engines.node` narrows to `>=22.20.0`, so the package no longer claims support for Node 22.0–22.19.x. No API surface changes; nothing changes at runtime (`engines` is advisory absent `engine-strict`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3