### PR TITLE
feat: export the protection bounds through a browser-safe subpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [48.1.0] - 2026-08-10
+
+### Added
+
+- **`/protection` subpath export**, so a browser bundle can read the published protection bounds instead of copying them. `FROST_PROTECTION_RANGE`, `OVERHEAT_PROTECTION_RANGE` and `PROTECTION_GAP` were reachable only through the root barrel, which pulls in the HTTP stack: bundling a _value_ from it for the browser fails on `undici`'s `node:` builtins (measured: 118 resolution errors), so a consuming webview copied the numbers into its own source instead. `dist/protection.js` imports nothing, so the new path bundles to 78 bytes with the three values inlined and the clamping helpers tree-shaken away. Strictly additive: nothing is removed and no existing import changes.
+
 ## [48.0.0] - 2026-08-10
 
 ### Changed
@@ -492,6 +498,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[48.1.0]: https://github.com/OlivierZal/melcloud-api/compare/v48.0.0...v48.1.0
 [48.0.0]: https://github.com/OlivierZal/melcloud-api/compare/v47.1.1...v48.0.0
 [47.1.1]: https://github.com/OlivierZal/melcloud-api/compare/v47.1.0...v47.1.1
 [47.1.0]: https://github.com/OlivierZal/melcloud-api/compare/v47.0.1...v47.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,9 +137,9 @@ where even reads need auth).
 
 - Shipped regexes stay on the `u` flag, and the reason is PERMANENT,
   not the firmware gap that first surfaced it: the consuming apps
-  bundle this package into their PHONE WEBVIEWS. `/constants` is
-  imported for values, not types, and esbuild inlines them —
-  `coolingMin:16` sits in com.melcloud's shipped widget bundle — so
+  bundle this package into their PHONE WEBVIEWS. `/constants` and
+  `/protection` are imported for values, not types, and esbuild inlines
+  them — `coolingMin:16` sits in com.melcloud's shipped widget bundle — so
   every `src` module is a candidate for a WebKit engine that rejects
   the es2024 `v` flag at parse time. No Homey update lifts that floor.
   Scoping the rule to the reachable subset would drift with every
@@ -200,6 +200,13 @@ where even reads need auth).
   fine for consts, types, and schemas.
 - `src/temporal.ts` is the only sanctioned `temporal-polyfill` entry point
   (enforced by `no-restricted-imports`).
+- A public module that imports nothing earns its own subpath in the
+  `exports` map (`/constants`, `/protection`). The root barrel reaches
+  the HTTP stack, so a browser bundler resolving a VALUE through it
+  fails on `undici`'s `node:` builtins (measured: 118 errors) — a
+  consumer that cannot reach a published constant copies it instead,
+  which is the drift these subpaths exist to prevent. Keep such modules
+  import-free; adding one edge closes the path silently.
 - Tests import vitest APIs explicitly (no globals) and use `it` inside
   `describe`, `.each` for tables, `describe(fn)` function titles.
   Boolean names take a semantic prefix (`is`, `has`, `should`…); `device`

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A typed Node.js client for the [MELCloud](https://app.melcloud.com/) and [MELClo
 - **Resilient by default** — auto-retry on transient failures, rate-limit awareness, pre-emptive session refresh.
 - **Validated boundaries** — Zod schemas guard every consumed payload, so upstream shape drift surfaces as a typed `ValidationError` instead of a deep `undefined` crash.
 - **Typed failures** — telemetry, reports and error-log getters return `Result<T>` so callers branch on `network` / `unauthorized` / `rate-limited` / `validation` / `server` / `not-found` instead of catching generic exceptions.
-- **Tree-shakable** — `sideEffects: false` plus `/classic`, `/home` and `/constants` subpath exports for namespace-style imports.
+- **Tree-shakable** — `sideEffects: false` plus `/classic`, `/home`, `/constants` and `/protection` subpath exports for namespace-style imports. The last two are dependency-free leaves, so a browser bundle can import their values; the root barrel reaches the HTTP stack and is Node-only.
 
 ## Requirements
 
@@ -169,9 +169,16 @@ const b: Home.AtaValues = ...
 
 // Shared enum-like constants (e.g. CLASSIC_FLAG_UNCHANGED, HomeDeviceType)
 import { ClassicDeviceType, HomeDeviceType } from '@olivierzal/melcloud-api/constants'
+
+// Protection bounds and clamping (frost, overheat)
+import { FROST_PROTECTION_RANGE } from '@olivierzal/melcloud-api/protection'
 ```
 
-Available subpaths: `/classic`, `/home`, `/constants`.
+Available subpaths: `/classic`, `/home`, `/constants`, `/protection`.
+
+`/constants` and `/protection` import nothing, so a browser bundler resolves
+them without reaching the Node-only HTTP stack that the root barrel pulls in —
+the path to take when a webview needs a published value rather than a copy.
 
 ## Documentation
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
     "./home": {
       "types": "./dist/home.d.ts",
       "default": "./dist/home.js"
+    },
+    "./protection": {
+      "types": "./dist/protection.d.ts",
+      "default": "./dist/protection.js"
     }
   },
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Why

`com.melcloud`'s settings page — a webview — rewrites by hand three values this library already publishes:

```ts
const frostProtectionTemperatureRange = { max: 16, min: 4 }      // = FROST_PROTECTION_RANGE
const overheatProtectionTemperatureRange = { max: 40, min: 31 }  // = OVERHEAT_PROTECTION_RANGE
const PROTECTION_TEMPERATURE_GAP = 2                             // = PROTECTION_GAP
```

It could not do otherwise. Those three constants were exported only by the root barrel, and bundling a **value** from the root for the browser pulls in the whole HTTP stack:

```
✘ [ERROR] Could not resolve "node:buffer"  undici/lib/core/socks5-utils.js:3
✘ [ERROR] Could not resolve "node:net"     undici/lib/core/socks5-utils.js:4
118 errors
```

The existing `type`-only imports erase at compile time, which is why nothing surfaced until a value was needed.

## What

Adds `./protection` to the `exports` map. No new API surface — the three constants and the two clamps are already public through the root; this only opens a path to them that a browser bundler can resolve.

## Why `./protection` rather than re-exporting from `./constants`

- `protection.ts` is a cohesive module whose own `@module` note says the clamping lives with the bounds *"so a direct SDK/flow call cannot escape the bounds the UIs guarantee"*. Splitting the values from the invariant that guards them would undo that.
- `constants.ts` is strictly **wire vocabulary** — dialect enums (`ClassicDeviceType`, `HomeDeviceType`, `ClassicFanSpeed`…). Protection bounds are cross-dialect domain limits; filing them there would make the module mean two things.
- A re-export would add an import edge `constants.js → protection.js`, loading a second module for every `./constants` consumer, to avoid a subpath that costs nothing.

## Measured

| bundle (esbuild, `--platform=browser --minify`) | result |
| --- | --- |
| value from the **root** | **fails**, 118 errors |
| `./constants` (existing, for reference) | 181 B, `coolingMin:16` inlined |
| the three constants from `./protection` | **78 B**, all three inlined |
| `clampFrostProtection` from `./protection` | 205 B |

Output of the 78-byte bundle — the clamps are tree-shaken away, so exposing the whole module imposes nothing on a consumer that wants only the numbers:

```js
(()=>{var t={max:16,min:4},O={max:40,min:31};globalThis.__probe=[t,O,2];})();
```

## Scope check

`protection.ts` is the **only** public zero-import module without a subpath. `fire-and-forget` and `time-units` are also leaves but are not part of the public API (the root barrel does not re-export them), so no other consumer is left facing the same wall.

## Gates

`format` · `lint` (zero disables) · `typecheck` · 1034 tests, **100% on all four axes** · `publint` *All good!* · `docs`.