### PR TITLE
fix(lint): hold the es2023 floor over the browser-reachable closure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,13 @@ where even reads need auth).
   the es2024 `v` flag at parse time. No Homey update lifts that floor.
   Scoping the rule to the reachable subset would drift with every
   import change, so the overlay pins `require-unicode-regexp` to `u`
-  across all of `src`.
+  across all of `src`. The FULL es2023 floor (`webviewFloorBlock` —
+  no `Object.groupBy`/`Map.groupBy`, no iterator helpers) applies on
+  top of that to the browser-reachable closure alone: the flat subpath
+  modules plus their value-import closure, held against drift by
+  `tests/unit/webview-floor.test.ts`, which recomputes the closure and
+  fails in both directions. Node-only layers (facades, entities, HTTP,
+  observability) keep the modern-API freedom the device Node allows.
 
 - Code adapts to the rules, never the reverse. Never add a disable — not
   inline, not through config options or ignore regexes: refactor until the

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,5 +1,22 @@
+import { webviewFloorBlock } from '@olivierzal/configs/eslint'
 import { library } from '@olivierzal/configs/eslint/library'
 import { type Config, defineConfig } from 'eslint/config'
+
+// The browser-reachable closure: the flat subpath modules of the
+// export map plus their value-import closure (`utils.ts`, reached via
+// `enum-mappings.ts`). These are the modules the consuming apps bundle
+// into phone webviews, so the full es2023 API floor applies — not just
+// the `u`-flag step-down below. `tests/unit/webview-floor.test.ts`
+// recomputes the closure and fails when this list drifts from it.
+const WEBVIEW_FLOOR_FILES = [
+  'src/constants.ts',
+  'src/enum-mappings.ts',
+  'src/holiday-mode.ts',
+  'src/protection.ts',
+  'src/temperature-range.ts',
+  'src/temporal.ts',
+  'src/utils.ts',
+]
 
 const config: Config[] = defineConfig([
   {
@@ -64,6 +81,7 @@ const config: Config[] = defineConfig([
     files: ['src/facades/classic-flags.ts'],
     rules: { '@typescript-eslint/no-magic-numbers': 'off' },
   },
+  webviewFloorBlock(WEBVIEW_FLOOR_FILES),
   {
     // Shipped regexes stay on the `u` flag: the consuming apps bundle
     // this package INTO their phone webviews — `/constants` is imported

--- a/tests/unit/webview-floor.test.ts
+++ b/tests/unit/webview-floor.test.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+// The es2023 webview floor must cover exactly the browser-reachable
+// closure: the flat modules the root barrel re-exports (each published
+// under its own subpath) plus every module they reach through a VALUE
+// import — type imports erase at emit, so they pull nothing into a
+// bundle. A file the closure reaches but the floor list misses would
+// ship API the phone engines lack without any lint saying so; a file
+// the list names but the closure no longer reaches would pin the floor
+// on dead scope. Both directions fail here.
+
+const FLAT_REEXPORT = /from '\.\/(?<module>[a-z\-]+)\.ts'/gv
+
+const FLOOR_LIST = /const WEBVIEW_FLOOR_FILES = \[(?<entries>[^\]]*)\]/gv
+
+const FLOOR_ENTRY = /'(?<file>[^']+)'/gv
+
+// One statement spans from `import` to its single `from` clause; the
+// lazy quantifier stops at the first, so statements never bleed into
+// each other even without semicolons.
+const IMPORT_STATEMENT =
+  /^import(?<typeOnly> type)? (?<clause>[\s\S]*?)from '(?<specifier>[^']+)'/gmv
+
+const RELATIVE_FLAT = /^\.\/(?<module>[a-z\-]+)\.ts$/v
+
+const byName = (left: string, right: string): number =>
+  left.localeCompare(right)
+
+const readRepoFile = (relativePath: string): string =>
+  readFileSync(
+    fileURLToPath(new URL(`../../${relativePath}`, import.meta.url)),
+    'utf8',
+  )
+
+// The flat modules a source file pulls in through value imports.
+const getValueImports = (source: string): string[] =>
+  source
+    .matchAll(IMPORT_STATEMENT)
+    .filter((statement) => statement.groups?.typeOnly === undefined)
+    .map(
+      (statement) =>
+        RELATIVE_FLAT.exec(statement.groups?.specifier ?? '')?.groups?.module,
+    )
+    .filter((module) => module !== undefined)
+    .toArray()
+
+const getEmittedClosure = (seed: readonly string[]): string[] => {
+  const closure = new Set<string>()
+  const pending = [...seed]
+  for (
+    let module = pending.pop();
+    module !== undefined;
+    module = pending.pop()
+  ) {
+    if (closure.has(module)) {
+      continue
+    }
+    closure.add(module)
+    pending.push(...getValueImports(readRepoFile(`src/${module}.ts`)))
+  }
+  return [...closure].toSorted(byName)
+}
+
+describe.concurrent('webview floor closure', () => {
+  const barrel = readRepoFile('src/index.ts')
+  const seed = [
+    ...new Set(
+      barrel.matchAll(FLAT_REEXPORT).map((match) => match.groups?.module),
+    ),
+  ].filter((module) => module !== undefined)
+  const floorEntries = readRepoFile('eslint.config.ts')
+    .matchAll(FLOOR_LIST)
+    .flatMap((match) => (match.groups?.entries ?? '').matchAll(FLOOR_ENTRY))
+    .map((match) => match.groups?.file)
+    .filter((file) => file !== undefined)
+    .toArray()
+
+  // Guards the guard: broken extractors would equal two empty sets.
+  it('finds the flat re-exports and the floor list', () => {
+    expect(seed.length).toBeGreaterThan(3)
+    expect(floorEntries.length).toBeGreaterThan(3)
+  })
+
+  it('follows at least one value-import edge beyond the seed', () => {
+    expect(getEmittedClosure(seed).length).toBeGreaterThan(seed.length)
+  })
+
+  it('floors exactly the browser-reachable closure', () => {
+    expect(floorEntries.toSorted(byName)).toStrictEqual(
+      getEmittedClosure(seed).map((module) => `src/${module}.ts`),
+    )
+  })
+})


### PR DESCRIPTION
Counter-verification finding: the full webview floor applied nowhere in this package while its flat subpaths ship into phone webviews by design. `webviewFloorBlock` now covers the browser-reachable closure (the six flat barrel re-exports + `utils.ts`), and `tests/unit/webview-floor.test.ts` recomputes that closure from the sources — set equality, both directions, mutation-proven. Measured: no floored module violates the floor today (`.toArray()`/`Map.groupBy` all live in node-only layers), so nothing changes for the pending 48.2.0 release beyond the guard itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAgoJMEusWfZN41P7M9JP3