### PR TITLE
fix: project holiday-mode windows between the caller's clock and UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -521,6 +521,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[49.0.0]: https://github.com/OlivierZal/melcloud-api/compare/v48.2.0...v49.0.0
 [48.2.0]: https://github.com/OlivierZal/melcloud-api/compare/v48.1.0...v48.2.0
 [48.1.0]: https://github.com/OlivierZal/melcloud-api/compare/v48.0.0...v48.1.0
 [48.0.0]: https://github.com/OlivierZal/melcloud-api/compare/v47.1.1...v48.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [49.0.0] - 2026-08-18
+
+### Fixed
+
+- **Holiday-mode windows are no longer shifted by the caller's UTC offset** ([com.melcloud#1593](https://github.com/OlivierZal/com.melcloud/issues/1593)). Both MELCloud wires store holiday-mode datetimes as UTC wall clock, but the facades passed the caller's wall clock through verbatim in both directions — so every window landed late by the caller's offset on write (+1 h in BST, +2 h in CEST) and displayed early by the same amount on read. The Classic write, the Home batch write and both dialects' reads now project between the caller's clock and UTC at the facade boundary. A projection existed once (`7ba6364f`, 2023) and was lost in a 2024 refactor; the contract tests that pinned the buggy verbatim round-trip now pin the projection, across both DST offsets.
+
+### Changed
+
+- **BREAKING — the holiday-mode contract now names its timezone.** `HolidayModeUpdate` and `HolidayModeState` datetimes are wall clock in the API's configured `timezone` (`ClassicAPIConfig.timezone` / `HomeAPIConfig.timezone`), falling back to the host's zone when unset. Any consumer that compensated for the missing projection by passing pre-converted UTC must stop: pass local wall clock and let the facade project. Consumers that passed local wall clock all along (the intended reading) need no change and simply start getting correct behavior.
+- New internal projection helpers `toUtcWallClock` / `toZonedWallClock` carry the boundary conversion: writes throw on malformed input before any I/O; reads pass unparseable values through verbatim, so a bad wire value cannot take a sync down. DST-gap wall clocks resolve per Temporal's `'compatible'` disambiguation.
+
 ## [48.2.0] - 2026-08-11
 
 ### Added

--- a/src/facades/classic-base.ts
+++ b/src/facades/classic-base.ts
@@ -47,6 +47,8 @@ import {
   hoursUpTo,
   mergeHourlyChartResults,
   padHourlyChartToMidnight,
+  toUtcWallClock,
+  toZonedWallClock,
   withMinuteClockLabels,
 } from '../utils.ts'
 import { HourSchema, parseOrThrow } from '../validation/index.ts'
@@ -66,14 +68,24 @@ const toProtectionState = (
       }
     : null
 
+// The wire stores UTC wall clock (its `TimeZone` field is a location
+// list, not a projection): both bounds come back projected onto the
+// caller's clock, `null` staying the wire's unset marker.
 const toHolidayModeState = (
   data: ClassicHolidayModeData,
+  timeZone?: string,
 ): HolidayModeState | null =>
   data.HMDefined
     ? {
-        endDate: data.HMEndDate,
+        endDate:
+          data.HMEndDate === null
+            ? null
+            : toZonedWallClock(data.HMEndDate, timeZone),
         isEnabled: data.HMEnabled,
-        startDate: data.HMStartDate,
+        startDate:
+          data.HMStartDate === null
+            ? null
+            : toZonedWallClock(data.HMStartDate, timeZone),
       }
     : null
 
@@ -239,10 +251,15 @@ export abstract class ClassicBaseFacade<
     isEnabled,
     startDate,
   }: HolidayModeUpdate): Promise<void> {
-    // Parse the window before the location fetch so malformed dates throw
-    // ahead of any I/O; dates are cleared when disabling.
-    const start = isEnabled ? Temporal.PlainDateTime.from(startDate) : null
-    const end = isEnabled ? Temporal.PlainDateTime.from(endDate) : null
+    // Project the window before the location fetch so malformed dates
+    // throw ahead of any I/O; dates are cleared when disabling. The
+    // caller speaks its own wall clock (`api.timezone`), the wire
+    // stores UTC — the projection this path once had (7ba6364f) and
+    // lost (b7286303), stranding every window by the caller's offset.
+    const start = isEnabled
+      ? toUtcWallClock(startDate, this.api.timezone)
+      : null
+    const end = isEnabled ? toUtcWallClock(endDate, this.api.timezone) : null
     assertUpdateAccepted(
       await this.api.updateHolidayMode({
         postData: {
@@ -299,7 +316,7 @@ export abstract class ClassicBaseFacade<
         async () => this.#getZoneHolidayMode(),
         async () => this.#getDevicesHolidayMode(),
       ),
-      toHolidayModeState,
+      (data) => toHolidayModeState(data, this.api.timezone),
     )
   }
 

--- a/src/facades/home-base-device.ts
+++ b/src/facades/home-base-device.ts
@@ -20,6 +20,7 @@ import {
   type Result,
   mapResult,
 } from '../types/index.ts'
+import { toZonedWallClock } from '../utils.ts'
 import type { ReportChartLineOptions } from './report-types.ts'
 import {
   resolveHomeDayWindow,
@@ -45,15 +46,18 @@ export const toHomeProtectionState = (
         min: protection.min,
       }
 
+// The Home wire speaks UTC wall clock everywhere (live-probed; see
+// CLAUDE.md): both bounds come back projected onto the caller's clock.
 const toHolidayModeState = (
   holidayMode: HomeHolidayMode | null,
+  timeZone?: string,
 ): HolidayModeState | null =>
   holidayMode === null
     ? null
     : {
-        endDate: holidayMode.endDate,
+        endDate: toZonedWallClock(holidayMode.endDate, timeZone),
         isEnabled: holidayMode.enabled,
-        startDate: holidayMode.startDate,
+        startDate: toZonedWallClock(holidayMode.startDate, timeZone),
       }
 
 /**
@@ -108,7 +112,7 @@ export abstract class HomeBaseDeviceFacade<TData extends HomeDeviceData>
    * @returns The cross-dialect holiday-mode state from `/context`.
    */
   public get holidayMode(): HolidayModeState | null {
-    return toHolidayModeState(this.model.data.holidayMode)
+    return toHolidayModeState(this.model.data.holidayMode, this.api.timezone)
   }
 
   /**

--- a/src/facades/home-manager.ts
+++ b/src/facades/home-manager.ts
@@ -14,6 +14,7 @@ import {
   clampFrostProtection,
   clampOverheatProtection,
 } from '../protection.ts'
+import { toUtcWallClock } from '../utils.ts'
 import type { HomeDeviceFacadeAny } from './home-types.ts'
 import { HomeBuildingAtaFacade } from './home-building-ata.ts'
 import { HomeDeviceAtaFacade } from './home-device-ata.ts'
@@ -180,10 +181,17 @@ export class HomeFacadeManager {
     deviceIds: readonly string[],
     { endDate, isEnabled, startDate }: HolidayModeUpdate,
   ): Promise<void> {
+    // The caller speaks its own wall clock, the wire stores UTC (see
+    // CLAUDE.md, live-probed); a disabled window's dates are ignored
+    // and pass through unprojected.
     await this.#api.updateHolidayMode({
       enabled: isEnabled,
-      endDate,
-      startDate,
+      endDate: isEnabled
+        ? toUtcWallClock(endDate, this.#api.timezone).toString()
+        : endDate,
+      startDate: isEnabled
+        ? toUtcWallClock(startDate, this.#api.timezone).toString()
+        : startDate,
       units: this.#toUnits(deviceIds),
     })
   }

--- a/src/holiday-mode.ts
+++ b/src/holiday-mode.ts
@@ -1,6 +1,14 @@
 /**
  * Unified holiday-mode write contract, shared by the Classic and Home APIs
  * so one window drives both without per-API translation.
+ *
+ * Every datetime crossing this contract is a zoneless ISO 8601 wall
+ * clock in the CALLER's timezone — the `timezone` both API configs
+ * take, falling back to the host's zone. Both wires store UTC; the
+ * facades project at the boundary, in both directions. Naming the zone
+ * is the point: the unnamed contract is how a projection got lost once
+ * and stranded every window by the caller's UTC offset (the ±1 h of
+ * com.melcloud#1593).
  * @module
  */
 
@@ -13,7 +21,7 @@
  */
 export interface HolidayModeState {
   /**
-   * Window end (ISO 8601 wall clock), when set.
+   * Window end (ISO 8601 wall clock in the caller's timezone), when set.
    */
   readonly endDate: string | null
   /**
@@ -21,21 +29,24 @@ export interface HolidayModeState {
    */
   readonly isEnabled: boolean
   /**
-   * Window start (ISO 8601 wall clock), when set.
+   * Window start (ISO 8601 wall clock in the caller's timezone), when
+   * set.
    */
   readonly startDate: string | null
 }
 
 /**
  * A holiday-mode window to apply. `startDate`/`endDate` are ISO 8601
- * wall-clock strings; both are ignored when `isEnabled` is `false`. The
- * start is always explicit (the Home API carries no timezone context to
- * anchor a "now" default), so callers pass the full window.
+ * wall-clock strings in the caller's timezone; both are ignored when
+ * `isEnabled` is `false`. The start is always explicit (the Home API
+ * carries no timezone context to anchor a "now" default), so callers
+ * pass the full window.
  * @category Facades
  */
 export interface HolidayModeUpdate {
   /**
-   * Window end (ISO 8601). Ignored when `isEnabled` is `false`.
+   * Window end (ISO 8601, caller's wall clock). Ignored when
+   * `isEnabled` is `false`.
    */
   readonly endDate: string
   /**
@@ -43,7 +54,8 @@ export interface HolidayModeUpdate {
    */
   readonly isEnabled: boolean
   /**
-   * Window start (ISO 8601). Ignored when `isEnabled` is `false`.
+   * Window start (ISO 8601, caller's wall clock). Ignored when
+   * `isEnabled` is `false`.
    */
   readonly startDate: string
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,6 +87,50 @@ export const now = (timeZone?: string): string =>
   })
 
 /**
+ * Projects a caller-local wall-clock datetime onto the UTC wall clock
+ * the MELCloud wires store. Counterpart of {@link toZonedWallClock}.
+ * Malformed input throws, so a write fails before any I/O; a local time
+ * a DST transition skips or repeats resolves per Temporal's default
+ * disambiguation (`'compatible'`).
+ * @param local - Zoneless ISO 8601 datetime, read as wall clock in
+ * `timeZone`.
+ * @param timeZone - IANA timezone the wall clock belongs to; the host's
+ * zone when omitted.
+ * @returns The same instant's UTC wall clock.
+ */
+export const toUtcWallClock = (
+  local: string,
+  timeZone?: string,
+): Temporal.PlainDateTime =>
+  Temporal.PlainDateTime.from(local)
+    .toZonedDateTime(timeZone ?? Temporal.Now.timeZoneId())
+    .withTimeZone('UTC')
+    .toPlainDateTime()
+
+/**
+ * Projects a UTC wall-clock datetime from the MELCloud wires onto the
+ * caller's wall clock. Counterpart of {@link toUtcWallClock}. An
+ * unparseable value passes through verbatim — the same tolerance the
+ * report query dates get: a read must never take a sync down.
+ * @param utc - Zoneless ISO 8601 datetime, read as wall clock in UTC.
+ * @param timeZone - IANA timezone to project into; the host's zone when
+ * omitted.
+ * @returns The same instant's wall clock in `timeZone`.
+ */
+export const toZonedWallClock = (utc: string, timeZone?: string): string => {
+  const zone = timeZone ?? Temporal.Now.timeZoneId()
+  try {
+    return Temporal.PlainDateTime.from(utc)
+      .toZonedDateTime('UTC')
+      .withTimeZone(zone)
+      .toPlainDateTime()
+      .toString()
+  } catch {
+    return utc
+  }
+}
+
+/**
  * Factory for a type guard that narrows a key to the own keys of `record`.
  * Uses `Object.hasOwn` so prototype-chain pollution cannot produce false positives.
  * @param record - The record whose keys the returned guard recognises.

--- a/tests/contracts/holiday-mode-state.test.ts
+++ b/tests/contracts/holiday-mode-state.test.ts
@@ -30,18 +30,32 @@ interface BoundedWindow extends HolidayModeState {
   readonly startDate: string
 }
 
-// The neutral holiday state is the same contract on both dialects, so the
-// clauses live here once and every implementation answers them. Start and
-// end are deliberately far apart and ordered: a start/end swap has to
-// change the result.
+// Both wires store UTC wall clock while the contract speaks the
+// caller's (`api.timezone`, pinned here so no host zone can leak in).
+const CONTRACT_TIMEZONE = 'Europe/Paris'
+
+// The neutral holiday state is the same contract on both dialects, so
+// the clauses live here once and every implementation answers them.
+// Each case is a wire/state PAIR: the wire side is what the API
+// serves (UTC), the state side the same instants on the caller's
+// clock. The windows straddle the DST switch — a winter bound (+1) and
+// a summer bound (+2) in one case — so a projection that hardcodes
+// either offset has to change the result; start and end stay far apart
+// and ordered, so a swap has to as well.
 const CASES: readonly {
   readonly label: string
   readonly state: BoundedWindow | null
+  readonly wire: BoundedWindow | null
 }[] = [
   {
-    label: 'enabled window',
+    label: 'enabled window straddling the DST switch',
     state: {
-      endDate: '2026-03-10T18:30:00',
+      endDate: '2026-04-10T20:30:00',
+      isEnabled: true,
+      startDate: '2026-03-01T09:15:00',
+    },
+    wire: {
+      endDate: '2026-04-10T18:30:00',
       isEnabled: true,
       startDate: '2026-03-01T08:15:00',
     },
@@ -49,12 +63,17 @@ const CASES: readonly {
   {
     label: 'disabled window',
     state: {
-      endDate: '2026-04-20T21:45:00',
+      endDate: '2026-11-20T22:45:00',
       isEnabled: false,
-      startDate: '2026-04-05T06:20:00',
+      startDate: '2026-07-05T08:20:00',
+    },
+    wire: {
+      endDate: '2026-11-20T21:45:00',
+      isEnabled: false,
+      startDate: '2026-07-05T06:20:00',
     },
   },
-  { label: 'never configured', state: null },
+  { label: 'never configured', state: null, wire: null },
 ]
 
 /**
@@ -69,15 +88,18 @@ const CASES: readonly {
 const describeHolidayModeStateContract = (
   name: string,
   read: (
-    state: BoundedWindow | null,
+    wire: BoundedWindow | null,
   ) => HolidayModeState | Promise<HolidayModeState | null> | null,
 ): void => {
   describe(`holidayModeState — ${name}`, () => {
     beforeEach(resetHomeDevices)
 
-    it.each(CASES)('round-trips a $label unchanged', async ({ state }) => {
-      await expect(Promise.resolve(read(state))).resolves.toStrictEqual(state)
-    })
+    it.each(CASES)(
+      "projects a $label from the wire's UTC onto the caller's clock",
+      async ({ state, wire }) => {
+        await expect(Promise.resolve(read(wire))).resolves.toStrictEqual(state)
+      },
+    )
   })
 }
 
@@ -91,6 +113,7 @@ const classicFacade = (
     getHolidayMode: vi
       .fn<ClassicAPIAdapter['getHolidayMode']>()
       .mockResolvedValue(ok(classicHolidayModeResponse(data))),
+    timezone: CONTRACT_TIMEZONE,
   })
   return new ClassicBuildingFacade(
     api,
@@ -99,49 +122,52 @@ const classicFacade = (
   )
 }
 
-describeHolidayModeStateContract('Classic zone', async (state) =>
+describeHolidayModeStateContract('Classic zone', async (wire) =>
   okValue(
     await classicFacade(
-      state === null
+      wire === null
         ? { HMDefined: false }
         : {
             HMDefined: true,
-            HMEnabled: state.isEnabled,
-            HMEndDate: state.endDate,
-            HMStartDate: state.startDate,
+            HMEnabled: wire.isEnabled,
+            HMEndDate: wire.endDate,
+            HMStartDate: wire.startDate,
           },
     ).getHolidayMode(),
   ),
 )
 
 const homeApi = (): HomeAPIAdapter =>
-  mock<HomeAPIAdapter>({ registry: homeTestRegistry })
+  mock<HomeAPIAdapter>({
+    registry: homeTestRegistry,
+    timezone: CONTRACT_TIMEZONE,
+  })
 
 const toHomeWire = (
-  state: BoundedWindow | null,
+  wire: BoundedWindow | null,
 ): { enabled: boolean; endDate: string; startDate: string } | null =>
-  state === null
+  wire === null
     ? null
     : {
-        enabled: state.isEnabled,
-        endDate: state.endDate,
-        startDate: state.startDate,
+        enabled: wire.isEnabled,
+        endDate: wire.endDate,
+        startDate: wire.startDate,
       }
 
-describeHolidayModeStateContract('Home ATA device', (state) => {
+describeHolidayModeStateContract('Home ATA device', (wire) => {
   const facade = new HomeDeviceAtaFacade(
     homeApi(),
-    homeDevice({ holidayMode: toHomeWire(state), id: 'contract-ata' }),
+    homeDevice({ holidayMode: toHomeWire(wire), id: 'contract-ata' }),
   )
   return facade.holidayMode
 })
 
 // The ATW facade inherits the getter; asserting it here keeps the pair
 // from drifting apart the way the protection getter once could.
-describeHolidayModeStateContract('Home ATW device', (state) => {
+describeHolidayModeStateContract('Home ATW device', (wire) => {
   const facade = new HomeDeviceAtwFacade(
     homeApi(),
-    homeAtwDevice({ holidayMode: toHomeWire(state), id: 'contract-atw' }),
+    homeAtwDevice({ holidayMode: toHomeWire(wire), id: 'contract-atw' }),
   )
   return facade.holidayMode
 })
@@ -155,7 +181,7 @@ describe('holidayModeState — Classic-only wire shapes', () => {
       classicFacade({
         HMDefined: true,
         HMEnabled: true,
-        HMEndDate: '2026-05-12T23:00:00',
+        HMEndDate: '2026-05-12T21:00:00',
         HMStartDate: null,
       }).getHolidayMode(),
     ).resolves.toStrictEqual({
@@ -173,8 +199,8 @@ describe('holidayModeState — Classic-only wire shapes', () => {
       classicFacade({
         HMDefined: true,
         HMEnabled: false,
-        HMEndDate: '2026-06-02T12:00:00',
-        HMStartDate: '2026-06-01T09:00:00',
+        HMEndDate: '2026-06-02T10:00:00',
+        HMStartDate: '2026-06-01T07:00:00',
       }).getHolidayMode(),
     ).resolves.toStrictEqual({
       ok: true,

--- a/tests/unit/classic-facades.test.ts
+++ b/tests/unit/classic-facades.test.ts
@@ -436,16 +436,36 @@ describe('building facade holiday mode', () => {
     expect(value).toHaveProperty('isEnabled')
   })
 
-  it('sets holiday mode with dates', async () => {
-    const { api, facade } = createBuildingFacade()
+  it('projects the window onto UTC components on the wire', async () => {
+    const { api, facade } = createBuildingFacade({ timezone: 'Europe/Paris' })
     await facade.getHolidayMode()
+    // Paris summer wall clock (UTC+2): midnight locally is 22:00 UTC
+    // the previous day — a projection that drops the zone cannot pass.
     await facade.updateHolidayMode({
-      endDate: '2024-06-15',
+      endDate: '2024-06-15T00:00',
       isEnabled: true,
-      startDate: '2024-06-01',
+      startDate: '2024-06-01T00:00',
     })
+    const call = vi.mocked(api.updateHolidayMode).mock.lastCall?.[0]
 
-    expect(api.updateHolidayMode).toHaveBeenCalledWith(expect.any(Object))
+    expect(call).toBeDefined()
+
+    expect(defined(call).postData.StartDate).toStrictEqual({
+      Day: 31,
+      Hour: 22,
+      Minute: 0,
+      Month: 5,
+      Second: 0,
+      Year: 2024,
+    })
+    expect(defined(call).postData.EndDate).toStrictEqual({
+      Day: 14,
+      Hour: 22,
+      Minute: 0,
+      Month: 6,
+      Second: 0,
+      Year: 2024,
+    })
   })
 
   it('disables holiday mode and ignores the window dates', async () => {

--- a/tests/unit/home-device-ata-facade.test.ts
+++ b/tests/unit/home-device-ata-facade.test.ts
@@ -44,11 +44,13 @@ describe('home device ata facade', () => {
   describe('protection accessors', () => {
     it('exposes frost protection and holiday mode from context', () => {
       const frostProtection = { active: false, enabled: true, max: 12, min: 6 }
+      // The wire's UTC wall clock; the facade projects it onto the
+      // caller's timezone.
       const holidayMode = {
         active: false,
         enabled: true,
-        endDate: '2026-08-05T00:00:00',
-        startDate: '2026-08-01T00:00:00',
+        endDate: '2026-08-04T22:00:00',
+        startDate: '2026-07-31T22:00:00',
       }
       const overheatProtection = {
         active: false,
@@ -57,7 +59,7 @@ describe('home device ata facade', () => {
         min: 35,
       }
       const facade = new HomeDeviceAtaFacade(
-        createApi(),
+        createApi({ timezone: 'Europe/Paris' }),
         homeDevice({
           frostProtection,
           holidayMode,

--- a/tests/unit/home-facade-manager.test.ts
+++ b/tests/unit/home-facade-manager.test.ts
@@ -220,10 +220,38 @@ describe('home facade manager', () => {
       startDate: '2026-08-01T00:00:00',
     })
 
+    // A disabled window's dates are ignored by the wire and pass
+    // through unprojected — no conversion may fail a disable.
     expect(api.updateHolidayMode).toHaveBeenCalledWith({
       enabled: false,
       endDate: '2026-08-05T00:00:00',
       startDate: '2026-08-01T00:00:00',
+      units: { ATA: ['device-1'] },
+    })
+  })
+})
+
+describe('holiday-mode write projection', () => {
+  it("projects an enabled window from the caller's clock onto UTC", async () => {
+    const api = mock<HomeAPIAdapter>({
+      registry: homeTestRegistry,
+      timezone: 'Europe/Paris',
+      updateHolidayMode: vi.fn<HomeAPIAdapter['updateHolidayMode']>(),
+    })
+    const manager = new HomeFacadeManager(api)
+
+    // Paris summer wall clock (UTC+2): midnight locally is 22:00 UTC
+    // the previous day.
+    await manager.updateHolidayMode(['device-1'], {
+      endDate: '2026-08-05T00:00',
+      isEnabled: true,
+      startDate: '2026-08-01T00:00',
+    })
+
+    expect(api.updateHolidayMode).toHaveBeenCalledWith({
+      enabled: true,
+      endDate: '2026-08-04T22:00:00',
+      startDate: '2026-07-31T22:00:00',
       units: { ATA: ['device-1'] },
     })
   })

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { ReportChartLineOptions } from '../../src/facades/index.ts'
+import { Temporal } from '../../src/temporal.ts'
 import { err, ok } from '../../src/types/index.ts'
 import {
   fromListToSetAta,
@@ -12,6 +13,8 @@ import {
   mergeHourlyChartResults,
   omitUndefined,
   padHourlyChartToMidnight,
+  toUtcWallClock,
+  toZonedWallClock,
   typedFromEntries,
 } from '../../src/utils.ts'
 import { okValue } from '../helpers.ts'
@@ -211,5 +214,64 @@ describe.concurrent(padHourlyChartToMidnight, () => {
 
     expect(padded.labels).toStrictEqual(['23:30'])
     expect(padded.series).toStrictEqual([{ data: [-60], name: 'Signal' }])
+  })
+})
+
+// The wall-clock projections are the holiday-mode contract's floor: the
+// caller speaks its own zone, the wires store UTC. The pair must be
+// exact inverses outside DST transitions, and each direction carries
+// its own failure posture — a write throws before I/O, a read passes
+// verbatim rather than taking a sync down.
+describe('wall-clock projections', () => {
+  it('projects a summer wall clock onto UTC and back', () => {
+    const utc = toUtcWallClock('2026-07-10T20:30', 'Europe/Paris')
+
+    expect(utc.toString()).toBe('2026-07-10T18:30:00')
+    expect(toZonedWallClock(utc.toString(), 'Europe/Paris')).toBe(
+      '2026-07-10T20:30:00',
+    )
+  })
+
+  it('projects a winter wall clock with the winter offset', () => {
+    expect(toUtcWallClock('2026-03-01T09:15', 'Europe/Paris').toString()).toBe(
+      '2026-03-01T08:15:00',
+    )
+  })
+
+  it('resolves a DST-gap wall clock per compatible disambiguation', () => {
+    // 02:30 does not exist on 2026-03-29 in Paris: the clock jumps
+    // 02:00 -> 03:00, and 'compatible' shifts forward.
+    expect(toUtcWallClock('2026-03-29T02:30', 'Europe/Paris').toString()).toBe(
+      '2026-03-29T01:30:00',
+    )
+  })
+
+  it('falls back to the host zone when none is given', () => {
+    const zone = Temporal.Now.timeZoneId()
+
+    expect(toUtcWallClock('2026-07-10T20:30').toString()).toBe(
+      Temporal.PlainDateTime.from('2026-07-10T20:30')
+        .toZonedDateTime(zone)
+        .withTimeZone('UTC')
+        .toPlainDateTime()
+        .toString(),
+    )
+    expect(toZonedWallClock('2026-07-10T18:30')).toBe(
+      Temporal.PlainDateTime.from('2026-07-10T18:30')
+        .toZonedDateTime('UTC')
+        .withTimeZone(zone)
+        .toPlainDateTime()
+        .toString(),
+    )
+  })
+
+  it('throws on a malformed write-side datetime', () => {
+    expect(() => toUtcWallClock('not-a-date', 'Europe/Paris')).toThrow(
+      RangeError,
+    )
+  })
+
+  it('passes a malformed read-side datetime through verbatim', () => {
+    expect(toZonedWallClock('not-a-date', 'Europe/Paris')).toBe('not-a-date')
   })
 })


### PR DESCRIPTION
Fixes the mechanism behind [com.melcloud#1593](https://github.com/OlivierZal/com.melcloud/issues/1593): both MELCloud wires store holiday-mode datetimes as **UTC wall clock**, but the facades passed the caller's wall clock through **verbatim in both directions** — every window landed late by the caller's UTC offset on write and displayed early by the same amount on read (±1 h in BST, ±2 h in CEST, 0 in winter GMT, which is why it read as intermittent).

## History, dated

- `7ba6364f` (2023-01) fixed this exact bug in com.melcloud with a toUTC/fromUTC pair — also the historical proof the Classic wire is UTC (the Home wire is live-probed UTC per CLAUDE.md).
- `b7286303` (2024-06) deleted the pair; when the logic moved into this library the contract said only "ISO 8601 wall clock" and named no zone, so nothing forced the conversion back — and the contract tests pinned the buggy verbatim round-trip.

## The fix

The contract now **names its timezone**: `HolidayModeUpdate`/`HolidayModeState` datetimes are wall clock in the API's configured `timezone` (both configs already receive it from com.melcloud via `getTimeZone(homey)`), host zone when unset. Two internal helpers carry the boundary — writes throw on malformed input before any I/O; reads pass unparseable values through verbatim (the same tolerance the report query dates get) — applied at **all four boundaries**: Classic write + read, Home batch write + Home context read. A disabled window's dates stay unprojected: the wire ignores them, and no conversion may fail a disable.

## Tests, hardened where they were soft

- The contract suite now pins the **projection** with an explicit test timezone (no host zone can leak in) and a window **straddling the DST switch** — a hardcoded offset cannot pass.
- The write-side tests stop accepting `expect.any(Object)`: Classic asserts the exact projected UTC components, Home the exact projected strings.
- The utils suite pins DST-gap resolution (`'compatible'`), the strict/tolerant failure split, and the host-zone fallback.

Local note: the 3 branch-coverage misses reported locally exist **on main too** (Node 26 vs the CI's Node 22 V8 branch counting) — this PR adds 12 branches, all covered; the CI leg is authoritative.

**BREAKING** (49.0.0): a consumer that compensated by passing pre-converted UTC must now pass local wall clock. com.melcloud passed local all along — it needs no change and starts getting correct behavior. Release + com.melcloud adoption follow.