### PR TITLE
fix: seal the Classic type surfaces and pin the remaining cross-dialect contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [49.1.0] - 2026-08-18
+
+### Added
+
+- **Contract kernels for the two remaining de-facto cross-dialect contracts** — signal strength and energy report. `getSignalStrength` answers the same chart shape in dBm on every dialect (Classic's hour-by-hour zone fan-out and Home's five-minute single fetch are mechanics, not contract), and `getEnergyReport` answers the same chart shape in kWh on every dialect and type that has an energy wire. The holiday-mode write asymmetry on a disabled window is now pinned too: neither dialect projects the ignored bounds (Classic clears them to null components, Home forwards them untouched), so a malformed leftover date can no longer fail a disable on either side.
+
+### Fixed
+
+- **Classic report reads no longer touch the wire for device types whose report does not exist.** `getInternalTemperatures` and `getHourlyTemperatures` on ATA and ERV devices used to make a real `Report/GetInternalTemperatures` call only to render zero series (the wire is ATW-only, as the interface docs always said); they now resolve an empty chart without any I/O, driven by the same per-type descriptor idiom as the energy extractor (`internalTemperaturesLegend`, empty = the report does not exist for this type). ERV `getEnergy` — typed `never` since the beginning — now throws `No energy report exists for this device type` before any I/O instead of firing a request whose answer nothing could consume.
+
+### Changed
+
+- **The Classic report surface no longer leaks `shouldUseExactRange`.** The device classes took a second boolean parameter the published interfaces never declared; the classes now match the interfaces (`getInternalTemperatures(query?)`, `getOperationModes(query?)`, `getTemperatures(query?)`), the internal exact-range choice being each method's own. The published interface parameters are now optional, matching the classes — a widening, so existing callers compile unchanged.
+
 ## [49.0.0] - 2026-08-18
 
 ### Fixed
@@ -521,6 +535,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[49.1.0]: https://github.com/OlivierZal/melcloud-api/compare/v49.0.0...v49.1.0
 [49.0.0]: https://github.com/OlivierZal/melcloud-api/compare/v48.2.0...v49.0.0
 [48.2.0]: https://github.com/OlivierZal/melcloud-api/compare/v48.1.0...v48.2.0
 [48.1.0]: https://github.com/OlivierZal/melcloud-api/compare/v48.0.0...v48.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "49.0.0",
+  "version": "49.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "49.0.0",
+      "version": "49.1.0",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "49.0.0",
+  "version": "49.1.0",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/facades/classic-base-device.ts
+++ b/src/facades/classic-base-device.ts
@@ -59,6 +59,17 @@ const DEFAULT_YEAR = '1970-01-01'
 
 const ENERGY_REPORT_UNIT = 'kWh'
 
+const emptyTemperatureChart = ({
+  FromDate: from,
+  ToDate: to,
+}: ClassicReportPostData): ReportChartLineOptions => ({
+  from,
+  labels: [],
+  series: [],
+  to,
+  unit: '°C',
+})
+
 // ISO 8601 weekday number for Sunday.
 const ISO_SUNDAY = 7
 
@@ -341,6 +352,13 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
   public async getEnergy(
     query?: ReportQuery,
   ): Promise<Result<ClassicEnergyData<T>>> {
+    // The same per-type hook that empties `getEnergyReport` refuses the
+    // raw read: `ClassicEnergyData<Erv>` is `never`, so no caller could
+    // use a success anyway, and the wire request it used to fire could
+    // only come back as an error dressed up as transport trouble.
+    if (this.extractEnergyReport === null) {
+      throw new TypeError('No energy report exists for this device type')
+    }
     return this.api.getEnergy<T>({ postData: this.#buildReportPostData(query) })
   }
 
@@ -382,6 +400,9 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
   public async getHourlyTemperatures(
     hour?: Hour,
   ): Promise<Result<ReportChartLineOptions>> {
+    if (this.internalTemperaturesLegend.length === 0) {
+      return ok(emptyTemperatureChart(this.#buildReportPostData()))
+    }
     return this.fetchHourlyDayChart(
       async (hourOfDay) => this.#fetchTemperaturesHour(hourOfDay),
       hour,
@@ -390,12 +411,16 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
 
   public async getInternalTemperatures(
     query?: ReportQuery,
-    shouldUseExactRange = true,
   ): Promise<Result<ReportChartLineOptions>> {
+    const postData = this.#buildReportPostData(query, true)
+    // An empty legend marks a type the report does not exist for (the
+    // docs say ATW only): the wire call used to fire anyway and every
+    // series was masked away after — an expensive spelling of "nothing".
+    if (this.internalTemperaturesLegend.length === 0) {
+      return ok(emptyTemperatureChart(postData))
+    }
     return mapResult(
-      await this.api.getInternalTemperatures({
-        postData: this.#buildReportPostData(query, shouldUseExactRange),
-      }),
+      await this.api.getInternalTemperatures({ postData }),
       (data) =>
         getChartLineOptions(data, {
           legend: this.internalTemperaturesLegend,
@@ -407,9 +432,8 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
 
   public async getOperationModes(
     query?: ReportQuery,
-    shouldUseExactRange = true,
   ): Promise<Result<ReportChartPieOptions>> {
-    const postData = this.#buildReportPostData(query, shouldUseExactRange)
+    const postData = this.#buildReportPostData(query, true)
     const dateRange = { from: postData.FromDate, to: postData.ToDate }
     return mapResult(await this.api.getOperationModes({ postData }), (data) =>
       getChartPieOptions(data, dateRange),
@@ -418,12 +442,11 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
 
   public async getTemperatures(
     query?: ReportQuery,
-    shouldUseExactRange = true,
   ): Promise<Result<ReportChartLineOptions>> {
     return mapResult(
       await this.api.getTemperatures({
         postData: {
-          ...this.#buildReportPostData(query, shouldUseExactRange),
+          ...this.#buildReportPostData(query, true),
           Location: this.registry.buildings.getById(this.device.buildingId)
             ?.location,
         },

--- a/src/facades/classic-device-atw.ts
+++ b/src/facades/classic-device-atw.ts
@@ -182,23 +182,18 @@ export class ClassicDeviceAtwFacade extends BaseDeviceFacade<
    * Fetches both the external (building) and internal (tank/boiler)
    * temperature reports and merges them into a single chart series.
    * @param query - Optional report time window.
-   * @param shouldUseExactRange - Whether to clamp the query to its exact bounds.
    * @returns The merged chart options, or a typed failure.
    */
   // ATW reports both external (building) and internal (tank/boiler)
   // temperatures — merge them into a single chart
   public override async getTemperatures(
     query?: ReportQuery,
-    shouldUseExactRange = true,
   ): Promise<Result<ReportChartLineOptions>> {
-    const temperatures = await super.getTemperatures(query, shouldUseExactRange)
+    const temperatures = await super.getTemperatures(query)
     if (!temperatures.ok) {
       return temperatures
     }
-    const internal = await this.getInternalTemperatures(
-      query,
-      shouldUseExactRange,
-    )
+    const internal = await this.getInternalTemperatures(query)
     return mapResult(internal, ({ series: internalTemperaturesSeries }) => ({
       ...temperatures.value,
       series: mergeSeries(

--- a/src/facades/classic-device-erv.ts
+++ b/src/facades/classic-device-erv.ts
@@ -29,10 +29,9 @@ export class ClassicDeviceErvFacade extends BaseDeviceFacade<
 
   public override async getOperationModes(
     query?: ReportQuery,
-    shouldUseExactRange = true,
   ): Promise<Result<ReportChartPieOptions>> {
     return mapResult(
-      await super.getOperationModes(query, shouldUseExactRange),
+      await super.getOperationModes(query),
       ({ labels, series, ...options }) => {
         // Filter labels and series together to keep indices in sync
         const filtered = labels

--- a/src/facades/classic-types.ts
+++ b/src/facades/classic-types.ts
@@ -150,19 +150,19 @@ export interface ClassicDeviceFacade<T extends ClassicDeviceType>
    * Fetch internal temperature report. ATW only.
    */
   readonly getInternalTemperatures: (
-    query: ReportQuery,
+    query?: ReportQuery,
   ) => Promise<Result<ReportChartLineOptions>>
   /**
    * Fetch operation mode usage as pie chart data.
    */
   readonly getOperationModes: (
-    query: ReportQuery,
+    query?: ReportQuery,
   ) => Promise<Result<ReportChartPieOptions>>
   /**
    * Fetch temperature history as line chart data.
    */
   readonly getTemperatures: (
-    query: ReportQuery,
+    query?: ReportQuery,
   ) => Promise<Result<ReportChartLineOptions>>
   /**
    * Fetch tile overview data, optionally selecting a specific device.

--- a/tests/contracts/energy-report.test.ts
+++ b/tests/contracts/energy-report.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ClassicAPIAdapter } from '../../src/api/classic-types.ts'
+import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
+import type { ReportChartLineOptions } from '../../src/facades/report-types.ts'
+import { ClassicRegistry } from '../../src/entities/index.ts'
+import { ClassicDeviceAtaFacade } from '../../src/facades/classic-device-ata.ts'
+import { ClassicDeviceAtwFacade } from '../../src/facades/classic-device-atw.ts'
+import { ClassicDeviceErvFacade } from '../../src/facades/classic-device-erv.ts'
+import { HomeDeviceAtaFacade } from '../../src/facades/home-device-ata.ts'
+import { HomeDeviceAtwFacade } from '../../src/facades/home-device-atw.ts'
+import { type Result, ok } from '../../src/types/index.ts'
+import {
+  classicAtaDevice,
+  classicAtwDevice,
+  classicBuildingData,
+  classicErvDevice,
+  createMockClassicApi,
+} from '../classic-fixtures.ts'
+import { cast, defined, mock, okValue } from '../helpers.ts'
+import {
+  homeAtwDevice,
+  homeDevice,
+  homeTestRegistry,
+} from '../home-fixtures.ts'
+
+// The one window every dialect is asked about: explicit bounds, so no
+// clock is involved and no host timezone can leak in.
+const WINDOW = { from: '2026-03-01T00:00:00Z', to: '2026-03-03T00:00:00Z' }
+
+const classicRegistry = (): ClassicRegistry => {
+  const registry = new ClassicRegistry()
+  registry.syncBuildings([classicBuildingData()])
+  registry.syncDevices([
+    classicAtaDevice(),
+    classicAtwDevice(),
+    classicErvDevice(),
+  ])
+  return registry
+}
+
+// One response body satisfying BOTH Classic extractors: the ATA buckets
+// (Heating/Cooling/Auto/Dry/Fan/Other) and the ATW stack
+// (Heating/Cooling/HotWater/Produced*) simply coexist as keys.
+const classicEnergyApi = (): ClassicAPIAdapter =>
+  createMockClassicApi({
+    getEnergy: vi
+      .fn<ClassicAPIAdapter['getEnergy']>()
+      .mockResolvedValue(
+        ok(
+          cast({
+            Auto: [0],
+            Cooling: [1],
+            Dry: [0],
+            Fan: [0],
+            Heating: [2],
+            HotWater: [3],
+            Labels: [1],
+            LabelType: 2,
+            Other: [0],
+            ProducedCooling: [0],
+            ProducedHeating: [1],
+            ProducedHotWater: [1],
+          }),
+        ),
+      ),
+  })
+
+// One energy-report contract for every dialect and type that has an
+// energy wire: the same query shape in, the same chart shape out, the
+// same unit — so a consumer charts any of them without branching.
+const describeEnergyReportContract = (
+  name: string,
+  read: () => Promise<Result<ReportChartLineOptions>>,
+): void => {
+  describe(`energyReport — ${name}`, () => {
+    it('answers the shared chart shape in kWh', async () => {
+      expect.assertions(3)
+
+      const value = okValue(await read())
+      const seriesNames = value.series.map(({ name: seriesName }) => seriesName)
+
+      expect(value.unit).toBe('kWh')
+      expect(value.series.length).toBeGreaterThan(0)
+      expect(seriesNames).not.toContain('')
+    })
+  })
+}
+
+describeEnergyReportContract('Classic ATA device', async () => {
+  const registry = classicRegistry()
+  const facade = new ClassicDeviceAtaFacade(
+    classicEnergyApi(),
+    registry,
+    defined(registry.devices.getById(1000)),
+  )
+  return facade.getEnergyReport(WINDOW)
+})
+
+describeEnergyReportContract('Classic ATW device', async () => {
+  const registry = classicRegistry()
+  const facade = new ClassicDeviceAtwFacade(
+    classicEnergyApi(),
+    registry,
+    defined(registry.devices.getById(1001)),
+  )
+  return facade.getEnergyReport(WINDOW)
+})
+
+const homeEnergyValues = [
+  { time: '2026-03-01 06:00:00.000000000', value: '571.0' },
+  { time: '2026-03-02 06:00:00.000000000', value: '229.0' },
+]
+
+describeEnergyReportContract('Home ATA device', async () => {
+  const facade = new HomeDeviceAtaFacade(
+    mock<HomeAPIAdapter>({
+      getEnergy: vi
+        .fn<HomeAPIAdapter['getEnergy']>()
+        .mockResolvedValue(
+          ok({
+            measureData: [
+              {
+                type: 'cumulative_energy_consumed_since_last_upload',
+                values: homeEnergyValues,
+              },
+            ],
+          }),
+        ),
+      registry: homeTestRegistry,
+      timezone: 'UTC',
+    }),
+    homeDevice({ id: 'contract-energy-ata' }),
+  )
+  return facade.getEnergyReport(WINDOW)
+})
+
+describeEnergyReportContract('Home ATW device', async () => {
+  const facade = new HomeDeviceAtwFacade(
+    mock<HomeAPIAdapter>({
+      getEnergy: vi.fn<HomeAPIAdapter['getEnergy']>().mockResolvedValue(
+        ok({
+          measureData: [
+            { type: 'interval_energy_consumed', values: homeEnergyValues },
+            { type: 'interval_energy_produced', values: homeEnergyValues },
+          ],
+        }),
+      ),
+      registry: homeTestRegistry,
+      timezone: 'UTC',
+    }),
+    homeAtwDevice({ id: 'contract-energy-atw' }),
+  )
+  return facade.getEnergyReport(WINDOW)
+})
+
+// Only Classic can express this: ERV has no energy wire at all, and the
+// contract there is an EMPTY chart with no wire call — plus the raw
+// read refusing before any I/O.
+describe('energyReport — Classic ERV (no energy wire)', () => {
+  it('resolves an empty chart without touching the wire', async () => {
+    const api = classicEnergyApi()
+    const registry = classicRegistry()
+    const facade = new ClassicDeviceErvFacade(
+      api,
+      registry,
+      defined(registry.devices.getById(1002)),
+    )
+    const value = okValue(await facade.getEnergyReport(WINDOW))
+
+    expect(value.series).toStrictEqual([])
+    expect(value.unit).toBe('kWh')
+    expect(api.getEnergy).not.toHaveBeenCalled()
+  })
+
+  it('refuses the raw energy read before any I/O', async () => {
+    const api = classicEnergyApi()
+    const registry = classicRegistry()
+    const facade = new ClassicDeviceErvFacade(
+      api,
+      registry,
+      defined(registry.devices.getById(1002)),
+    )
+
+    await expect(facade.getEnergy(WINDOW)).rejects.toThrow(
+      'No energy report exists for this device type',
+    )
+    expect(api.getEnergy).not.toHaveBeenCalled()
+  })
+})

--- a/tests/contracts/holiday-mode-write.test.ts
+++ b/tests/contracts/holiday-mode-write.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ClassicAPIAdapter } from '../../src/api/classic-types.ts'
+import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
+import { ClassicRegistry } from '../../src/entities/index.ts'
+import { ClassicBuildingFacade } from '../../src/facades/classic-building.ts'
+import { HomeFacadeManager } from '../../src/facades/home-manager.ts'
+import {
+  classicAtaDevice,
+  classicBuildingData,
+  createMockClassicApi,
+} from '../classic-fixtures.ts'
+import { defined, mock } from '../helpers.ts'
+import { homeDevice, homeTestRegistry } from '../home-fixtures.ts'
+
+// The write-side twin of the holiday-mode read contract: a DISABLED
+// window's dates are ignored by both wires, so neither dialect may
+// project them — a malformed leftover date must not fail a disable.
+// The wire spelling of "ignored" legitimately differs (Classic clears
+// the bounds to null components, Home forwards the strings untouched);
+// what the contract pins is that NO projection runs on either.
+describe('holidayMode write — disabled window', () => {
+  const DISABLE = {
+    endDate: 'not-a-parsable-date',
+    isEnabled: false,
+    startDate: 'not-a-parsable-date',
+  }
+
+  it('classic clears the bounds without projecting them', async () => {
+    const registry = new ClassicRegistry()
+    registry.syncBuildings([classicBuildingData()])
+    registry.syncDevices([classicAtaDevice()])
+    const updateHolidayMode = vi
+      .fn<ClassicAPIAdapter['updateHolidayMode']>()
+      .mockResolvedValue({ AttributeErrors: null, Success: true })
+    const api = createMockClassicApi({
+      timezone: 'Europe/Paris',
+      updateHolidayMode,
+    })
+    const facade = new ClassicBuildingFacade(
+      api,
+      registry,
+      defined(registry.buildings.getById(1)),
+    )
+
+    await facade.updateHolidayMode(DISABLE)
+
+    const call = defined(updateHolidayMode.mock.lastCall?.[0])
+
+    expect(call.postData.Enabled).toBe(false)
+    expect(call.postData.StartDate).toBeNull()
+    expect(call.postData.EndDate).toBeNull()
+  })
+
+  it('home forwards the window untouched without projecting it', async () => {
+    // Registers the device into the shared test registry, which is how
+    // the manager resolves the ATA/ATW unit buckets.
+    homeDevice({ id: 'device-1' })
+    const updateHolidayMode = vi
+      .fn<HomeAPIAdapter['updateHolidayMode']>()
+      .mockResolvedValue()
+    const manager = new HomeFacadeManager(
+      mock<HomeAPIAdapter>({
+        registry: homeTestRegistry,
+        timezone: 'Europe/Paris',
+        updateHolidayMode,
+      }),
+    )
+
+    await manager.updateHolidayMode(['device-1'], DISABLE)
+
+    expect(updateHolidayMode).toHaveBeenCalledWith({
+      enabled: false,
+      endDate: 'not-a-parsable-date',
+      startDate: 'not-a-parsable-date',
+      units: { ATA: ['device-1'] },
+    })
+  })
+})

--- a/tests/contracts/signal-strength.test.ts
+++ b/tests/contracts/signal-strength.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClassicAPIAdapter } from '../../src/api/classic-types.ts'
+import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
+import type { ReportChartLineOptions } from '../../src/facades/report-types.ts'
+import { ClassicRegistry } from '../../src/entities/index.ts'
+import { ClassicBuildingFacade } from '../../src/facades/classic-building.ts'
+import { HomeDeviceAtaFacade } from '../../src/facades/home-device-ata.ts'
+import { Temporal } from '../../src/temporal.ts'
+import { type Hour, type Result, ok } from '../../src/types/index.ts'
+import {
+  classicAtaDevice,
+  classicBuildingData,
+  classicReportData,
+  createMockClassicApi,
+} from '../classic-fixtures.ts'
+import { defined, mock, mockTemporalNowZoned, okValue } from '../helpers.ts'
+import { homeDevice, homeTestRegistry } from '../home-fixtures.ts'
+
+// Both dialects are asked about the same pinned moment, so neither the
+// host clock nor its timezone can shape the answer.
+const NOW = '2026-03-01T12:00:00Z'
+
+const classicSignalFacade = (): ClassicBuildingFacade => {
+  const registry = new ClassicRegistry()
+  registry.syncBuildings([classicBuildingData()])
+  registry.syncDevices([classicAtaDevice()])
+  const api = createMockClassicApi({
+    getSignal: vi
+      .fn<ClassicAPIAdapter['getSignal']>()
+      .mockResolvedValue(ok(classicReportData({ Data: [[-66]] }))),
+  })
+  return new ClassicBuildingFacade(
+    api,
+    registry,
+    defined(registry.buildings.getById(1)),
+  )
+}
+
+const homeSignalFacade = (): HomeDeviceAtaFacade => {
+  const api = mock<HomeAPIAdapter>({
+    getSignal: vi
+      .fn<HomeAPIAdapter['getSignal']>()
+      .mockResolvedValue(
+        ok({
+          measureData: [
+            {
+              type: 'rssi',
+              values: [{ time: '2026-03-01 12:05:00.000000000', value: '-66' }],
+            },
+          ],
+        }),
+      ),
+    registry: homeTestRegistry,
+    timezone: 'UTC',
+  })
+  return new HomeDeviceAtaFacade(api, homeDevice({ id: 'contract-signal' }))
+}
+
+// The de-facto signal contract, now pinned: same method name, same
+// signature, same chart shape, same dBm unit on every dialect — the
+// mechanics underneath (Classic's hour-by-hour fan-out over a zone,
+// Home's five-minute single fetch) are not part of the contract.
+const describeSignalStrengthContract = (
+  name: string,
+  read: (hour: Hour) => Promise<Result<ReportChartLineOptions>>,
+): void => {
+  describe(`signalStrength — ${name}`, () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.setSystemTime(Temporal.Instant.from(NOW).epochMilliseconds)
+      mockTemporalNowZoned()
+    })
+
+    afterEach(() => {
+      vi.mocked(Temporal.Now.zonedDateTimeISO).mockRestore()
+      vi.useRealTimers()
+    })
+
+    it('answers the shared chart shape in dBm', async () => {
+      const value = okValue(await read(12))
+
+      expect(value.unit).toBe('dBm')
+      expect(value.series.length).toBeGreaterThan(0)
+      expect(value.series[0]?.data).toContain(-66)
+      expect(value.labels.length).toBeGreaterThan(0)
+    })
+  })
+}
+
+describeSignalStrengthContract('Classic zone', async (hour) =>
+  classicSignalFacade().getSignalStrength(hour),
+)
+
+describeSignalStrengthContract('Home ATA device', async (hour) =>
+  homeSignalFacade().getSignalStrength(hour),
+)

--- a/tests/unit/classic-facades.test.ts
+++ b/tests/unit/classic-facades.test.ts
@@ -1071,24 +1071,43 @@ describe('ata device facade', () => {
     expect(api.getTemperatures).toHaveBeenCalledWith(expect.any(Object))
   })
 
-  it('calls internalTemperatures', async () => {
-    const { api, facade } = createAtaFacade()
+  it('calls internalTemperatures on the type that has them', async () => {
+    const { api, facade } = createAtwFacade()
     const value = okValue(await facade.getInternalTemperatures())
 
     expect(value).toHaveProperty('series')
     expect(api.getInternalTemperatures).toHaveBeenCalledWith(expect.any(Object))
   })
 
-  it('calls hourlyTemperatures', async () => {
+  // The docs say ATW only, and they now mean it: the wire call used to
+  // fire anyway and every series was masked away after.
+  it('answers internalTemperatures without the wire on a type without them', async () => {
     const { api, facade } = createAtaFacade()
+    const value = okValue(await facade.getInternalTemperatures())
+
+    expect(value.series).toStrictEqual([])
+    expect(value.labels).toStrictEqual([])
+    expect(api.getInternalTemperatures).not.toHaveBeenCalled()
+  })
+
+  it('calls hourlyTemperatures on the type that has them', async () => {
+    const { api, facade } = createAtwFacade()
     const value = okValue(await facade.getHourlyTemperatures(12))
 
     expect(value).toHaveProperty('series')
     expect(api.getHourlyTemperatures).toHaveBeenCalledWith(expect.any(Object))
   })
 
+  it('answers hourlyTemperatures without the wire on a type without them', async () => {
+    const { api, facade } = createAtaFacade()
+    const value = okValue(await facade.getHourlyTemperatures(12))
+
+    expect(value.series).toStrictEqual([])
+    expect(api.getHourlyTemperatures).not.toHaveBeenCalled()
+  })
+
   it('formats the hourly temperature labels as clock labels', async () => {
-    const { facade } = createAtaFacade({
+    const { facade } = createAtwFacade({
       getHourlyTemperatures: vi
         .fn<ClassicAPIAdapter['getHourlyTemperatures']>()
         .mockResolvedValue(ok(classicReportData({ Labels: ['5'] }))),
@@ -1106,7 +1125,7 @@ describe('ata device facade', () => {
     )
     try {
       // Pin the label locale: the runner's default is not ours.
-      const { api, facade } = createAtaFacade({ locale: 'fr-FR' })
+      const { api, facade } = createAtwFacade({ locale: 'fr-FR' })
       const value = okValue(await facade.getHourlyTemperatures())
 
       expect(api.getHourlyTemperatures).toHaveBeenCalledTimes(2)


### PR DESCRIPTION
## Vague 0 of the interface-mutualization plan — seal and repair

### Added
- **Contract kernels** for the two remaining de-facto cross-dialect contracts:
  - `tests/contracts/signal-strength.test.ts` — `getSignalStrength` answers the same chart shape in **dBm** on every dialect (Classic's hour-by-hour zone fan-out vs Home's five-minute single fetch are mechanics, not contract), under a pinned clock so no host timezone can leak in.
  - `tests/contracts/energy-report.test.ts` — `getEnergyReport` answers the same chart shape in **kWh** on every dialect and type that has an energy wire (Classic ATA/ATW, Home ATA/ATW), with the ERV divergence quarantined: empty chart, no wire call.
  - `tests/contracts/holiday-mode-write.test.ts` — the disabled-window write clause: neither dialect projects the ignored bounds (Classic clears to null components, Home forwards untouched), so a malformed leftover date cannot fail a disable.

### Fixed
- **Classic report reads no longer touch the wire for types whose report does not exist**: `getInternalTemperatures`/`getHourlyTemperatures` on ATA and ERV resolve an empty chart without I/O (the wire is ATW-only, as the interface docs always said), driven by the same per-type descriptor idiom as the energy extractor (`internalTemperaturesLegend`, empty = no report for this type).
- **ERV `getEnergy`** — typed `never` since the beginning — now throws before any I/O instead of firing a request whose answer nothing could consume.

### Changed
- **`shouldUseExactRange` no longer leaks**: the device classes took a second boolean the published interfaces never declared; classes now match the interfaces (`query?` only), the exact-range choice being each method's own. Interface params became optional — a widening, existing callers compile unchanged.

Non-breaking → **49.1.0** (minor). 1074 tests / 47 files green; branch coverage locally at 99.71% is the known Node 26 conditional-spread counting artifact in untouched files (`home.ts`, `token-auth.ts`) — the CI Node 22 leg is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn