### PR TITLE
chore(release): 48.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "48.0.0",
+  "version": "48.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "48.0.0",
+      "version": "48.1.0",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "48.0.0",
+  "version": "48.1.0",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",


### PR DESCRIPTION
Minor: `./protection` subpath export added in #1710 — strictly additive, nothing removed and no existing import changes.

See [CHANGELOG.md](https://github.com/OlivierZal/melcloud-api/blob/main/CHANGELOG.md#4810---2026-08-10).