### PR TITLE
chore: drop the merge_group trigger an org-only feature cannot fire

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
       run-lint-package: true
 name: CI
 on:
-  merge_group: {}
   pull_request: {}
   push:
     branches: [main]

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -8,7 +8,6 @@ jobs:
     uses: OlivierZal/configs/.github/workflows/zizmor.yml@802b7e1bd61d37420efa982eb471356711b46251 # v3.2.0
 name: zizmor
 on:
-  merge_group: {}
   pull_request: {}
   push:
     branches: [main]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,10 +263,12 @@ where even reads need auth).
   declares). A Sonar finding is handled like a lint error — the code
   adapts (duplication refactors into a shared module), or the
   divergence is settled as a documented verdict — never merged over.
-- GitHub merge queue is impossible here: the repo is user-owned and the
-  feature is org-only (verified via API — no ruleset payload enables it).
-  Dependabot PRs auto-merge via `gh pr merge --auto`; the `merge_group`
-  triggers in the workflows are inert but harmless.
+- GitHub merge queue is impossible here: the feature is gated on
+  ORGANISATION ownership and this repo is user-owned (verified 2026-08
+  against the docs source). The workflows therefore declare no
+  `merge_group` trigger — an event that cannot fire needs no handling,
+  and "inert but harmless" is not a reason to keep configuration.
+  Dependabot PRs auto-merge via `gh pr merge --auto`.
 - The docs site deploys only on release or `gh workflow run docs.yml`.
 - CI: `Test (Node latest)` is `continue-on-error` by design — keep it out
   of required status checks. Sonar coverage runs on the `lts/*` leg only.


### PR DESCRIPTION
GitHub gates merge queues on **organisation ownership**. From the docs source ([`gated-features/merge-queue`](https://github.com/github/docs/blob/main/data/reusables/gated-features/merge-queue.md)):

> Pull request merge queues are available in any public repository **owned by an organization**, or in private repositories owned by organizations using GitHub Enterprise Cloud.

Every repo in this family is public but owned by a **personal account** (`owner.type = User`, checked on all seven). The `merge_group` event therefore cannot arrive, and the trigger was configuration for a need that cannot appear.

That is the same standard applied earlier today when an `allow-ghsas` input was kept out of the dependency review — *"no repo needs it; building for a need that has not appeared is precisely what we remove"*. A standard applied in one direction only is not a standard.

The doctrine is corrected where it claimed these triggers were "inert but harmless": inertness is not a reason to keep configuration.