### PR TITLE
build: declare the GitHub Packages registry for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,8 @@
+registries:
+  npm-github:
+    token: ${{ secrets.MY_GITHUB_PERSONAL_TOKEN }}
+    type: npm-registry
+    url: https://npm.pkg.github.com
 updates:
   # Both ecosystems share the `build(deps)` type: it keeps every bump under
   # one `git log --grep` and leaves `ci` to mean hand-written CI changes.
@@ -54,6 +59,8 @@ updates:
           - '@vitest/*'
           - vitest
     package-ecosystem: npm
+    registries:
+      - npm-github
     schedule:
       interval: weekly
 version: 2


### PR DESCRIPTION
## The defect

The repo depends on `@olivierzal/*` packages hosted on **GitHub Packages**, but `.github/dependabot.yml` declared no `registries:` block. Dependabot therefore resolved them against the public npm registry, where they do not exist — so those bumps **never ran**, silently. The `github-actions` ecosystem in the same file kept succeeding, which is why the failure stayed invisible.

## The fix

The `registries:` block and its reference from the `npm` entry, byte-identical to the ones `com.melcloud`, `com.heatzy` and `homey-kit` already carry. Seven insertions, zero deletions: the `cooldown`, the `ignore` on `OlivierZal/configs` and the pinned commit prefixes are untouched.

The `MY_GITHUB_PERSONAL_TOKEN` Dependabot secret this reads is already in place, carrying exactly the `read:packages` scope it needs.

Verified structurally rather than textually: after the change, all six repos that need a registry parse to the same `registries` mapping and the same `["npm-github"]` reference from their npm entry.