### PR TITLE
fix(build): purge dist before emitting so stale modules cannot ship

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,11 @@ is on: no runtime enums, no parameter properties, no runtime namespaces.
 - `npm run typecheck` — `tsc` from `@typescript/native` (TypeScript 7);
   does not cover `*.config.ts` (the lint does). The tooling (typedoc,
   typescript-eslint) still resolves the separate `typescript` 6.x install.
+- `npm run build` — purges `dist` before emitting, because `tsc` overwrites
+  but never deletes: a module renamed or removed in `src` would otherwise
+  survive in `dist`, and `files` ships that directory, so `prepare` would
+  pack the fossil. The purge is inline rather than a `prebuild` hook so it
+  cannot be skipped with `--ignore-scripts`.
 - `npm run format` / `npm run format:fix` — prettier.
 - `npm run docs` — typedoc. The config is `typedoc.config.js` (JSDoc-typed
   with `@ts-check`: typedoc cannot load `.ts` configs and silently ignores

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "src"
   ],
   "scripts": {
-    "build": "node ./node_modules/@typescript/native/bin/tsc --project tsconfig.build.json",
+    "build": "rm -rf dist && node ./node_modules/@typescript/native/bin/tsc --project tsconfig.build.json",
     "docs": "typedoc",
     "format": "prettier . --check",
     "format:fix": "prettier . --write",


### PR DESCRIPTION
`tsc` overwrites but never deletes: a module renamed or removed in `src` survives in `dist`. Since `files` ships that directory and `prepare` runs the build, the fossil is packed.

**Measured, not assumed.** A probe file placed in `dist` before the fix:

```
$ npm pack --dry-run --ignore-scripts | grep zz-fossile
npm notice 19B dist/zz-fossile.js
```

After the fix the same probe is gone once `npm run build` runs, and `dist` still carries its 58 expected modules.

The purge is inline in `build` rather than a `prebuild` hook so it cannot be skipped by `--ignore-scripts`, and it needs no dependency.

The published package was never affected — CI publishes from a fresh checkout — but that guarantee was circumstantial, not structural.