### PR TITLE
docs: state the durable reason behind the u-flag pin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,10 +135,16 @@ where even reads need auth).
 
 ## Lint doctrine
 
-- Shipped regexes stay on the `u` flag — the es2024 `v` flag is a
-  parse-time SyntaxError on Homey Pro 2016-2019 (Node < 20) and killed
-  the consuming app at boot (2026-08 crash report). The overlay pins
-  `require-unicode-regexp` to `u`.
+- Shipped regexes stay on the `u` flag, and the reason is PERMANENT,
+  not the firmware gap that first surfaced it: the consuming apps
+  bundle this package into their PHONE WEBVIEWS. `/constants` is
+  imported for values, not types, and esbuild inlines them —
+  `coolingMin:16` sits in com.melcloud's shipped widget bundle — so
+  every `src` module is a candidate for a WebKit engine that rejects
+  the es2024 `v` flag at parse time. No Homey update lifts that floor.
+  Scoping the rule to the reachable subset would drift with every
+  import change, so the overlay pins `require-unicode-regexp` to `u`
+  across all of `src`.
 
 - Code adapts to the rules, never the reverse. Never add a disable — not
   inline, not through config options or ignore regexes: refactor until the

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -65,10 +65,13 @@ const config: Config[] = defineConfig([
     rules: { '@typescript-eslint/no-magic-numbers': 'off' },
   },
   {
-    // Shipped regexes stay on the `u` flag: the es2024 `v` flag is a
-    // parse-time SyntaxError on older Homey Pro (2016-2019) firmware
-    // (pre-Node-20 runtime) — it killed the consuming app at boot
-    // there (2026-08 crash report).
+    // Shipped regexes stay on the `u` flag: the consuming apps bundle
+    // this package INTO their phone webviews — `/constants` is imported
+    // for values, and esbuild inlines them (`coolingMin:16` is in the
+    // shipped widget bundle) — and those WebKit engines reject the
+    // es2024 `v` flag at parse time. Scoping to the reachable subset is
+    // unmaintainable, so all of `src` holds the floor. Unlike the
+    // firmware gap that first surfaced this, no update lifts it.
     files: ['src/**/*.ts'],
     rules: { 'require-unicode-regexp': ['error', { requireFlag: 'u' }] },
   },


### PR DESCRIPTION
The overlay's `require-unicode-regexp` pin carried this reason: the es2024 `v` flag is a parse-time `SyntaxError` on the pre-Node-20 runtime of older Homey Pro (2016-2019) firmware.

That floor is gone for this package — it declares `engines: ">=22.20.0"`. Applying "a rule whose reason expired should not be included" would remove the pin. **That would be wrong**, and this PR records why.

## The pin stays; the reason was simply not the real one

The consuming apps bundle this package **into their phone webviews**. `com.melcloud`'s webview sources import `@olivierzal/melcloud-api/constants` for **values**, not types:

- `widgets/ata-group-setting/public/ata-values.mts` — `ClassicTemperature`, `classicCoolModes`
- `widgets/ata-group-setting/public/animation.mts` — `CLASSIC_OPERATION_MODE_MIXED`, `ClassicFanSpeed`, `ClassicOperationMode`
- `widgets/charts/public/index.mts` — `ClassicDeviceType`, `HomeDeviceType`

`scripts/bundle.mts` runs esbuild with `bundle: true` and no `external`, and the phone has no `node_modules`, so those values can only work inlined. Verified in the built artifact rather than argued:

```
$ grep -o "coolingMin[^,]*" .homeybuild/widgets/ata-group-setting/public/index.js
coolingMin:16
```

That is `ClassicTemperature.coolingMin`, this package's own value, baked into a bundle that runs on a phone WebKit engine — which rejects `v` at parse time and which **no Homey firmware update rejuvenates**. Unlike the firmware gap, this floor is permanent.

Scoping the rule to the subset reachable from `/constants` would drift with every import change, so all of `src` keeps it.

Sibling repos differ on purpose: `heatzy-api` is imported type-only by `com.heatzy` (which has no widgets at all), so its pin is being dropped in OlivierZal/heatzy-api#1204.

## Changes

Comment and doctrine only — no rule, code or behaviour changes.

## Gates

format · lint (zero disable) · typecheck · 1034 tests · **100 % on all four axes** (2400/1023/827/2357) · docs · publint