### PR TITLE
build: adopt @olivierzal/configs 4.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
       packages: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@8e7ae72e9efcbb5b201ea9e43e248ea5f9d2da76 # v4.1.0
+    uses: OlivierZal/configs/.github/workflows/reusable-ci.yml@9a7c5901faa9f17cf82b67553434c80a21a1df36 # v4.2.0
     with:
       run-docs: true
       run-lint-package: true

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,7 @@ jobs:
       pull-requests: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@8e7ae72e9efcbb5b201ea9e43e248ea5f9d2da76 # v4.1.0
+    uses: OlivierZal/configs/.github/workflows/claude-code-review.yml@9a7c5901faa9f17cf82b67553434c80a21a1df36 # v4.2.0
 name: claude-code-review
 on:
   pull_request:

--- a/.github/workflows/claude-dependabot-fix.yml
+++ b/.github/workflows/claude-dependabot-fix.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@8e7ae72e9efcbb5b201ea9e43e248ea5f9d2da76 # v4.1.0
+    uses: OlivierZal/configs/.github/workflows/reusable-claude-dependabot-fix.yml@9a7c5901faa9f17cf82b67553434c80a21a1df36 # v4.2.0
     with:
       repo-guidance: >-
         Twin discipline: several source and test files here are

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -6,7 +6,7 @@ jobs:
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@8e7ae72e9efcbb5b201ea9e43e248ea5f9d2da76 # v4.1.0
+    uses: OlivierZal/configs/.github/workflows/claude-issue-triage.yml@9a7c5901faa9f17cf82b67553434c80a21a1df36 # v4.2.0
 name: claude-issue-triage
 on:
   issues:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    uses: OlivierZal/configs/.github/workflows/claude.yml@8e7ae72e9efcbb5b201ea9e43e248ea5f9d2da76 # v4.1.0
+    uses: OlivierZal/configs/.github/workflows/claude.yml@9a7c5901faa9f17cf82b67553434c80a21a1df36 # v4.2.0
 name: claude
 on:
   # No pull_request_review(_comment): Copilot auto-review fires them as a

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: OlivierZal/configs/.github/workflows/dependabot.yml@8e7ae72e9efcbb5b201ea9e43e248ea5f9d2da76 # v4.1.0
+    uses: OlivierZal/configs/.github/workflows/dependabot.yml@9a7c5901faa9f17cf82b67553434c80a21a1df36 # v4.2.0
 name: dependabot
 on:
   pull_request: {}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,7 +3,7 @@ jobs:
   dependency-review:
     permissions:
       contents: read
-    uses: OlivierZal/configs/.github/workflows/dependency-review.yml@8e7ae72e9efcbb5b201ea9e43e248ea5f9d2da76 # v4.1.0
+    uses: OlivierZal/configs/.github/workflows/dependency-review.yml@9a7c5901faa9f17cf82b67553434c80a21a1df36 # v4.2.0
 name: Dependency review
 on:
   pull_request: {}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,7 +3,7 @@ jobs:
   pr_title:
     permissions:
       pull-requests: read
-    uses: OlivierZal/configs/.github/workflows/pr-title.yml@8e7ae72e9efcbb5b201ea9e43e248ea5f9d2da76 # v4.1.0
+    uses: OlivierZal/configs/.github/workflows/pr-title.yml@9a7c5901faa9f17cf82b67553434c80a21a1df36 # v4.2.0
 name: pr-title
 on:
   pull_request:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,7 +5,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: OlivierZal/configs/.github/workflows/zizmor.yml@8e7ae72e9efcbb5b201ea9e43e248ea5f9d2da76 # v4.1.0
+    uses: OlivierZal/configs/.github/workflows/zizmor.yml@9a7c5901faa9f17cf82b67553434c80a21a1df36 # v4.2.0
 name: zizmor
 on:
   pull_request: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@olivierzal/configs": "4.1.0",
+        "@olivierzal/configs": "4.2.0",
         "@types/node": "^26.1.2",
         "@typescript/native": "npm:typescript@^7.0.2",
         "@vitest/coverage-v8": "^4.1.10",
@@ -127,20 +127,20 @@
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.91.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.91.0.tgz",
-      "integrity": "sha512-vgqlMGNNhZxwDYbUNIHj3Hskb4R28iqdXx90ufHyt/NeuTQkeqjTDslAs9I0/GCAfbxP5BpH5WsL1R1fht5Lxg==",
+      "version": "0.95.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.95.0.tgz",
+      "integrity": "sha512-jbzwtRPuw1Nzld0lacvr1vwzPU/6zEHFGK5YOTstl2MQYMZBuKmSW3HMuEwsq1v4meK5Do4lizxyd/hi25rCZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.9",
-        "@typescript-eslint/types": "^8.65.0",
-        "comment-parser": "1.4.7",
+        "@typescript-eslint/types": "^8.67.0",
+        "comment-parser": "1.4.8",
         "esquery": "^1.7.0",
-        "jsdoc-type-pratt-parser": "~8.0.0"
+        "jsdoc-type-pratt-parser": "~9.1.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^22.22.2 || >=24.15.0"
       }
     },
     "node_modules/@es-joy/resolve.exports": {
@@ -586,9 +586,9 @@
       }
     },
     "node_modules/@olivierzal/configs": {
-      "version": "4.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/4.1.0/8ecb9ccefacf58f42d7b1077c301fe0994845cc6",
-      "integrity": "sha512-Mu5lWqr5rzqk4R/Rqn9eLcHIMGBZZQpHgKWABJFCoqNYM/S3ArabKRkSYVWpFo3bqg5nbB+HzyUZFSrYHRKcfQ==",
+      "version": "4.2.0",
+      "resolved": "https://npm.pkg.github.com/download/@olivierzal/configs/4.2.0/84ca347824f442a050b658820d14e0220c592e61",
+      "integrity": "sha512-rwjg44aaHd+PZ6hAxDd8bJew7XIQrUd/sn3fSQwC5y31/hjk/xy6VYpWczYlWYVTNd0LKcZMqc0kTLE5osB9Pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -602,7 +602,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^4.4.5",
         "eslint-plugin-import-x": "^4.17.1",
-        "eslint-plugin-jsdoc": "^63.3.3",
+        "eslint-plugin-jsdoc": "^64.2.0",
         "eslint-plugin-package-json": "^1.6.2",
         "eslint-plugin-perfectionist": "^5.10.0",
         "eslint-plugin-unicorn": "^73.0.0",
@@ -2612,13 +2612,13 @@
       }
     },
     "node_modules/are-docs-informative": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
-      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.1.1.tgz",
+      "integrity": "sha512-sqRsNQBwbKLRX0jV5Cu5uzmtflf892n4Vukz7T659ebL4pz3mpOqCMU7lxMoBTFwnp10E3YB5ZcyHM41W5bcDA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/argparse": {
@@ -2816,9 +2816,9 @@
       }
     },
     "node_modules/comment-parser": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.7.tgz",
-      "integrity": "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.8.tgz",
+      "integrity": "sha512-rKZTGo4fzKYna8UcL0isTg5wkBNla7bxTypLwZQXjIdi++IdP1OJ41rI5Mti3/jltkPujbu4i9LIARYA+zpotQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3268,18 +3268,18 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "63.3.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.3.3.tgz",
-      "integrity": "sha512-xI4IeVRzRFA2DGHrPLIxF3U+oJHU3FE+P9Zb27fVs5dPHgfcpoAs0PyCbznVhK7pwR+9BPUztFeXSgpw/CL4Yg==",
+      "version": "64.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-64.2.0.tgz",
+      "integrity": "sha512-z3zGmJoPhOdKnxzQ3R+8MZeJjW8vrRW8r7sYp/ErBp8K9+05RIa6vWXtbEGr7D1obBHk64LdKyLHoMLSzHFINA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.91.0",
+        "@es-joy/jsdoccomment": "~0.95.0",
         "@es-joy/resolve.exports": "1.2.0",
-        "are-docs-informative": "^0.0.2",
-        "comment-parser": "1.4.7",
+        "are-docs-informative": "^0.1.1",
+        "comment-parser": "1.4.8",
         "debug": "^4.4.3",
-        "escape-string-regexp": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
         "espree": "^11.2.0",
         "esquery": "^1.7.0",
         "html-entities": "^2.6.0",
@@ -3290,10 +3290,23 @@
         "to-valid-identifier": "^1.0.0"
       },
       "engines": {
-        "node": "^22.13.0 || >=24"
+        "node": "^22.22.2 || >=24.15.0"
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
@@ -4004,13 +4017,16 @@
       "license": "MIT"
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-8.0.0.tgz",
-      "integrity": "sha512-uQu/fXVqVaMg6gM8/E5G5+eygVcZ1NV0Z51CvqhNa2bDWxvHMl484ETr6vph4oPyC+KUcbP/w2W2pewfCiR9aQ==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-9.1.1.tgz",
+      "integrity": "sha512-kojSbQb9iQM2bk2PmHiKa3reG0U4v2gN9U8D8+eCQq+4KM5ZXBUyBVeF8KmR0RiwqyrW4+uVWYWTOLnpsavnkw==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.9"
+      },
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^22.22.2 || >=24.15.0"
       }
     },
     "node_modules/jsesc": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@olivierzal/configs": "4.1.0",
+    "@olivierzal/configs": "4.2.0",
     "@types/node": "^26.1.2",
     "@typescript/native": "npm:typescript@^7.0.2",
     "@vitest/coverage-v8": "^4.1.10",


### PR DESCRIPTION
Both channels move together: npm pin 4.1.0 -> 4.2.0 (exact) and all 9 workflow refs `8e7ae72e9efcbb5b201ea9e43e248ea5f9d2da76` (v4.1.0) -> `9a7c5901faa9f17cf82b67553434c80a21a1df36` (v4.2.0).

## Policy changes adopted

- **eslint (configs#64)**: `eslint-plugin-jsdoc` 63.3.3 -> 64.2.0; `jsdoc/check-param-names` now runs with `enableFixer: true`, so out-of-order `@param` blocks are reordered into signature order by `--fix`. `extraParams` and `badParamNames` stay off.
- **ci (configs#65)**: the triage reusable now posts deterministically — a read-only agent emits one fenced JSON verdict and a deterministic step validates it, posts the comment, and fails the run otherwise. Stub YAML here is unchanged; only the called reusable moves.

## Measured print-config delta

`npx eslint --print-config src/index.ts`, before vs after, compared rule by rule — exactly one delta, byte-identical otherwise:

```
jsdoc/check-param-names: [2] -> [2, {"enableFixer": true}]
```

## Verification

- `npm run typecheck`: clean (exit 0)
- `npm test`: 1055/1055 passing across 44 files (exit 0)
- lint runs in CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn
