### PR TITLE
build: adopt @olivierzal/configs 4.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       packages: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
+    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@8e7ae72e9efcbb5b201ea9e43e248ea5f9d2da76 # v4.1.0
     with:
       run-docs: true
       run-lint-package: true

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
+    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@8e7ae72e9efcbb5b201ea9e43e248ea5f9d2da76 # v4.1.0
 name: claude-code-review
 on:
   pull_request:

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
+    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@8e7ae72e9efcbb5b201ea9e43e248ea5f9d2da76 # v4.1.0
     with:
       repo-guidance: >-
         Twin discipline: several source and test files here are

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -6,7 +6,7 @@ jobs:
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
+    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@8e7ae72e9efcbb5b201ea9e43e248ea5f9d2da76 # v4.1.0
 name: claude-issue-triage
 on:
   issues:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
+    uses: OlivierZal/configs/.github/workflows/claude.yml@8e7ae72e9efcbb5b201ea9e43e248ea5f9d2da76 # v4.1.0
 name: claude
 on:
   # No pull_request_review(_comment): Copilot auto-review fires them as a

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: OlivierZal/configs/.github/workflows/dependabot.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
+    uses: OlivierZal/configs/.github/workflows/dependabot.yml@8e7ae72e9efcbb5b201ea9e43e248ea5f9d2da76 # v4.1.0
 name: dependabot
 on:
   pull_request: {}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,7 +3,7 @@ jobs:
   dependency-review:
     permissions:
       contents: read
-    uses: OlivierZal/configs/.github/workflows/dependency-review.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
+    uses: OlivierZal/configs/.github/workflows/dependency-review.yml@8e7ae72e9efcbb5b201ea9e43e248ea5f9d2da76 # v4.1.0
 name: Dependency review
 on:
   pull_request: {}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ jobs:
   pr_title:
     permissions:
       pull-requests: read
-    uses: OlivierZal/configs/.github/workflows/pr-title.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
+    uses: OlivierZal/configs/.github/workflows/pr-title.yml@8e7ae72e9efcbb5b201ea9e43e248ea5f9d2da76 # v4.1.0
 name: pr-title
 on:
   pull_request:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: OlivierZal/configs/.github/workflows/zizmor.yml@1fbb744f0684e5ead7f5e919d6f6ad1e973e54b4 # v4.0.1
+    uses: OlivierZal/configs/.github/workflows/zizmor.yml@8e7ae72e9efcbb5b201ea9e43e248ea5f9d2da76 # v4.1.0
 name: zizmor
 on:
   pull_request: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@olivierzal/configs": "4.0.1",
+        "@olivierzal/configs": "4.1.0",
         "@types/node": "^26.1.2",
         "@typescript/native": "npm:typescript@^7.0.2",
         "@vitest/coverage-v8": "^4.1.10",
@@ -586,9 +586,9 @@
       }
     },
     "node_modules/@olivierzal/configs": {
-      "version": "4.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/4.0.1/baaf00059f15b95f4f339311beb52db55658bf4a",
-      "integrity": "sha512-gz7mQl4K2OA9H3qMrzt5Y2dOCMG9UhIorxQoK8G12+KYzSuG2PxhBiqakDGsIVtxdfCPpLiW/6hC3juTeUG5Dg==",
+      "version": "4.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/4.1.0/8ecb9ccefacf58f42d7b1077c301fe0994845cc6",
+      "integrity": "sha512-Mu5lWqr5rzqk4R/Rqn9eLcHIMGBZZQpHgKWABJFCoqNYM/S3ArabKRkSYVWpFo3bqg5nbB+HzyUZFSrYHRKcfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@olivierzal/configs": "4.0.1",
+    "@olivierzal/configs": "4.1.0",
     "@types/node": "^26.1.2",
     "@typescript/native": "npm:typescript@^7.0.2",
     "@vitest/coverage-v8": "^4.1.10",


### PR DESCRIPTION
Adopts configs 4.1.0 — ESM-named config files (`*.config.{js,mjs,mts,ts}`) join the config blocks, and the config export pattern is documented as derived from `isolatedDeclarations` (TS9037) rather than style. Both channels move together: the npm pin to `4.1.0`, every workflow ref to `8e7ae72e9efcbb5b201ea9e43e248ea5f9d2da76 # v4.1.0`.

Iso-behavior, stated exactly rather than claimed loosely: against 4.0.1, `eslint --print-config` differs in two option values that print into every file's resolved config — the `import-x/no-extraneous-dependencies` devDependencies allow-list now reads `*.config.{js,mjs,mts,ts}`, and `projectService.allowDefaultProject` gains `*.config.mjs` beside `*.config.js`. No file matching an ESM config name exists in this tree, so no file's lint outcome moves, and `npm run lint` is green on 4.1.0. Capability release, not policy — the first adoption attempt was refused by its own gate for predicting a byte-identical diff, and this body replaces the false prediction with the measured delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
