### PR TITLE
build: adopt @olivierzal/configs 4.0.1 and derive the regex-floor wording

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       packages: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
     with:
       run-docs: true
       run-lint-package: true

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
 name: claude-code-review
 on:
   pull_request:

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
     with:
       repo-guidance: >-
         Twin discipline: several source and test files here are

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -6,7 +6,7 @@ jobs:
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
 name: claude-issue-triage
 on:
   issues:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/claude.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
 name: claude
 on:
   # No pull_request_review(_comment): Copilot auto-review fires them as a

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: OlivierZal/configs/.github/workflows/dependabot.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/dependabot.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
 name: dependabot
 on:
   pull_request: {}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,7 +3,7 @@ jobs:
   dependency-review:
     permissions:
       contents: read
-    uses: OlivierZal/configs/.github/workflows/dependency-review.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/dependency-review.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
 name: Dependency review
 on:
   pull_request: {}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ jobs:
   pr_title:
     permissions:
       pull-requests: read
-    uses: OlivierZal/configs/.github/workflows/pr-title.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/pr-title.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
 name: pr-title
 on:
   pull_request:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: OlivierZal/configs/.github/workflows/zizmor.yml@dd5ebe19d5b7f3381c34aa25ccba6ce7f324116f # v4.0.0
+    uses: OlivierZal/configs/.github/workflows/zizmor.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
 name: zizmor
 on:
   pull_request: {}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,13 +140,19 @@ where even reads need auth).
 
 ## Lint doctrine
 
-- Shipped regexes stay on the `u` flag, and the reason is PERMANENT,
-  not the firmware gap that first surfaced it: the consuming apps
-  bundle this package into their PHONE WEBVIEWS. `/constants` and
-  `/protection` are imported for values, not types, and esbuild inlines
-  them — `coolingMin:16` sits in com.melcloud's shipped widget bundle — so
-  every `src` module is a candidate for a WebKit engine that rejects
-  the es2024 `v` flag at parse time. No Homey update lifts that floor.
+- Shipped regexes stay on the `u` flag, and the reason outlives the
+  firmware gap that first surfaced it: the consuming apps bundle this
+  package into their PHONE WEBVIEWS. `/constants` and `/protection`
+  are imported for values, not types, and esbuild inlines them —
+  `coolingMin:16` sits in com.melcloud's shipped widget bundle — so
+  every `src` module is a candidate for the worst webview engine the
+  Homey mobile app admits: iOS 16.4's WebKit (its App Store minimum,
+  read 2026-08-11), which predates the `v` flag. Under the apps'
+  sub-es2024 esbuild target an escaped `v` literal ships as a
+  `new RegExp` call and throws at runtime inside the feature that
+  runs it — the parse-time crash of incident 45.x was this library's
+  tsc output on device Node, a different path. No Homey update lifts
+  that floor; the App Store minimum reaching 17.4 re-opens es2024.
   Scoping the rule to the reachable subset would drift with every
   import change, so the overlay pins `require-unicode-regexp` to `u`
   across all of `src`. The FULL es2023 floor (`webviewFloorBlock` —

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -86,10 +86,12 @@ const config: Config[] = defineConfig([
     // Shipped regexes stay on the `u` flag: the consuming apps bundle
     // this package INTO their phone webviews — `/constants` is imported
     // for values, and esbuild inlines them (`coolingMin:16` is in the
-    // shipped widget bundle) — and those WebKit engines reject the
-    // es2024 `v` flag at parse time. Scoping to the reachable subset is
-    // unmaintainable, so all of `src` holds the floor. Unlike the
-    // firmware gap that first surfaced this, no update lifts it.
+    // shipped widget bundle) — and the worst engine the Homey app
+    // admits, iOS 16.4's WebKit (App Store minimum, 2026-08-11),
+    // predates the `v` flag: an escapee ships as `new RegExp` under
+    // the apps' esbuild target and throws at runtime. Scoping to the
+    // reachable subset is unmaintainable, so all of `src` holds the
+    // floor until the App Store minimum reaches 17.4.
     files: ['src/**/*.ts'],
     rules: { 'require-unicode-regexp': ['error', { requireFlag: 'u' }] },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@olivierzal/configs": "4.0.0",
+        "@olivierzal/configs": "4.0.1",
         "@types/node": "^26.1.2",
         "@typescript/native": "npm:typescript@^7.0.2",
         "@vitest/coverage-v8": "^4.1.10",
@@ -586,9 +586,9 @@
       }
     },
     "node_modules/@olivierzal/configs": {
-      "version": "4.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/4.0.0/e9c57bdad07904b2daa123538bf5408db87d430e",
-      "integrity": "sha512-ERblKVcsjHmoOWvo97q3U7Qk3IrzgzCkwgW4pfe53RETUb+f0Xh+2Woqubr3jmdi7I9aBw36FeE/IRMyTyD+Lw==",
+      "version": "4.0.1",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/4.0.1/baaf00059f15b95f4f339311beb52db55658bf4a",
+      "integrity": "sha512-gz7mQl4K2OA9H3qMrzt5Y2dOCMG9UhIorxQoK8G12+KYzSuG2PxhBiqakDGsIVtxdfCPpLiW/6hC3juTeUG5Dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@olivierzal/configs": "4.0.0",
+    "@olivierzal/configs": "4.0.1",
     "@types/node": "^26.1.2",
     "@typescript/native": "npm:typescript@^7.0.2",
     "@vitest/coverage-v8": "^4.1.10",


### PR DESCRIPTION
Adopts configs 4.0.1 — the release that carries OlivierZal/configs#57's corrected webview-floor doctrine into the installed artifact. Both channels move together: the npm pin to `4.0.1`, every workflow ref to `1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1`.

Iso-behavior: `eslint --print-config` on `src/constants.ts` (inside the webview floor) and `src/http/client.ts` (node-only) differs from 4.0.0 only in `message` strings (4 lines, all in the floor file; the node-side file is byte-identical) — selectors, globs and severities untouched. Not a policy change.

This PR also carries the two doctrine edits: the CLAUDE.md lint-doctrine bullet and the `eslint.config.ts` overlay comment carried the claim #57 invalidated ("rejects the es2024 `v` flag at parse time" / "no update lifts it"). They now state the derived floor (iOS 16.4's WebKit, the Homey app's App Store minimum as read 2026-08-11), the runtime failure mode under the apps' sub-es2024 esbuild target (an escaped `v` literal ships as a `new RegExp` call and throws at runtime, localized to the feature that runs it), and the 17.4 re-evaluation trigger — and they distinguish the incident 45.x parse-time crash (this library's tsc output on device Node) from the webview case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
