### PR TITLE
fix: publish every flat barrel module under its own subpath

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,6 +58,14 @@ updates:
         patterns:
           - '@vitest/*'
           - vitest
+    # TypeScript 7 has no stable typedoc: 0.28.x caps its peer at 6.0.x and
+    # only the 1.0.0-dev prereleases widen it. Taking the major would trade a
+    # blocked bump for a prerelease docs toolchain in a published package.
+    # Drop this once typedoc 1.0 ships stable.
+    ignore:
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
     package-ecosystem: npm
     registries:
       - npm-github

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,13 +205,25 @@ where even reads need auth).
   fine for consts, types, and schemas.
 - `src/temporal.ts` is the only sanctioned `temporal-polyfill` entry point
   (enforced by `no-restricted-imports`).
-- A public module that imports nothing earns its own subpath in the
-  `exports` map (`/constants`, `/protection`). The root barrel reaches
-  the HTTP stack, so a browser bundler resolving a VALUE through it
-  fails on `undici`'s `node:` builtins (measured: 118 errors) — a
-  consumer that cannot reach a published constant copies it instead,
-  which is the drift these subpaths exist to prevent. Keep such modules
-  import-free; adding one edge closes the path silently.
+- Every FLAT module the root barrel re-exports earns its own subpath in
+  the `exports` map, and `tests/unit/export-map.test.ts` holds that 1:1.
+  The barrel reaches the HTTP stack, so a browser bundler resolving a
+  VALUE through it fails on `undici`'s `node:` builtins (measured: 118
+  errors); a consumer that cannot reach a published symbol copies it
+  instead, which is the drift these subpaths exist to prevent — and the
+  copy surfaces only later, at the cost of a release plus an adoption
+  round everywhere, which is what the missing `/protection` cost. A
+  subpath does NOT widen the API: the barrel already exports those
+  symbols, so it only restores reach where the barrel cannot load. The
+  criterion is the EMITTED closure, not the absence of edges —
+  `/temperature-range` reaches `utils` yet bundles to 2 052 B because
+  esbuild shakes out what no export touches. What forecloses a subpath
+  is reaching the HTTP stack, never importing a sibling. Directory
+  barrels (`errors/`, `types/`, `http/`…) are exempt by verdict, not by
+  oversight: they are grouped surfaces rather than leaves, and none has
+  been needed from a browser — the test pins their set so a new one
+  forces that decision. `./package.json` is published too: an `exports`
+  map otherwise hides the manifest from the tooling that reads it.
 - Tests import vitest APIs explicitly (no globals) and use `it` inside
   `describe`, `.each` for tables, `describe(fn)` function titles.
   Boolean names take a semantic prefix (`is`, `has`, `should`…); `device`

--- a/package.json
+++ b/package.json
@@ -31,13 +31,30 @@
       "types": "./dist/constants.d.ts",
       "default": "./dist/constants.js"
     },
+    "./enum-mappings": {
+      "types": "./dist/enum-mappings.d.ts",
+      "default": "./dist/enum-mappings.js"
+    },
+    "./holiday-mode": {
+      "types": "./dist/holiday-mode.d.ts",
+      "default": "./dist/holiday-mode.js"
+    },
     "./home": {
       "types": "./dist/home.d.ts",
       "default": "./dist/home.js"
     },
+    "./package.json": "./package.json",
     "./protection": {
       "types": "./dist/protection.d.ts",
       "default": "./dist/protection.js"
+    },
+    "./temperature-range": {
+      "types": "./dist/temperature-range.d.ts",
+      "default": "./dist/temperature-range.js"
+    },
+    "./temporal": {
+      "types": "./dist/temporal.d.ts",
+      "default": "./dist/temporal.js"
     }
   },
   "types": "dist/index.d.ts",

--- a/src/errors/base.ts
+++ b/src/errors/base.ts
@@ -1,3 +1,6 @@
+// Byte-identical twin shared by melcloud-api and heatzy-api. The
+// deferred `api-core` extraction leaves no mechanism to link them:
+// the two repos have no dependency, so edit both or neither.
 /**
  * Base class for all errors thrown by this SDK.
  * @category Errors

--- a/src/fire-and-forget.ts
+++ b/src/fire-and-forget.ts
@@ -1,3 +1,6 @@
+// Byte-identical twin shared by melcloud-api and heatzy-api. The
+// deferred `api-core` extraction leaves no mechanism to link them:
+// the two repos have no dependency, so edit both or neither.
 import type { Logger } from './api/types.ts'
 
 /**

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -1,3 +1,6 @@
+// Byte-identical twin shared by melcloud-api and heatzy-api. The
+// deferred `api-core` extraction leaves no mechanism to link them:
+// the two repos have no dependency, so edit both or neither.
 export type { LoggableRequestConfig } from './context.ts'
 
 export { createAPICallErrorData } from './error.ts'

--- a/src/observability/request.ts
+++ b/src/observability/request.ts
@@ -1,3 +1,6 @@
+// Byte-identical twin shared by melcloud-api and heatzy-api. The
+// deferred `api-core` extraction leaves no mechanism to link them:
+// the two repos have no dependency, so edit both or neither.
 import { type LoggableRequestConfig, APICallLogData } from './context.ts'
 
 /**

--- a/src/observability/response.ts
+++ b/src/observability/response.ts
@@ -1,3 +1,6 @@
+// Byte-identical twin shared by melcloud-api and heatzy-api. The
+// deferred `api-core` extraction leaves no mechanism to link them:
+// the two repos have no dependency, so edit both or neither.
 import type { HttpResponse } from '../http/index.ts'
 import { type LoggableRequestConfig, APICallLogData } from './context.ts'
 

--- a/src/temporal.ts
+++ b/src/temporal.ts
@@ -1,3 +1,6 @@
+// Byte-identical twin shared by melcloud-api and heatzy-api. The
+// deferred `api-core` extraction leaves no mechanism to link them:
+// the two repos have no dependency, so edit both or neither.
 // Re-export of `temporal-polyfill` as the single Temporal entry point
 // for the rest of the codebase. Node 22 (the minimum supported runtime)
 // does not yet ship native `Temporal`; the polyfill stays bundled

--- a/tests/unit/export-map.test.ts
+++ b/tests/unit/export-map.test.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+// The root barrel imports the HTTP stack, so it cannot be bundled for a
+// browser: a webview that needs a VALUE has to reach its module directly.
+// Every flat module the barrel re-exports is therefore published under its
+// own subpath — not to widen the API, which already exposes those symbols,
+// but to keep an already-public surface reachable where the barrel cannot
+// load. Omitting one costs a release plus an adoption round at every
+// consumer, which is what the missing `./protection` cost.
+//
+// Directory barrels are exempt by verdict, not by oversight: they are
+// grouped surfaces rather than leaves, and none has been needed from a
+// browser. DIRECTORY_REEXPORTS pins the known set so a new one forces that
+// decision instead of inheriting the exemption in silence.
+
+const DIRECTORY_REEXPORT = /from '\.\/(?<directory>[a-z\-]+)\/index\.ts'/gv
+
+const FLAT_REEXPORT = /from '\.\/(?<module>[a-z\-]+)\.ts'/gv
+
+// Answers a tooling contract rather than the barrel: consumers and linters
+// read the manifest, and Node hides it once an `exports` map exists.
+const MANIFEST_SUBPATH = './package.json'
+
+const DIRECTORY_REEXPORTS = [
+  'api',
+  'decorators',
+  'entities',
+  'errors',
+  'facades',
+  'http',
+  'types',
+]
+
+const isManifest = (
+  value: unknown,
+): value is { exports: Record<string, unknown> } =>
+  typeof value === 'object' &&
+  value !== null &&
+  'exports' in value &&
+  typeof value.exports === 'object' &&
+  value.exports !== null
+
+const readRepoFile = (relativePath: string): string =>
+  readFileSync(
+    fileURLToPath(new URL(`../../${relativePath}`, import.meta.url)),
+    'utf8',
+  )
+
+const getGroups = (
+  source: string,
+  pattern: RegExp,
+  group: string,
+): string[] => [
+  ...new Set(
+    source.matchAll(pattern).map((match) => match.groups?.[group] ?? ''),
+  ),
+]
+
+const getSubpaths = (): string[] => {
+  const manifest: unknown = JSON.parse(readRepoFile('package.json'))
+  if (!isManifest(manifest)) {
+    throw new Error('package.json declares no `exports` map')
+  }
+  return Object.keys(manifest.exports)
+}
+
+describe.concurrent('export map', () => {
+  const barrel = readRepoFile('src/index.ts')
+  const flatModules = getGroups(barrel, FLAT_REEXPORT, 'module')
+  const directories = getGroups(barrel, DIRECTORY_REEXPORT, 'directory')
+  const subpaths = getSubpaths()
+
+  // Guards the guard: a broken extractor would make every assertion below
+  // pass over an empty set.
+  it('finds the flat modules the root barrel re-exports', () => {
+    expect(flatModules.length).toBeGreaterThan(3)
+    expect(flatModules).toContain('protection')
+  })
+
+  it.each(flatModules)('publishes %s under its own subpath', (module) => {
+    expect(subpaths).toContain(`./${module}`)
+  })
+
+  // A new directory barrel must be weighed, not silently exempted.
+  it('exempts only the directory barrels this verdict names', () => {
+    expect(
+      directories.toSorted((left, right) => left.localeCompare(right)),
+    ).toStrictEqual(DIRECTORY_REEXPORTS)
+  })
+
+  it.each(subpaths.filter((subpath) => subpath !== MANIFEST_SUBPATH))(
+    'points %s at files the build emits',
+    (subpath) => {
+      const target = subpath === '.' ? 'index' : subpath.slice(2)
+
+      expect(() => readRepoFile(`src/${target}.ts`)).not.toThrow()
+    },
+  )
+
+  // Tooling that reads the manifest breaks once an `exports` map exists
+  // unless the manifest is published explicitly.
+  it('publishes the manifest itself', () => {
+    expect(subpaths).toContain(MANIFEST_SUBPATH)
+  })
+})


### PR DESCRIPTION
## Why

The root barrel imports the HTTP stack, so a browser bundler resolving a **value** through it fails on `undici`'s `node:` builtins. Measured on the packaged tarball:

| import | browser bundle |
| --- | --- |
| root barrel | **fails** |
| `./constants` | 1 840 B |
| `./enum-mappings` | 2 134 B |
| `./holiday-mode` | 38 B |
| `./protection` | 476 B |
| `./temperature-range` | 2 052 B |
| `./temporal` | 58 697 B |

`rangeForHomeMode` / `rangeForClassicMode` — the shared temperature surface itself — were reachable only through the barrel, so no webview could reach them.

## The criterion

Every **flat** module the barrel re-exports earns its own subpath, held 1:1 by `tests/unit/export-map.test.ts`. A subpath does not widen the API: those symbols are already public; it only restores reach where the barrel cannot load.

The criterion is the **emitted closure**, not the absence of edges — `/temperature-range` reaches `utils` yet bundles to 2 052 B because esbuild shakes out what no export touches. This replaces the previous doctrine, which claimed a module must import nothing and that "adding one edge closes the path silently". Both were false.

Directory barrels (`errors/`, `types/`, `http/`…) stay exempt **by verdict**: grouped surfaces rather than leaves, none needed from a browser. The test pins their set, so a new one forces the decision instead of inheriting the exemption from a regex.

## Mutations

| mutation | test that fails |
| --- | --- |
| `./temperature-range` removed | publishes temperature-range under its own subpath |
| `./package.json` removed | publishes the manifest itself |
| extractor neutralised | finds the flat modules the root barrel re-exports |
| undeclared directory barrel added | exempts only the directory barrels this verdict names |

## Also

- **`./package.json` published** — an exports map otherwise hides the manifest from tooling that reads it.
- **Twin marks** on the six files kept byte-identical with `heatzy-api`. Nothing linked them; the two repos have no dependency, so no test of one can read the other. The header is symmetric — naming the opposite repo would have made the copies differ and broken the invariant it documents. Byte-identity verified after marking.
- **TypeScript held on 6.x** — no stable typedoc accepts 7 (`0.28.x` caps its peer at `6.0.x`; only `1.0.0-dev` prereleases widen it). The ignore carries its reason and the trigger that retires it.

Local: format, lint (no disables), typecheck, **1052 tests, 100 % on all four axes**, publint, docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3