### PR TITLE
chore(release): 49.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "48.2.0",
+  "version": "49.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "48.2.0",
+      "version": "49.0.0",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "48.2.0",
+  "version": "49.0.0",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",


### PR DESCRIPTION
Release PR for 49.0.0, carrying #1728 (holiday-mode wall-clock projection — BREAKING: the contract now names its timezone). The changelog section is the release's breaking surface.