### PR TITLE
refactor: post-wave cleanup sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [51.0.1] - 2026-08-18
+
+### Changed
+
+- Post-wave cleanup sweep, no public-surface change. Internal factorings: the Classic energy report chart is built in one pass from the neutral extract (no intermediate re-shaping); the Home "today or one hour" chart window (day-on-five-minutes with a "now" cutoff vs hour-on-minutes) resolves in ONE shared helper for the signal and hourly-temperature reads; the ATW dual-zone write coupling drops guards its own construction already proves; the building member-unit fold rides the shared `toHomeProtectionUnits`; the recurring `await Promise.resolve(…)` rule-pair escape is one named `resolved` helper carrying the single documented disable. Docs: README examples fixed to the current constructor and typed device reads; doc categories align the neutral contract modules (`/atw-state`, `/error-log`) with the protection/holiday precedent. Tests: kernel-duplicated cases deleted (the contract kernels are the one home of cross-dialect clauses), registry/API mock scaffolding unified on shared fixtures.
+
 ## [51.0.0] - 2026-08-18
 
 ### Changed
@@ -577,6 +583,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[51.0.1]: https://github.com/OlivierZal/melcloud-api/compare/v51.0.0...v51.0.1
 [51.0.0]: https://github.com/OlivierZal/melcloud-api/compare/v50.0.0...v51.0.0
 [50.0.0]: https://github.com/OlivierZal/melcloud-api/compare/v49.2.0...v50.0.0
 [49.2.0]: https://github.com/OlivierZal/melcloud-api/compare/v49.1.0...v49.2.0

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ const api = await ClassicAPI.create({
   password: 'password',
 })
 
-const manager = new ClassicFacadeManager(api, api.registry)
+const manager = new ClassicFacadeManager(api)
 
 // Browse the device hierarchy
 for (const zone of manager.getZones()) {
@@ -76,7 +76,11 @@ if (device !== undefined) {
 ### MELCloud Home
 
 ```ts title="home"
-import { HomeAPI, HomeFacadeManager } from '@olivierzal/melcloud-api'
+import {
+  HomeAPI,
+  HomeDeviceType,
+  HomeFacadeManager,
+} from '@olivierzal/melcloud-api'
 
 const api = await HomeAPI.create({
   username: 'user@example.com',
@@ -86,8 +90,8 @@ const api = await HomeAPI.create({
 await api.list()
 const manager = new HomeFacadeManager(api)
 
-// Interact with a device through its facade
-const [device] = api.registry.getAll()
+// Interact with a device through its type-narrowed facade
+const [device] = api.registry.getDevicesByType(HomeDeviceType.Ata)
 if (device !== undefined) {
   const facade = manager.get(device)
   console.log(facade.name, facade.operationMode, facade.setTemperature)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "51.0.0",
+  "version": "51.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "51.0.0",
+      "version": "51.0.1",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "51.0.0",
+  "version": "51.0.1",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/api/classic-types.ts
+++ b/src/api/classic-types.ts
@@ -269,7 +269,7 @@ export interface ClassicAPISettings extends BaseAPISettings {
  * Parsed error log — the cross-dialect {@link ErrorLogPage} with the
  * Classic-precise entries: neutral shape, reverse chronological order,
  * plus the chained window bounds.
- * @category Configuration
+ * @category Types
  */
 export interface ClassicErrorLog extends ErrorLogPage {
   /**
@@ -282,7 +282,7 @@ export interface ClassicErrorLog extends ErrorLogPage {
  * One Classic error-log entry: the cross-dialect {@link ErrorLogEntry}
  * kept precise — the Classic wire always carries a numeric device id
  * and a message text, so neither loosens to the neutral optionality.
- * @category Configuration
+ * @category Types
  */
 export interface ClassicErrorLogEntry extends ErrorLogEntry {
   /**
@@ -298,6 +298,6 @@ export interface ClassicErrorLogEntry extends ErrorLogEntry {
 /**
  * Query parameters for paginating the error log — the cross-dialect
  * {@link ErrorLogQuery}.
- * @category Configuration
+ * @category Types
  */
 export type ClassicErrorLogQuery = ErrorLogQuery

--- a/src/atw-state.ts
+++ b/src/atw-state.ts
@@ -14,7 +14,7 @@ import type {
 
 /**
  * Hot-water snapshot of an ATW unit in the cross-dialect vocabulary.
- * @category Types
+ * @category Facades
  */
 export interface AtwHotWaterState {
   /**
@@ -57,7 +57,7 @@ export interface AtwHotWaterState {
  * Classic member names, the Home wire-normalized values and the
  * consumer capability ids are one vocabulary; the Classic facade
  * projects its numeric wire form through the total bijection.
- * @category Types
+ * @category Facades
  */
 export interface AtwZoneState {
   /**

--- a/src/error-log.ts
+++ b/src/error-log.ts
@@ -12,7 +12,7 @@ import { Temporal } from './temporal.ts'
  * `deviceId` exist on every dialect; `message` when the wire carries a
  * text (always on Classic, when a reason exists on Home); `code` and
  * `clearedAt` only where the wire has them (Home).
- * @category Types
+ * @category Facades
  */
 export interface ErrorLogEntry {
   /**
@@ -44,7 +44,7 @@ export interface ErrorLogEntry {
  * window bounds driving the next page (feed `nextFromDate` and
  * `nextToDate` back as `from` and `to`). The Home wire has no window —
  * Home reads answer bare entries.
- * @category Types
+ * @category Facades
  */
 export interface ErrorLogPage {
   /**
@@ -70,7 +70,7 @@ export interface ErrorLogPage {
  * (`offset` is then moot); otherwise pages stack backwards from `to`
  * (defaulting to today) in `period`-day windows, `offset` counting the
  * steps back.
- * @category Types
+ * @category Facades
  */
 export interface ErrorLogQuery {
   /**
@@ -99,7 +99,7 @@ export interface ErrorLogQuery {
 /**
  * The page window an {@link ErrorLogQuery} denotes, as ISO dates:
  * the resolved bounds plus the chained next-page bounds.
- * @category Types
+ * @category Facades
  */
 export interface ErrorLogWindow {
   /**

--- a/src/facades/classic-base-device.ts
+++ b/src/facades/classic-base-device.ts
@@ -33,12 +33,14 @@ import {
   ok,
 } from '../types/index.ts'
 import {
+  formatLabels,
   fromListToSetAta,
   getChartLineOptions,
   getChartPieOptions,
   isSetDeviceDataAtaInList,
   isUpdateDeviceData,
   now,
+  resolved,
   typedFromEntries,
   typedKeys,
   withMinuteClockLabels,
@@ -318,13 +320,10 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
   }
 
   // The `@fetchDevices` decorator awaits a registry sync before this
-  // body runs; the body just exposes the now-fresh `this.data`. The
-  // `const data = await Promise.resolve(...)` shape is the only one
-  // that simultaneously satisfies `promise-function-async`,
-  // `require-await`, and `return-await`.
+  // body runs; the body just exposes the now-fresh `this.data`.
   @fetchDevices()
   public async fetch(): Promise<Readonly<ClassicListDeviceData<T>>> {
-    const data = await Promise.resolve(this.data)
+    const data = await resolved(this.data)
     return data
   }
 
@@ -377,8 +376,8 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
   ): Promise<Result<ClassicEnergyData<T>>> {
     // The same per-type hook that empties `getEnergyReport` refuses the
     // raw read: `ClassicEnergyData<Erv>` is `never`, so no caller could
-    // use a success anyway, and the wire request it used to fire could
-    // only come back as an error dressed up as transport trouble.
+    // use a success anyway — a wire request here could only come back
+    // as an error dressed up as transport trouble.
     if (this.extractEnergyReport === null) {
       throw new TypeError('No energy report exists for this device type')
     }
@@ -401,22 +400,19 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
         locale: this.api.locale,
         window: { from, to },
       })
-      return getChartLineOptions(
-        {
-          Data: series.map(({ data: values }) => [...values]),
-          FromDate: from,
-          Labels: report.labels,
-          LabelType: report.labelType,
-          Points: labels.length,
-          Series: series.length,
-          ToDate: to,
-        },
-        {
-          legend: series.map(({ name }) => name),
-          locale: this.api.locale,
-          unit: ENERGY_REPORT_UNIT,
-        },
-      )
+      // The extract already IS the chart's substance: bucket names as
+      // the legend, bucket arrays as the series — no synthetic wire
+      // payload in between.
+      return {
+        from,
+        labels: formatLabels(report.labels, report.labelType, this.api.locale),
+        series: series.map(({ data: values, name }) => ({
+          data: [...values],
+          name,
+        })),
+        to,
+        unit: ENERGY_REPORT_UNIT,
+      }
     })
   }
 
@@ -437,8 +433,8 @@ export abstract class BaseDeviceFacade<T extends ClassicDeviceType>
   ): Promise<Result<ReportChartLineOptions>> {
     const postData = this.#buildReportPostData(query, true)
     // An empty legend marks a type the report does not exist for (the
-    // docs say ATW only): the wire call used to fire anyway and every
-    // series was masked away after — an expensive spelling of "nothing".
+    // docs say ATW only): answer the empty chart locally rather than
+    // paying a wire call whose every series would be masked away.
     if (this.internalTemperaturesLegend.length === 0) {
       return ok(emptyTemperatureChart(postData))
     }

--- a/src/facades/classic-building.ts
+++ b/src/facades/classic-building.ts
@@ -7,6 +7,7 @@ import type {
 } from '../entities/index.ts'
 import type { ClassicBuildingID, ClassicZoneSettings } from '../types/index.ts'
 import { fetchDevices } from '../decorators/index.ts'
+import { resolved } from '../utils.ts'
 import { BaseZoneFacade } from './classic-base-zone.ts'
 
 /**
@@ -62,10 +63,9 @@ export class ClassicBuildingFacade extends BaseZoneFacade<ClassicBuilding> {
    * current zone settings (frost-protection + holiday-mode flags).
    * @returns The building's zone settings.
    */
-  // See `BaseDeviceFacade.fetch` for the rationale on this shape.
   @fetchDevices()
   public async fetch(): Promise<ClassicZoneSettings> {
-    const data = await Promise.resolve(this.data)
+    const data = await resolved(this.data)
     return data
   }
 }

--- a/src/facades/classic-device-ata.ts
+++ b/src/facades/classic-device-ata.ts
@@ -16,7 +16,7 @@ import {
   type Result,
   ok,
 } from '../types/index.ts'
-import { clampToRange, isValue } from '../utils.ts'
+import { clampToRange, isValue, resolved } from '../utils.ts'
 import type { ClassicEnergyReportExtract } from './classic-types.ts'
 import { BaseDeviceFacade, makeEnergyExtract } from './classic-base-device.ts'
 import { classicAtaFlags } from './classic-flags.ts'
@@ -101,11 +101,8 @@ export class ClassicDeviceAtaFacade extends BaseDeviceFacade<
    * or unset fan speed reads as `null` (a group cannot hold silent).
    * @returns A success result wrapping the device's group state.
    */
-  // Pure projection of cached data; the `await Promise.resolve(...)` shape
-  // satisfies the async group contract shared with the zone facades without
-  // an eslint disable (see `fetch` in classic-base-device.ts).
   public async getGroup(): Promise<Result<ClassicGroupState>> {
-    const { data } = await Promise.resolve(this)
+    const { data } = await resolved(this)
     return ok({
       FanSpeed: toGroupFanSpeed(data.FanSpeed),
       OperationMode: data.OperationMode,

--- a/src/facades/classic-device-atw.ts
+++ b/src/facades/classic-device-atw.ts
@@ -164,7 +164,7 @@ export class ClassicDeviceAtwFacade extends BaseDeviceFacade<
    * @returns The Zone 1 state snapshot.
    */
   public get zone1(): ClassicZoneState {
-    return this.getZoneState('Zone1')
+    return this.#zoneState('Zone1')
   }
 
   /**
@@ -175,7 +175,7 @@ export class ClassicDeviceAtwFacade extends BaseDeviceFacade<
    * @returns The Zone 2 state snapshot, or `null`.
    */
   public get zone2(): ClassicZoneState | null {
-    return this.data.HasZone2 ? this.getZoneState('Zone2') : null
+    return this.data.HasZone2 ? this.#zoneState('Zone2') : null
   }
 
   protected override readonly extractEnergyReport: (
@@ -275,26 +275,6 @@ export class ClassicDeviceAtwFacade extends BaseDeviceFacade<
     }))
   }
 
-  protected getZoneState(zone: ClassicZoneAtw): ClassicZoneState {
-    const { data } = this
-    return {
-      isCoolingProhibited: data[`ProhibitCooling${zone}`],
-      isHeatingProhibited: data[`ProhibitHeating${zone}`],
-      isIdle: data[`Idle${zone}`],
-      isInCoolMode: data[`${zone}InCoolMode`],
-      isInHeatMode: data[`${zone}InHeatMode`],
-      operationalState: getZoneOperationalState(data, zone),
-      // The wire speaks numbers; the cross-dialect state speaks the
-      // shared string vocabulary — the total bijection projects, and an
-      // out-of-vocabulary number degrades to the room basis.
-      operationMode:
-        zoneModeFromWireNumber[data[`OperationMode${zone}`]] ??
-        HomeAtwZoneMode.room,
-      roomTemperature: data[`RoomTemperature${zone}`],
-      setTemperature: data[`SetTemperature${zone}`],
-    }
-  }
-
   protected override prepareUpdateData(
     data: Partial<ClassicUpdateDeviceDataAtw>,
   ): Required<ClassicUpdateDeviceDataAtw> {
@@ -321,25 +301,21 @@ export class ClassicDeviceAtwFacade extends BaseDeviceFacade<
   #coupleOperationModes(
     data: Partial<ClassicUpdateDeviceDataAtw>,
   ): ClassicOperationModeZoneDataAtw | null {
-    const [operationModeZone1, operationModeZone2]: {
-      key: keyof ClassicOperationModeZoneDataAtw
-      value?: ClassicOperationModeZone | undefined
-    }[] = [
-      { key: 'OperationModeZone1', value: data.OperationModeZone1 },
-      { key: 'OperationModeZone2', value: data.OperationModeZone2 },
-    ]
+    const zone1 = {
+      key: 'OperationModeZone1',
+      value: data.OperationModeZone1,
+    } as const
+    const zone2 = {
+      key: 'OperationModeZone2',
+      value: data.OperationModeZone2,
+    } as const
 
     // Whichever zone was explicitly changed becomes the primary; the other
     // is automatically adjusted to maintain consistency
     const [primaryOperationMode, secondaryOperationMode] =
-      operationModeZone1?.value === undefined
-        ? [operationModeZone2, operationModeZone1]
-        : [operationModeZone1, operationModeZone2]
+      zone1.value === undefined ? [zone2, zone1] : [zone1, zone2]
 
-    if (
-      secondaryOperationMode === undefined ||
-      primaryOperationMode?.value === undefined
-    ) {
+    if (primaryOperationMode.value === undefined) {
       return null
     }
     return {
@@ -377,5 +353,25 @@ export class ClassicDeviceAtwFacade extends BaseDeviceFacade<
       secondaryValue += ROOM_FLOW_GAP
     }
     return toOperationModeZone(secondaryValue)
+  }
+
+  #zoneState(zone: ClassicZoneAtw): ClassicZoneState {
+    const { data } = this
+    return {
+      isCoolingProhibited: data[`ProhibitCooling${zone}`],
+      isHeatingProhibited: data[`ProhibitHeating${zone}`],
+      isIdle: data[`Idle${zone}`],
+      isInCoolMode: data[`${zone}InCoolMode`],
+      isInHeatMode: data[`${zone}InHeatMode`],
+      operationalState: getZoneOperationalState(data, zone),
+      // The wire speaks numbers; the cross-dialect state speaks the
+      // shared string vocabulary — the total bijection projects, and an
+      // out-of-vocabulary number degrades to the room basis.
+      operationMode:
+        zoneModeFromWireNumber[data[`OperationMode${zone}`]] ??
+        HomeAtwZoneMode.room,
+      roomTemperature: data[`RoomTemperature${zone}`],
+      setTemperature: data[`SetTemperature${zone}`],
+    }
   }
 }

--- a/src/facades/home-base-device.ts
+++ b/src/facades/home-base-device.ts
@@ -26,7 +26,7 @@ import {
   mapResult,
   ok,
 } from '../types/index.ts'
-import { omitUndefined, toZonedWallClock } from '../utils.ts'
+import { omitUndefined, resolved, toZonedWallClock } from '../utils.ts'
 import type { ReportChartLineOptions, ReportQuery } from './report-types.ts'
 import {
   pushHomeFrostProtection,
@@ -35,8 +35,7 @@ import {
 } from './home-protection.ts'
 import {
   fetchHomeReportChunks,
-  resolveHomeDayWindow,
-  resolveHomeHourWindow,
+  resolveHomeFineWindow,
   resolveHomeReportWindow,
   toHomeLineOptions,
   toHomeSignalOptions,
@@ -340,11 +339,8 @@ export abstract class HomeBaseDeviceFacade<TData extends HomeDeviceData>
    * from the synced `/context` model, no wire call.
    * @returns The protection state, or `null` when never configured.
    */
-  // Pure projection of cached data; the `await Promise.resolve(...)`
-  // shape satisfies the cross-dialect async contract without an eslint
-  // disable (see `getGroup` in home-device-ata.ts).
   public async getFrostProtection(): Promise<Result<ProtectionState | null>> {
-    const { data } = await Promise.resolve(this.model)
+    const { data } = await resolved(this.model)
     return ok(toHomeProtectionState(data.frostProtection))
   }
 
@@ -356,7 +352,7 @@ export abstract class HomeBaseDeviceFacade<TData extends HomeDeviceData>
    * @returns The holiday-mode state, or `null` when never configured.
    */
   public async getHolidayMode(): Promise<Result<HolidayModeState | null>> {
-    const { data } = await Promise.resolve(this.model)
+    const { data } = await resolved(this.model)
     return ok(toHolidayModeState(data.holidayMode, this.api.timezone))
   }
 
@@ -370,7 +366,7 @@ export abstract class HomeBaseDeviceFacade<TData extends HomeDeviceData>
   public async getOverheatProtection(): Promise<
     Result<ProtectionState | null>
   > {
-    const { data } = await Promise.resolve(this.model)
+    const { data } = await resolved(this.model)
     return ok(toHomeProtectionState(data.overheatProtection))
   }
 
@@ -398,20 +394,17 @@ export abstract class HomeBaseDeviceFacade<TData extends HomeDeviceData>
   public async getSignalStrength(
     hour?: Hour,
   ): Promise<Result<ReportChartLineOptions>> {
-    const { cutoff, window } =
-      hour === undefined
-        ? resolveHomeDayWindow(this.chartTimezone)
-        : {
-            cutoff: undefined,
-            window: resolveHomeHourWindow(hour, this.chartTimezone),
-          }
+    const { cutoff, gridUnit, window } = resolveHomeFineWindow(
+      hour,
+      this.chartTimezone,
+    )
     return mapResult(
       await this.api.getSignal(this.id, toHomeWireWindow(window)),
       (data) =>
         toHomeSignalOptions({
           cutoff,
           data,
-          gridUnit: hour === undefined ? 'fiveMinutes' : 'minute',
+          gridUnit,
           locale: this.api.locale,
           name: this.name,
           window,

--- a/src/facades/home-building.ts
+++ b/src/facades/home-building.ts
@@ -18,6 +18,7 @@ import {
   type Result,
   ok,
 } from '../types/index.ts'
+import { resolved } from '../utils.ts'
 import type { HomeDeviceAtaFacade } from './home-device-ata.ts'
 import {
   aggregateClassicAtaGroupStates,
@@ -32,6 +33,7 @@ import {
   pushHomeFrostProtection,
   pushHomeHolidayMode,
   pushHomeOverheatProtection,
+  toHomeProtectionUnits,
 } from './home-protection.ts'
 
 // `allSettled` reasons are `unknown`; non-Error rejections (possible
@@ -109,19 +111,10 @@ export class HomeBuildingFacade {
   }
 
   get #memberUnits(): HomeProtectionUnits {
-    const ata: string[] = []
-    const atw: string[] = []
-    for (const device of this.devices) {
-      if (device.isAta()) {
-        ata.push(device.id)
-      } else {
-        atw.push(device.id)
-      }
-    }
-    return {
-      ...(ata.length > 0 && { ATA: ata }),
-      ...(atw.length > 0 && { ATW: atw }),
-    }
+    return toHomeProtectionUnits(
+      this.#api,
+      this.devices.map(({ id }) => id),
+    )
   }
 
   /**
@@ -150,13 +143,10 @@ export class HomeBuildingFacade {
    * No wire call — the synced `/context` states are reused.
    * @returns A success result wrapping the aggregated state.
    */
-  // Pure aggregation of cached data; the `await Promise.resolve(...)`
-  // shape satisfies the cross-dialect async contract without an eslint
-  // disable (see `getGroup`).
   public async getFrostProtection(): Promise<
     Result<AggregatedProtectionState>
   > {
-    const members = await Promise.resolve(this.devices)
+    const members = await resolved(this.devices)
     return ok(
       aggregateProtectionStates(
         members.map(({ data }) => toHomeProtectionState(data.frostProtection)),
@@ -172,7 +162,7 @@ export class HomeBuildingFacade {
    * @returns A success result wrapping the aggregated group state.
    */
   public async getGroup(): Promise<Result<ClassicGroupState>> {
-    const members = await Promise.resolve(this.#ataDevices)
+    const members = await resolved(this.#ataDevices)
     return ok(
       aggregateClassicAtaGroupStates(
         members.map((device) =>
@@ -189,7 +179,7 @@ export class HomeBuildingFacade {
    * @returns A success result wrapping the aggregated state.
    */
   public async getHolidayMode(): Promise<Result<AggregatedHolidayModeState>> {
-    const members = await Promise.resolve(this.devices)
+    const members = await resolved(this.devices)
     return ok(
       aggregateHolidayModeStates(
         members.map(({ data }) =>
@@ -208,7 +198,7 @@ export class HomeBuildingFacade {
   public async getOverheatProtection(): Promise<
     Result<AggregatedProtectionState>
   > {
-    const members = await Promise.resolve(this.#ataDevices)
+    const members = await resolved(this.#ataDevices)
     return ok(
       aggregateProtectionStates(
         members.map(({ data }) =>

--- a/src/facades/home-device-ata.ts
+++ b/src/facades/home-device-ata.ts
@@ -28,7 +28,7 @@ import {
   mapResult,
   ok,
 } from '../types/index.ts'
-import { clampToRange } from '../utils.ts'
+import { clampToRange, resolved } from '../utils.ts'
 import type { ReportChartLineOptions, ReportQuery } from './report-types.ts'
 import { toClassicAtaGroupState, toHomeAtaValues } from './home-ata-group.ts'
 import { HomeBaseDeviceFacade } from './home-base-device.ts'
@@ -182,11 +182,8 @@ export class HomeDeviceAtaFacade extends HomeBaseDeviceFacade<HomeAtaDeviceData>
    * endpoint, so the already-synced values are reused with no wire call.
    * @returns A success result wrapping the device's group state.
    */
-  // Pure projection of cached data; the `await Promise.resolve(...)` shape
-  // satisfies the async group contract shared with the Classic facades
-  // without an eslint disable (see `fetch` in classic-base-device.ts).
   public async getGroup(): Promise<Result<ClassicGroupState>> {
-    const source = await Promise.resolve(this)
+    const source = await resolved(this)
     return ok(toClassicAtaGroupState(source))
   }
 

--- a/src/facades/home-device-atw.ts
+++ b/src/facades/home-device-atw.ts
@@ -28,8 +28,7 @@ import {
   type HomeChartWindow,
   fetchHomeReportChunks,
   MAX_ANNOTATION_CHUNK_DAYS,
-  resolveHomeDayWindow,
-  resolveHomeHourWindow,
+  resolveHomeFineWindow,
   resolveHomeReportWindow,
   shouldChartHomeBands,
   toHomeEnergyBucketUnit,
@@ -220,10 +219,7 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
    * @returns The zone-1 mode.
    */
   public get operationModeZone1(): HomeAtwZoneMode {
-    return (
-      zoneModeFromWire[this.setting('OperationModeZone1')] ??
-      HomeAtwZoneMode.room
-    )
+    return this.#zoneMode('Zone1')
   }
 
   /**
@@ -232,11 +228,7 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
    * @returns The zone-2 mode, or `null`.
    */
   public get operationModeZone2(): HomeAtwZoneMode | null {
-    return this.#whenZone2(
-      () =>
-        zoneModeFromWire[this.setting('OperationModeZone2')] ??
-        HomeAtwZoneMode.room,
-    )
+    return this.#whenZone2(() => this.#zoneMode('Zone2'))
   }
 
   /**
@@ -385,18 +377,11 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
   public async getHourlyTemperatures(
     hour?: Hour,
   ): Promise<Result<ReportChartLineOptions>> {
-    const { cutoff, window } =
-      hour === undefined
-        ? resolveHomeDayWindow(this.chartTimezone)
-        : {
-            cutoff: undefined,
-            window: resolveHomeHourWindow(hour, this.chartTimezone),
-          }
-    return this.#fetchTemperatureChart(
-      window,
-      hour === undefined ? 'fiveMinutes' : 'minute',
-      cutoff,
+    const { cutoff, gridUnit, window } = resolveHomeFineWindow(
+      hour,
+      this.chartTimezone,
     )
+    return this.#fetchTemperatureChart(window, gridUnit, cutoff)
   }
 
   /**
@@ -559,6 +544,16 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
   // The cross-dialect zone snapshot: flags null (absent from this
   // wire), the operational state the shared top-level projection, the
   // control basis from the zone's own setting.
+  // The zone's control basis, wire-normalized: the external
+  // `*Thermostat` variants and unknown firmware strings degrade to the
+  // room modes so new FTC vocabulary can never break a consumer's sync.
+  #zoneMode(zone: 'Zone1' | 'Zone2'): HomeAtwZoneMode {
+    return (
+      zoneModeFromWire[this.setting(`OperationMode${zone}`)] ??
+      HomeAtwZoneMode.room
+    )
+  }
+
   #zoneState(zone: 'Zone1' | 'Zone2'): AtwZoneState {
     return {
       isCoolingProhibited: null,
@@ -567,9 +562,7 @@ export class HomeDeviceAtwFacade extends HomeBaseDeviceFacade<HomeAtwDeviceData>
       isInCoolMode: null,
       isInHeatMode: null,
       operationalState: this.operationalStateZone1,
-      operationMode:
-        zoneModeFromWire[this.setting(`OperationMode${zone}`)] ??
-        HomeAtwZoneMode.room,
+      operationMode: this.#zoneMode(zone),
       roomTemperature: this.settingNumber(`RoomTemperature${zone}`),
       setTemperature: this.settingNumber(`SetTemperature${zone}`),
     }

--- a/src/facades/home-report.ts
+++ b/src/facades/home-report.ts
@@ -443,6 +443,31 @@ export const resolveHomeDayWindow = (
 }
 
 /**
+ * Resolve the fine "today or one hour" window shared by the signal and
+ * hourly-temperature charts: today's full day on a five-minute grid
+ * with the "now" cutoff, or the given hour on a minute grid with no
+ * cutoff.
+ * @param hour - Hour of today (0-23); omitted covers today.
+ * @param timezone - IANA display timezone (UTC when unset).
+ * @returns The resolved window, its grid unit, and the optional cutoff.
+ */
+export const resolveHomeFineWindow = (
+  hour: Hour | undefined,
+  timezone: string,
+): {
+  cutoff: Temporal.ZonedDateTime | undefined
+  gridUnit: HomeChartGridUnit
+  window: HomeChartWindow
+} =>
+  hour === undefined
+    ? { ...resolveHomeDayWindow(timezone), gridUnit: 'fiveMinutes' }
+    : {
+        cutoff: undefined,
+        gridUnit: 'minute',
+        window: resolveHomeHourWindow(hour, timezone),
+      }
+
+/**
  * Serialize a window into the ISO instant pair consumed by the raw
  * report/telemetry endpoints.
  * @param window - Resolved chart window.

--- a/src/time-units.ts
+++ b/src/time-units.ts
@@ -5,10 +5,6 @@
  */
 
 /**
- * Number of milliseconds in one second.
- */
-export const MS_PER_SECOND = 1000
-/**
  * Number of milliseconds in one minute.
  */
 export const MS_PER_MINUTE = 60_000

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -234,7 +234,7 @@ const buildLabelFormatters = (
   }
 }
 
-const formatLabels = (
+export const formatLabels = (
   labels: readonly string[],
   labelType: ClassicLabelType,
   locale: string | undefined,
@@ -251,6 +251,17 @@ const formatLabels = (
 export const typedKeys = <T extends Record<string, unknown>>(
   object: T,
 ): (string & keyof T)[] => Object.keys(object)
+
+/**
+ * Identity through the microtask queue — the await target that lets a
+ * method answer an async cross-dialect contract from synchronously
+ * available data.
+ * @template T - Resolved value type.
+ * @param value - The synchronously available value.
+ * @returns The value, once resolved.
+ */
+// eslint-disable-next-line @typescript-eslint/promise-function-async -- the async spelling would then trip require-await (no await inside): the rule pair leaves no disable-free form, and this one named escape spares one at every call site
+export const resolved = <T>(value: T): Promise<T> => Promise.resolve(value)
 
 /**
  * The first value when every entry strictly equals it, `null` otherwise

--- a/tests/classic-fixtures.ts
+++ b/tests/classic-fixtures.ts
@@ -459,22 +459,22 @@ export function assertClassicDeviceType(
  * `new ClassicRegistry() + syncBuildings + syncFloors + syncAreas + syncDevices`
  * pattern found in multiple test files.
  * @param data - Flat arrays of buildings, floors, areas, and devices.
- * @param data.areas - ClassicArea rows to sync.
- * @param data.buildings - ClassicBuilding rows to sync.
- * @param data.devices - ClassicDevice rows to sync.
- * @param data.floors - ClassicFloor rows to sync.
+ * @param data.areas - ClassicArea rows to sync (none when omitted).
+ * @param data.buildings - ClassicBuilding rows to sync (none when omitted).
+ * @param data.devices - ClassicDevice rows to sync (none when omitted).
+ * @param data.floors - ClassicFloor rows to sync (none when omitted).
  * @returns A fully synced `ClassicRegistry` instance.
  */
 export const populatedClassicRegistry = ({
-  areas,
-  buildings,
-  devices,
-  floors,
+  areas = [],
+  buildings = [],
+  devices = [],
+  floors = [],
 }: {
-  areas: ClassicAreaDataAny[]
-  buildings: ClassicBuildingData[]
-  devices: ClassicListDeviceAny[]
-  floors: ClassicFloorData[]
+  areas?: ClassicAreaDataAny[]
+  buildings?: ClassicBuildingData[]
+  devices?: ClassicListDeviceAny[]
+  floors?: ClassicFloorData[]
 }): ClassicRegistry => {
   const registry = new ClassicRegistry()
   registry.syncBuildings(buildings)

--- a/tests/contracts/atw-state.test.ts
+++ b/tests/contracts/atw-state.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest'
 
-import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
 import type { AtwHotWaterState, AtwZoneState } from '../../src/atw-state.ts'
 import {
   ClassicOperationModeState,
@@ -8,7 +7,6 @@ import {
   ClassicOperationModeStateZone,
   HomeAtwZoneMode,
 } from '../../src/constants.ts'
-import { ClassicRegistry } from '../../src/entities/index.ts'
 import { ClassicDeviceAtwFacade } from '../../src/facades/classic-device-atw.ts'
 import { HomeDeviceAtwFacade } from '../../src/facades/home-device-atw.ts'
 import {
@@ -16,9 +14,10 @@ import {
   classicAtwDeviceData,
   classicBuildingData,
   createMockClassicApi,
+  populatedClassicRegistry,
 } from '../classic-fixtures.ts'
-import { defined, mock } from '../helpers.ts'
-import { homeAtwDevice, homeTestRegistry } from '../home-fixtures.ts'
+import { defined } from '../helpers.ts'
+import { createMockHomeApi, homeAtwDevice } from '../home-fixtures.ts'
 
 // One ATW state vocabulary on both dialects: the same zone1/zone2/
 // hotWater reads, the same string zone-mode vocabulary, the same
@@ -54,18 +53,19 @@ const describeAtwStateContract = (
 }
 
 describeAtwStateContract('Classic ATW device', () => {
-  const registry = new ClassicRegistry()
-  registry.syncBuildings([classicBuildingData()])
-  registry.syncDevices([
-    classicAtwDevice({
-      Device: classicAtwDeviceData({
-        HasZone2: true,
-        IdleZone1: false,
-        OperationMode: ClassicOperationModeState.heating,
-        Zone1InHeatMode: true,
+  const registry = populatedClassicRegistry({
+    buildings: [classicBuildingData()],
+    devices: [
+      classicAtwDevice({
+        Device: classicAtwDeviceData({
+          HasZone2: true,
+          IdleZone1: false,
+          OperationMode: ClassicOperationModeState.heating,
+          Zone1InHeatMode: true,
+        }),
       }),
-    }),
-  ])
+    ],
+  })
   const facade = new ClassicDeviceAtwFacade(
     createMockClassicApi(),
     registry,
@@ -76,7 +76,7 @@ describeAtwStateContract('Classic ATW device', () => {
 
 describeAtwStateContract('Home ATW device', () => {
   const facade = new HomeDeviceAtwFacade(
-    mock<HomeAPIAdapter>({ registry: homeTestRegistry }),
+    createMockHomeApi(),
     homeAtwDevice({
       capabilities: { hasZone2: true },
       id: 'contract-atw-state',
@@ -94,17 +94,18 @@ describeAtwStateContract('Home ATW device', () => {
 // Only Classic can express these: the wire flag refinements.
 describe('atwState — Classic flag precision', () => {
   it('keeps the flags boolean and can answer prohibited', () => {
-    const registry = new ClassicRegistry()
-    registry.syncBuildings([classicBuildingData()])
-    registry.syncDevices([
-      classicAtwDevice({
-        Device: classicAtwDeviceData({
-          OperationMode: ClassicOperationModeState.heating,
-          ProhibitHeatingZone1: true,
-          Zone1InHeatMode: true,
+    const registry = populatedClassicRegistry({
+      buildings: [classicBuildingData()],
+      devices: [
+        classicAtwDevice({
+          Device: classicAtwDeviceData({
+            OperationMode: ClassicOperationModeState.heating,
+            ProhibitHeatingZone1: true,
+            Zone1InHeatMode: true,
+          }),
         }),
-      }),
-    ])
+      ],
+    })
     const facade = new ClassicDeviceAtwFacade(
       createMockClassicApi(),
       registry,
@@ -124,7 +125,7 @@ describe('atwState — Classic flag precision', () => {
 describe('atwState — Home null precision', () => {
   it('reads null for every flag the wire cannot say', () => {
     const facade = new HomeDeviceAtwFacade(
-      mock<HomeAPIAdapter>({ registry: homeTestRegistry }),
+      createMockHomeApi(),
       homeAtwDevice({ id: 'contract-atw-nulls' }),
     )
 

--- a/tests/contracts/energy-report.test.ts
+++ b/tests/contracts/energy-report.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { ClassicAPIAdapter } from '../../src/api/classic-types.ts'
 import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
+import type { ClassicRegistry } from '../../src/entities/index.ts'
 import type { ReportChartLineOptions } from '../../src/facades/report-types.ts'
-import { ClassicRegistry } from '../../src/entities/index.ts'
 import { ClassicDeviceAtaFacade } from '../../src/facades/classic-device-ata.ts'
 import { ClassicDeviceAtwFacade } from '../../src/facades/classic-device-atw.ts'
 import { ClassicDeviceErvFacade } from '../../src/facades/classic-device-erv.ts'
@@ -16,12 +16,14 @@ import {
   classicBuildingData,
   classicErvDevice,
   createMockClassicApi,
+  populatedClassicRegistry,
 } from '../classic-fixtures.ts'
-import { cast, defined, mock, okValue } from '../helpers.ts'
+import { cast, defined, okValue } from '../helpers.ts'
 import {
+  createMockHomeApi,
   homeAtwDevice,
   homeDevice,
-  homeTestRegistry,
+  homeEnergyEnvelope,
 } from '../home-fixtures.ts'
 
 // The one window every dialect is asked about: explicit bounds, so no
@@ -29,13 +31,10 @@ import {
 const WINDOW = { from: '2026-03-01T00:00:00Z', to: '2026-03-03T00:00:00Z' }
 
 const classicRegistry = (): ClassicRegistry => {
-  const registry = new ClassicRegistry()
-  registry.syncBuildings([classicBuildingData()])
-  registry.syncDevices([
-    classicAtaDevice(),
-    classicAtwDevice(),
-    classicErvDevice(),
-  ])
+  const registry = populatedClassicRegistry({
+    buildings: [classicBuildingData()],
+    devices: [classicAtaDevice(), classicAtwDevice(), classicErvDevice()],
+  })
   return registry
 }
 
@@ -112,22 +111,19 @@ const homeEnergyValues = [
   { time: '2026-03-02 06:00:00.000000000', value: '229.0' },
 ]
 
+const homeAtaEnergyResponse = ok(
+  homeEnergyEnvelope(
+    'cumulative_energy_consumed_since_last_upload',
+    homeEnergyValues,
+  ),
+)
+
 describeEnergyReportContract('Home ATA device', async () => {
   const facade = new HomeDeviceAtaFacade(
-    mock<HomeAPIAdapter>({
+    createMockHomeApi({
       getEnergy: vi
         .fn<HomeAPIAdapter['getEnergy']>()
-        .mockResolvedValue(
-          ok({
-            measureData: [
-              {
-                type: 'cumulative_energy_consumed_since_last_upload',
-                values: homeEnergyValues,
-              },
-            ],
-          }),
-        ),
-      registry: homeTestRegistry,
+        .mockResolvedValue(homeAtaEnergyResponse),
       timezone: 'UTC',
     }),
     homeDevice({ id: 'contract-energy-ata' }),
@@ -137,7 +133,7 @@ describeEnergyReportContract('Home ATA device', async () => {
 
 describeEnergyReportContract('Home ATW device', async () => {
   const facade = new HomeDeviceAtwFacade(
-    mock<HomeAPIAdapter>({
+    createMockHomeApi({
       getEnergy: vi.fn<HomeAPIAdapter['getEnergy']>().mockResolvedValue(
         ok({
           measureData: [
@@ -146,7 +142,6 @@ describeEnergyReportContract('Home ATW device', async () => {
           ],
         }),
       ),
-      registry: homeTestRegistry,
       timezone: 'UTC',
     }),
     homeAtwDevice({ id: 'contract-energy-atw' }),

--- a/tests/contracts/error-log.test.ts
+++ b/tests/contracts/error-log.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it, vi } from 'vitest'
 import type { ClassicAPIAdapter } from '../../src/api/classic-types.ts'
 import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
 import type { ErrorLogEntry } from '../../src/error-log.ts'
-import { ClassicRegistry } from '../../src/entities/index.ts'
 import { ClassicDeviceAtaFacade } from '../../src/facades/classic-device-ata.ts'
 import { HomeDeviceAtaFacade } from '../../src/facades/home-device-ata.ts'
 import { HomeDeviceAtwFacade } from '../../src/facades/home-device-atw.ts'
@@ -12,12 +11,13 @@ import {
   classicAtaDevice,
   classicBuildingData,
   createMockClassicApi,
+  populatedClassicRegistry,
 } from '../classic-fixtures.ts'
-import { defined, mock, okValue } from '../helpers.ts'
+import { defined, okValue } from '../helpers.ts'
 import {
+  createMockHomeApi,
   homeAtwDevice,
   homeDevice,
-  homeTestRegistry,
 } from '../home-fixtures.ts'
 
 // One neutral entry shape on every dialect: `at` and `deviceId` always,
@@ -46,9 +46,10 @@ const describeErrorLogContract = (
 }
 
 describeErrorLogContract('Classic ATA device', async () => {
-  const registry = new ClassicRegistry()
-  registry.syncBuildings([classicBuildingData()])
-  registry.syncDevices([classicAtaDevice()])
+  const registry = populatedClassicRegistry({
+    buildings: [classicBuildingData()],
+    devices: [classicAtaDevice()],
+  })
   const api = createMockClassicApi({
     getErrorLog: vi
       .fn<ClassicAPIAdapter['getErrorLog']>()
@@ -93,7 +94,7 @@ describeErrorLogContract('Home ATW device', async () => {
 })
 
 const homeErrorApi = (): HomeAPIAdapter =>
-  mock<HomeAPIAdapter>({
+  createMockHomeApi({
     getErrorLog: vi
       .fn<HomeAPIAdapter['getErrorLog']>()
       .mockResolvedValue(
@@ -106,5 +107,4 @@ const homeErrorApi = (): HomeAPIAdapter =>
           },
         ]),
       ),
-    registry: homeTestRegistry,
   })

--- a/tests/contracts/holiday-mode-state.test.ts
+++ b/tests/contracts/holiday-mode-state.test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ClassicAPIAdapter } from '../../src/api/classic-types.ts'
 import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
 import type { HolidayModeState } from '../../src/holiday-mode.ts'
-import { ClassicRegistry } from '../../src/entities/index.ts'
 import { ClassicBuildingFacade } from '../../src/facades/classic-building.ts'
 import { HomeDeviceAtaFacade } from '../../src/facades/home-device-ata.ts'
 import { HomeDeviceAtwFacade } from '../../src/facades/home-device-atw.ts'
@@ -13,12 +12,13 @@ import {
   classicBuildingData,
   classicHolidayModeResponse,
   createMockClassicApi,
+  populatedClassicRegistry,
 } from '../classic-fixtures.ts'
-import { defined, mock, okValue } from '../helpers.ts'
+import { defined, okValue } from '../helpers.ts'
 import {
+  createMockHomeApi,
   homeAtwDevice,
   homeDevice,
-  homeTestRegistry,
   resetHomeDevices,
 } from '../home-fixtures.ts'
 
@@ -106,9 +106,10 @@ const describeHolidayModeStateContract = (
 const classicFacade = (
   data: Parameters<typeof classicHolidayModeResponse>[0],
 ): ClassicBuildingFacade => {
-  const registry = new ClassicRegistry()
-  registry.syncBuildings([classicBuildingData()])
-  registry.syncDevices([classicAtaDevice()])
+  const registry = populatedClassicRegistry({
+    buildings: [classicBuildingData()],
+    devices: [classicAtaDevice()],
+  })
   const api = createMockClassicApi({
     getHolidayMode: vi
       .fn<ClassicAPIAdapter['getHolidayMode']>()
@@ -138,10 +139,7 @@ describeHolidayModeStateContract('Classic zone', async (wire) =>
 )
 
 const homeApi = (): HomeAPIAdapter =>
-  mock<HomeAPIAdapter>({
-    registry: homeTestRegistry,
-    timezone: CONTRACT_TIMEZONE,
-  })
+  createMockHomeApi({ timezone: CONTRACT_TIMEZONE })
 
 const toHomeWire = (
   wire: BoundedWindow | null,

--- a/tests/contracts/holiday-mode-write.test.ts
+++ b/tests/contracts/holiday-mode-write.test.ts
@@ -2,16 +2,16 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { ClassicAPIAdapter } from '../../src/api/classic-types.ts'
 import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
-import { ClassicRegistry } from '../../src/entities/index.ts'
 import { ClassicBuildingFacade } from '../../src/facades/classic-building.ts'
 import { HomeFacadeManager } from '../../src/facades/home-manager.ts'
 import {
   classicAtaDevice,
   classicBuildingData,
   createMockClassicApi,
+  populatedClassicRegistry,
 } from '../classic-fixtures.ts'
-import { defined, mock } from '../helpers.ts'
-import { homeDevice, homeTestRegistry } from '../home-fixtures.ts'
+import { defined } from '../helpers.ts'
+import { createMockHomeApi, homeDevice } from '../home-fixtures.ts'
 
 // The write-side twin of the holiday-mode read contract: a DISABLED
 // window's dates are ignored by both wires, so neither dialect may
@@ -27,9 +27,10 @@ describe('holidayMode write — disabled window', () => {
   }
 
   it('classic clears the bounds without projecting them', async () => {
-    const registry = new ClassicRegistry()
-    registry.syncBuildings([classicBuildingData()])
-    registry.syncDevices([classicAtaDevice()])
+    const registry = populatedClassicRegistry({
+      buildings: [classicBuildingData()],
+      devices: [classicAtaDevice()],
+    })
     const updateHolidayMode = vi
       .fn<ClassicAPIAdapter['updateHolidayMode']>()
       .mockResolvedValue({ AttributeErrors: null, Success: true })
@@ -60,11 +61,7 @@ describe('holidayMode write — disabled window', () => {
       .fn<HomeAPIAdapter['updateHolidayMode']>()
       .mockResolvedValue()
     const manager = new HomeFacadeManager(
-      mock<HomeAPIAdapter>({
-        registry: homeTestRegistry,
-        timezone: 'Europe/Paris',
-        updateHolidayMode,
-      }),
+      createMockHomeApi({ timezone: 'Europe/Paris', updateHolidayMode }),
     )
 
     await manager.updateHolidayMode(['device-1'], DISABLE)

--- a/tests/contracts/is-available.test.ts
+++ b/tests/contracts/is-available.test.ts
@@ -1,8 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
+import type { ClassicRegistry } from '../../src/entities/index.ts'
 import { ClassicDeviceType } from '../../src/constants.ts'
-import { ClassicRegistry } from '../../src/entities/index.ts'
 import { EntityNotFoundError } from '../../src/errors/index.ts'
 import { ClassicDeviceAtaFacade } from '../../src/facades/classic-device-ata.ts'
 import { HomeDeviceAtaFacade } from '../../src/facades/home-device-ata.ts'
@@ -15,11 +14,12 @@ import {
   classicBuildingData,
   classicFloorData,
   createMockClassicApi,
+  populatedClassicRegistry,
 } from '../classic-fixtures.ts'
-import { defined, mock } from '../helpers.ts'
+import { defined } from '../helpers.ts'
 import {
+  createMockHomeApi,
   homeDevice,
-  homeTestRegistry,
   pruneHomeDevice,
   resetHomeDevices,
 } from '../home-fixtures.ts'
@@ -75,10 +75,11 @@ const describeIsAvailableContract = (
 const now = (): Temporal.PlainDateTime => Temporal.Now.plainDateTimeISO('UTC')
 
 const classicRegistry = (): ClassicRegistry => {
-  const registry = new ClassicRegistry()
-  registry.syncBuildings([classicBuildingData()])
-  registry.syncFloors([classicFloorData()])
-  registry.syncAreas([classicAreaData()])
+  const registry = populatedClassicRegistry({
+    areas: [classicAreaData()],
+    buildings: [classicBuildingData()],
+    floors: [classicFloorData()],
+  })
   return registry
 }
 
@@ -111,9 +112,6 @@ describeIsAvailableContract(
   },
 )
 
-const homeApi = (): HomeAPIAdapter =>
-  mock<HomeAPIAdapter>({ registry: homeTestRegistry })
-
 // Home expresses silence as a disconnection streak, so the clock is
 // moved rather than the payload; `isConnected` stays true for a unit
 // heard from just now.
@@ -121,7 +119,7 @@ describeIsAvailableContract(
   'Home device',
   (silentHours) => {
     const facade = new HomeDeviceAtaFacade(
-      homeApi(),
+      createMockHomeApi(),
       homeDevice({
         id: `contract-available-${String(silentHours)}`,
         isConnected: silentHours === 0,
@@ -142,7 +140,7 @@ describeIsAvailableContract(
   },
   () => {
     const facade = new HomeDeviceAtaFacade(
-      homeApi(),
+      createMockHomeApi(),
       homeDevice({ id: 'contract-available-pruned' }),
     )
     pruneHomeDevice('contract-available-pruned')

--- a/tests/contracts/no-changes.test.ts
+++ b/tests/contracts/no-changes.test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ClassicAPIAdapter } from '../../src/api/classic-types.ts'
 import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
 import { ClassicDeviceType } from '../../src/constants.ts'
-import { ClassicRegistry } from '../../src/entities/index.ts'
 import { NoChangesError } from '../../src/errors/index.ts'
 import { ClassicDeviceAtaFacade } from '../../src/facades/classic-device-ata.ts'
 import { HomeDeviceAtaFacade } from '../../src/facades/home-device-ata.ts'
@@ -14,11 +13,12 @@ import {
   classicBuildingData,
   classicFloorData,
   createMockClassicApi,
+  populatedClassicRegistry,
 } from '../classic-fixtures.ts'
-import { cast, defined, mock } from '../helpers.ts'
+import { cast, defined } from '../helpers.ts'
 import {
+  createMockHomeApi,
   homeDevice,
-  homeTestRegistry,
   resetHomeDevices,
 } from '../home-fixtures.ts'
 
@@ -107,10 +107,11 @@ const CLASSIC_VALUES = {
 } as const
 
 describeNoChangesContract('Classic ATA device', (kind) => {
-  const registry = new ClassicRegistry()
-  registry.syncBuildings([classicBuildingData()])
-  registry.syncFloors([classicFloorData()])
-  registry.syncAreas([classicAreaData()])
+  const registry = populatedClassicRegistry({
+    areas: [classicAreaData()],
+    buildings: [classicBuildingData()],
+    floors: [classicFloorData()],
+  })
   const device = classicAtaDevice()
   registry.syncDevices([device])
   const instance = defined(registry.devices.getById(device.DeviceID))
@@ -134,7 +135,7 @@ describeNoChangesContract('Home ATA device', (kind) => {
   const updateValues = vi
     .fn<HomeAPIAdapter['updateValues']>()
     .mockResolvedValue()
-  const api = mock<HomeAPIAdapter>({ registry: homeTestRegistry, updateValues })
+  const api = createMockHomeApi({ updateValues })
   const facade = new HomeDeviceAtaFacade(
     api,
     homeDevice({ id: `contract-no-changes-${kind}` }),
@@ -150,10 +151,11 @@ describeNoChangesContract('Home ATA device', (kind) => {
 // rather than a contract one.
 describe('updateValues — Classic state comparison', () => {
   it('refuses a value already in the synced state', async () => {
-    const registry = new ClassicRegistry()
-    registry.syncBuildings([classicBuildingData()])
-    registry.syncFloors([classicFloorData()])
-    registry.syncAreas([classicAreaData()])
+    const registry = populatedClassicRegistry({
+      areas: [classicAreaData()],
+      buildings: [classicBuildingData()],
+      floors: [classicFloorData()],
+    })
     const device = classicAtaDevice()
     registry.syncDevices([device])
     const instance = defined(registry.devices.getById(device.DeviceID))

--- a/tests/contracts/protection-state.test.ts
+++ b/tests/contracts/protection-state.test.ts
@@ -1,9 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClassicAPIAdapter } from '../../src/api/classic-types.ts'
-import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
 import type { ProtectionState } from '../../src/protection.ts'
-import { ClassicRegistry } from '../../src/entities/index.ts'
 import { ClassicBuildingFacade } from '../../src/facades/classic-building.ts'
 import { HomeDeviceAtaFacade } from '../../src/facades/home-device-ata.ts'
 import { HomeDeviceAtwFacade } from '../../src/facades/home-device-atw.ts'
@@ -13,12 +11,13 @@ import {
   classicBuildingData,
   classicFrostProtectionResponse,
   createMockClassicApi,
+  populatedClassicRegistry,
 } from '../classic-fixtures.ts'
-import { defined, mock, okValue } from '../helpers.ts'
+import { defined, okValue } from '../helpers.ts'
 import {
+  createMockHomeApi,
   homeAtwDevice,
   homeDevice,
-  homeTestRegistry,
   resetHomeDevices,
 } from '../home-fixtures.ts'
 
@@ -58,9 +57,10 @@ const describeProtectionStateContract = (
 }
 
 describeProtectionStateContract('Classic zone', async (state) => {
-  const registry = new ClassicRegistry()
-  registry.syncBuildings([classicBuildingData()])
-  registry.syncDevices([classicAtaDevice()])
+  const registry = populatedClassicRegistry({
+    buildings: [classicBuildingData()],
+    devices: [classicAtaDevice()],
+  })
   const api = createMockClassicApi({
     getFrostProtection: vi
       .fn<ClassicAPIAdapter['getFrostProtection']>()
@@ -87,9 +87,6 @@ describeProtectionStateContract('Classic zone', async (state) => {
   return okValue(await facade.getFrostProtection())
 })
 
-const homeApi = (): HomeAPIAdapter =>
-  mock<HomeAPIAdapter>({ registry: homeTestRegistry })
-
 const toHomeWire = (
   state: ProtectionState | null,
 ): { enabled: boolean; max: number; min: number } | null =>
@@ -99,7 +96,7 @@ const toHomeWire = (
 
 describeProtectionStateContract('Home ATA device', async (state) => {
   const facade = new HomeDeviceAtaFacade(
-    homeApi(),
+    createMockHomeApi(),
     homeDevice({ frostProtection: toHomeWire(state), id: 'contract-ata' }),
   )
   return okValue(await facade.getFrostProtection())
@@ -109,7 +106,7 @@ describeProtectionStateContract('Home ATA device', async (state) => {
 // coverage gate was satisfied by the ATA path alone.
 describeProtectionStateContract('Home ATW device', async (state) => {
   const facade = new HomeDeviceAtwFacade(
-    homeApi(),
+    createMockHomeApi(),
     homeAtwDevice({ frostProtection: toHomeWire(state), id: 'contract-atw' }),
   )
   return okValue(await facade.getFrostProtection())
@@ -121,7 +118,7 @@ describe('protectionState — overheat shares the shape', () => {
   it('reads the overheat descriptor through the same contract', async () => {
     const state = { isEnabled: true, max: 37, min: 35 }
     const facade = new HomeDeviceAtaFacade(
-      homeApi(),
+      createMockHomeApi(),
       homeDevice({
         id: 'contract-overheat',
         overheatProtection: toHomeWire(state),
@@ -135,7 +132,7 @@ describe('protectionState — overheat shares the shape', () => {
 
   it('answers null on an ATW unit without a type guard', async () => {
     const facade = new HomeDeviceAtwFacade(
-      homeApi(),
+      createMockHomeApi(),
       homeAtwDevice({ id: 'contract-overheat-atw' }),
     )
 
@@ -149,9 +146,10 @@ describe('protectionState — overheat shares the shape', () => {
 // off": Home has no *Defined flag, so `null` is its only absence marker.
 describe('protectionState — Classic *Defined semantics', () => {
   it('reads a configured-but-disabled window as a real state, not null', async () => {
-    const registry = new ClassicRegistry()
-    registry.syncBuildings([classicBuildingData()])
-    registry.syncDevices([classicAtaDevice()])
+    const registry = populatedClassicRegistry({
+      buildings: [classicBuildingData()],
+      devices: [classicAtaDevice()],
+    })
     const api = createMockClassicApi({
       getFrostProtection: vi
         .fn<ClassicAPIAdapter['getFrostProtection']>()

--- a/tests/contracts/signal-strength.test.ts
+++ b/tests/contracts/signal-strength.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ClassicAPIAdapter } from '../../src/api/classic-types.ts'
 import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
 import type { ReportChartLineOptions } from '../../src/facades/report-types.ts'
-import { ClassicRegistry } from '../../src/entities/index.ts'
 import { ClassicBuildingFacade } from '../../src/facades/classic-building.ts'
 import { HomeDeviceAtaFacade } from '../../src/facades/home-device-ata.ts'
 import { Temporal } from '../../src/temporal.ts'
@@ -13,18 +12,24 @@ import {
   classicBuildingData,
   classicReportData,
   createMockClassicApi,
+  populatedClassicRegistry,
 } from '../classic-fixtures.ts'
-import { defined, mock, mockTemporalNowZoned, okValue } from '../helpers.ts'
-import { homeDevice, homeTestRegistry } from '../home-fixtures.ts'
+import { defined, mockTemporalNowZoned, okValue } from '../helpers.ts'
+import {
+  createMockHomeApi,
+  homeDevice,
+  homeEnergyEnvelope,
+} from '../home-fixtures.ts'
 
 // Both dialects are asked about the same pinned moment, so neither the
 // host clock nor its timezone can shape the answer.
 const NOW = '2026-03-01T12:00:00Z'
 
 const classicSignalFacade = (): ClassicBuildingFacade => {
-  const registry = new ClassicRegistry()
-  registry.syncBuildings([classicBuildingData()])
-  registry.syncDevices([classicAtaDevice()])
+  const registry = populatedClassicRegistry({
+    buildings: [classicBuildingData()],
+    devices: [classicAtaDevice()],
+  })
   const api = createMockClassicApi({
     getSignal: vi
       .fn<ClassicAPIAdapter['getSignal']>()
@@ -38,20 +43,16 @@ const classicSignalFacade = (): ClassicBuildingFacade => {
 }
 
 const homeSignalFacade = (): HomeDeviceAtaFacade => {
-  const api = mock<HomeAPIAdapter>({
+  const api = createMockHomeApi({
     getSignal: vi
       .fn<HomeAPIAdapter['getSignal']>()
       .mockResolvedValue(
-        ok({
-          measureData: [
-            {
-              type: 'rssi',
-              values: [{ time: '2026-03-01 12:05:00.000000000', value: '-66' }],
-            },
-          ],
-        }),
+        ok(
+          homeEnergyEnvelope('rssi', [
+            { time: '2026-03-01 12:05:00.000000000', value: '-66' },
+          ]),
+        ),
       ),
-    registry: homeTestRegistry,
     timezone: 'UTC',
   })
   return new HomeDeviceAtaFacade(api, homeDevice({ id: 'contract-signal' }))

--- a/tests/home-fixtures.ts
+++ b/tests/home-fixtures.ts
@@ -1,3 +1,6 @@
+import { vi } from 'vitest'
+
+import type { HomeAPIAdapter } from '../src/api/home-types.ts'
 import type {
   HomeRegistry,
   TypedHomeDeviceData,
@@ -8,6 +11,8 @@ import type {
   HomeAtwDeviceCapabilities,
   HomeAtwDeviceData,
   HomeBuildingRef,
+  HomeEnergyData,
+  HomeEnergyPoint,
   HomeFrostProtection,
   HomeHolidayMode,
   HomeOverheatProtection,
@@ -259,3 +264,37 @@ export const homeReportPoint = (
   y: value,
   /* eslint-enable id-length */
 })
+
+/**
+ * Wrap one measure series into the telemetry wire envelope
+ * (`{ measureData: [{ type, values }] }`) shared by the energy and
+ * signal endpoints.
+ * @param type - Wire measure name (e.g. `rssi`, `interval_energy_consumed`).
+ * @param values - Time-stamped wire samples of the series.
+ * @returns The wire-shaped envelope.
+ */
+export const homeEnergyEnvelope = (
+  type: string,
+  values: readonly HomeEnergyPoint[],
+): HomeEnergyData => ({ measureData: [{ type, values: [...values] }] })
+
+// Every adapter call stubbed and the shared test registry plugged in;
+// overrides spread last so call sites can replace any of them.
+export const createMockHomeApi = (
+  overrides: Partial<HomeAPIAdapter> = {},
+): HomeAPIAdapter =>
+  mock<HomeAPIAdapter>({
+    getAtwInternalTemperatures:
+      vi.fn<HomeAPIAdapter['getAtwInternalTemperatures']>(),
+    getEnergy: vi.fn<HomeAPIAdapter['getEnergy']>(),
+    getErrorLog: vi.fn<HomeAPIAdapter['getErrorLog']>(),
+    getSignal: vi.fn<HomeAPIAdapter['getSignal']>(),
+    getTemperatures: vi.fn<HomeAPIAdapter['getTemperatures']>(),
+    registry: homeTestRegistry,
+    updateFrostProtection: vi.fn<HomeAPIAdapter['updateFrostProtection']>(),
+    updateHolidayMode: vi.fn<HomeAPIAdapter['updateHolidayMode']>(),
+    updateOverheatProtection:
+      vi.fn<HomeAPIAdapter['updateOverheatProtection']>(),
+    updateValues: vi.fn<HomeAPIAdapter['updateValues']>().mockResolvedValue(),
+    ...overrides,
+  })

--- a/tests/unit/classic-atw-zones.test.ts
+++ b/tests/unit/classic-atw-zones.test.ts
@@ -302,11 +302,4 @@ describe('atw device facade zone 2', () => {
       ClassicOperationModeStateZone.prohibited,
     )
   })
-
-  it('also exposes zone1 and hotWater', () => {
-    const facade = createZone2Facade()
-
-    expect(facade.zone1.roomTemperature).toBe(21)
-    expect(facade.hotWater.tankWaterTemperature).toBe(48)
-  })
 })

--- a/tests/unit/classic-facades.test.ts
+++ b/tests/unit/classic-facades.test.ts
@@ -356,14 +356,6 @@ describe('building facade', () => {
 })
 
 describe('building facade frost protection', () => {
-  it('gets frost protection with defined settings', async () => {
-    const { api, facade } = createBuildingFacade()
-    const value = okValue(await facade.getFrostProtection())
-
-    expect(value).toHaveProperty('isEnabled')
-    expect(api.getFrostProtection).toHaveBeenCalledWith(expect.any(Object))
-  })
-
   it('sets frost protection', async () => {
     const { api, facade } = createBuildingFacade()
     await facade.getFrostProtection()
@@ -427,13 +419,6 @@ describe('building facade frost protection', () => {
 })
 
 describe('building facade holiday mode', () => {
-  it('gets holiday mode', async () => {
-    const { facade } = createBuildingFacade()
-    const value = okValue(await facade.getHolidayMode())
-
-    expect(value).toHaveProperty('isEnabled')
-  })
-
   it('projects the window onto UTC components on the wire', async () => {
     const { api, facade } = createBuildingFacade({ timezone: 'Europe/Paris' })
     await facade.getHolidayMode()
@@ -464,24 +449,6 @@ describe('building facade holiday mode', () => {
       Second: 0,
       Year: 2024,
     })
-  })
-
-  it('disables holiday mode and ignores the window dates', async () => {
-    const { api, facade } = createBuildingFacade()
-    await facade.getHolidayMode()
-    await facade.updateHolidayMode({
-      endDate: '2024-06-15',
-      isEnabled: false,
-      startDate: '2024-06-01',
-    })
-    const call = vi.mocked(api.updateHolidayMode).mock.lastCall?.[0]
-
-    expect(call).toBeDefined()
-
-    expect(defined(call).postData.Enabled).toBe(false)
-    // Dates are cleared to null on the wire when disabling.
-    expect(defined(call).postData.StartDate).toBeNull()
-    expect(defined(call).postData.EndDate).toBeNull()
   })
 })
 
@@ -1246,14 +1213,6 @@ describe('ata device facade', () => {
     ).rejects.toThrow(new NoChangesError(1000))
   })
 
-  it('updateValues treats explicitly-undefined values as absent', async () => {
-    const { facade } = createAtaFacade()
-
-    await expect(
-      facade.updateValues(cast({ SetTemperature: undefined })),
-    ).rejects.toThrow(new NoChangesError(1000))
-  })
-
   it('updateValues raises no flag for an undefined-valued key', async () => {
     const { api, facade } = createAtaFacade()
     await facade.updateValues(cast({ Power: false, SetTemperature: undefined }))
@@ -1708,39 +1667,6 @@ describe('atw device facade with zone 2', () => {
 })
 
 describe('device facade availability', () => {
-  it('is available when the unit communicated recently', () => {
-    const facade = buildAtaFacade({
-      LastTimeStamp: Temporal.Now.plainDateTimeISO('UTC').toString(),
-    })
-
-    expect(facade.isAvailable).toBe(true)
-  })
-
-  it('is unavailable after a day without communication', () => {
-    const facade = buildAtaFacade({ LastTimeStamp: '2020-01-01T00:00:00' })
-
-    expect(facade.isAvailable).toBe(false)
-  })
-
-  it('propagates a pruned registry id instead of reading available', () => {
-    const registry = new ClassicRegistry()
-    registry.syncBuildings([classicBuildingData({ HMDefined: true })])
-    registry.syncFloors([classicFloorData()])
-    registry.syncAreas([classicAreaData()])
-    registry.syncDevices([classicAtaDevice()])
-    const instance = defined(registry.devices.getById(1000))
-    assertClassicDeviceType(instance, ClassicDeviceType.Ata)
-    const facade = new ClassicDeviceAtaFacade(
-      createMockClassicApi(),
-      registry,
-      instance,
-    )
-
-    registry.syncDevices([])
-
-    expect(() => facade.isAvailable).toThrow(EntityNotFoundError)
-  })
-
   it('errs on the available side for an unparsable timestamp', () => {
     const facade = buildAtaFacade({ LastTimeStamp: 'garbage' })
 
@@ -1794,20 +1720,6 @@ describe('device type guards', () => {
       expect(guard(nonMatching)).toBe(false)
     },
   )
-})
-
-describe('zone2 as a capability', () => {
-  it('answers the zone-2 snapshot on a dual-zone unit', () => {
-    const { facade } = createZone2Facade()
-
-    expect(facade.zone2).not.toBeNull()
-  })
-
-  it('answers null on a single-zone unit', () => {
-    const { facade } = createAtwFacade()
-
-    expect(facade.zone2).toBeNull()
-  })
 })
 
 describe('base device facade tiles', () => {

--- a/tests/unit/home-api.test.ts
+++ b/tests/unit/home-api.test.ts
@@ -12,7 +12,6 @@ import type {
 import { EntityNotFoundError } from '../../src/errors/index.ts'
 import { type HttpResponse, HttpError } from '../../src/http/index.ts'
 import { Temporal } from '../../src/temporal.ts'
-import { MS_PER_SECOND } from '../../src/time-units.ts'
 import {
   cast,
   createLogger,
@@ -22,8 +21,11 @@ import {
   matchObject,
   mockFetchResponse,
   mockResponse,
+  mockTemporalNowInstant,
 } from '../helpers.ts'
 import { homeReportPoint, typedHomeAtwDeviceData } from '../home-fixtures.ts'
+
+const MS_PER_SECOND = 1000
 
 const BASE_URL = 'https://melcloudhome.com'
 const COGNITO = 'https://live-melcloudhome.auth.eu-west-1.amazoncognito.com'
@@ -1367,6 +1369,7 @@ describe('melcloud home API', () => {
   describe('session expiry', () => {
     it('should re-authenticate when session is expired', async () => {
       vi.useFakeTimers()
+      mockTemporalNowInstant()
       try {
         setupSuccessfulLogin()
 
@@ -2536,6 +2539,7 @@ describe('melcloud home API', () => {
   describe('token refresh', () => {
     it('should refresh access token when expired instead of full re-auth', async () => {
       vi.useFakeTimers()
+      mockTemporalNowInstant()
       try {
         setupSuccessfulLogin()
         const api = await createApi({ syncIntervalMinutes: false })
@@ -2561,12 +2565,14 @@ describe('melcloud home API', () => {
           expect.any(Object),
         )
       } finally {
+        vi.mocked(Temporal.Now.instant).mockRestore()
         vi.useRealTimers()
       }
     })
 
     it('should pass AbortSignal to refresh token request', async () => {
       vi.useFakeTimers()
+      mockTemporalNowInstant()
       try {
         const controller = new AbortController()
         setupSuccessfulLogin()
@@ -2601,6 +2607,7 @@ describe('melcloud home API', () => {
 
     it('should fall back to full OIDC when token refresh fails', async () => {
       vi.useFakeTimers()
+      mockTemporalNowInstant()
       try {
         setupSuccessfulLogin()
         const api = await createApi({ syncIntervalMinutes: false })
@@ -2645,6 +2652,7 @@ describe('melcloud home API', () => {
   describe('token response without refresh_token', () => {
     it('should not overwrite refresh token when response omits it', async () => {
       vi.useFakeTimers()
+      mockTemporalNowInstant()
       try {
         setupSuccessfulLogin()
         const api = await createApi({ syncIntervalMinutes: false })
@@ -2666,6 +2674,7 @@ describe('melcloud home API', () => {
 
         expect(buildings).toStrictEqual([mockBuilding])
       } finally {
+        vi.mocked(Temporal.Now.instant).mockRestore()
         vi.useRealTimers()
       }
     })

--- a/tests/unit/home-ata-group.test.ts
+++ b/tests/unit/home-ata-group.test.ts
@@ -23,6 +23,7 @@ import { HomeDeviceAtaFacade } from '../../src/facades/home-device-ata.ts'
 import { HomeFacadeManager } from '../../src/facades/home-manager.ts'
 import { mock, okValue } from '../helpers.ts'
 import {
+  createMockHomeApi,
   homeBuildingRef,
   typedHomeAtwDeviceData,
   typedHomeDeviceData,
@@ -37,13 +38,10 @@ const heatState = {
   VaneVerticalDirection: 'Auto',
 }
 
-const createApi = (): HomeAPIAdapter => {
-  const registry = new HomeRegistry()
-  return mock<HomeAPIAdapter>({
-    registry,
-    updateValues: vi.fn<HomeAPIAdapter['updateValues']>().mockResolvedValue(),
-  })
-}
+// A private registry per api double: group tests sync whole buildings
+// and must not leak devices into the shared test registry.
+const createApi = (): HomeAPIAdapter =>
+  createMockHomeApi({ registry: new HomeRegistry() })
 
 const syncBuilding = (
   api: HomeAPIAdapter,

--- a/tests/unit/home-building-facade.test.ts
+++ b/tests/unit/home-building-facade.test.ts
@@ -4,8 +4,9 @@ import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
 import type { HomeBuildingFacade } from '../../src/facades/home-building.ts'
 import { HomeRegistry } from '../../src/entities/home-registry.ts'
 import { HomeFacadeManager } from '../../src/facades/home-manager.ts'
-import { mock, okValue } from '../helpers.ts'
+import { okValue } from '../helpers.ts'
 import {
+  createMockHomeApi,
   homeBuildingRef,
   typedHomeAtwDeviceData,
   typedHomeDeviceData,
@@ -19,16 +20,10 @@ const HOLIDAY = {
   startDate: '2026-07-31T22:00:00',
 }
 
+// A private registry per api double: these tests sync whole buildings
+// and must not leak devices into the shared test registry.
 const createApi = (): HomeAPIAdapter =>
-  mock<HomeAPIAdapter>({
-    registry: new HomeRegistry(),
-    timezone: 'Europe/Paris',
-    updateFrostProtection: vi.fn<HomeAPIAdapter['updateFrostProtection']>(),
-    updateHolidayMode: vi.fn<HomeAPIAdapter['updateHolidayMode']>(),
-    updateOverheatProtection:
-      vi.fn<HomeAPIAdapter['updateOverheatProtection']>(),
-    updateValues: vi.fn<HomeAPIAdapter['updateValues']>().mockResolvedValue(),
-  })
+  createMockHomeApi({ registry: new HomeRegistry(), timezone: 'Europe/Paris' })
 
 const syncMixedBuilding = (
   api: HomeAPIAdapter,

--- a/tests/unit/home-device-ata-facade.test.ts
+++ b/tests/unit/home-device-ata-facade.test.ts
@@ -1,16 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
 import { ClassicOperationMode } from '../../src/constants.ts'
 import { EntityNotFoundError, NoChangesError } from '../../src/errors/index.ts'
 import { HomeDeviceAtaFacade } from '../../src/facades/home-device-ata.ts'
 import { Temporal } from '../../src/temporal.ts'
 import { type HomeAtaDeviceCapabilities, ok } from '../../src/types/index.ts'
-import { cast, mock, mockTemporalNowZoned, okValue } from '../helpers.ts'
+import { cast, mockTemporalNowZoned, okValue } from '../helpers.ts'
 import {
+  createMockHomeApi,
   homeDevice,
+  homeEnergyEnvelope,
   homeReportPoint,
-  homeTestRegistry,
   pruneHomeDevice,
   resetHomeDevices,
 } from '../home-fixtures.ts'
@@ -28,71 +28,13 @@ const createModel = (
     settings,
   })
 
-const createApi = (overrides: Partial<HomeAPIAdapter> = {}): HomeAPIAdapter =>
-  mock<HomeAPIAdapter>({
-    ...overrides,
-    getEnergy: vi.fn<HomeAPIAdapter['getEnergy']>(),
-    getErrorLog: vi.fn<HomeAPIAdapter['getErrorLog']>(),
-    getSignal: vi.fn<HomeAPIAdapter['getSignal']>(),
-    getTemperatures: vi.fn<HomeAPIAdapter['getTemperatures']>(),
-    registry: homeTestRegistry,
-    updateFrostProtection: vi.fn<HomeAPIAdapter['updateFrostProtection']>(),
-    updateHolidayMode: vi.fn<HomeAPIAdapter['updateHolidayMode']>(),
-    updateOverheatProtection:
-      vi.fn<HomeAPIAdapter['updateOverheatProtection']>(),
-    updateValues: vi.fn<HomeAPIAdapter['updateValues']>().mockResolvedValue(),
-  })
-
 describe('home device ata facade', () => {
   beforeEach(resetHomeDevices)
 
   describe('protection accessors', () => {
-    it('exposes frost protection and holiday mode from context', async () => {
-      const frostProtection = { active: false, enabled: true, max: 12, min: 6 }
-      // The wire's UTC wall clock; the facade projects it onto the
-      // caller's timezone.
-      const holidayMode = {
-        active: false,
-        enabled: true,
-        endDate: '2026-08-04T22:00:00',
-        startDate: '2026-07-31T22:00:00',
-      }
-      const overheatProtection = {
-        active: false,
-        enabled: true,
-        max: 37,
-        min: 35,
-      }
-      const facade = new HomeDeviceAtaFacade(
-        createApi({ timezone: 'Europe/Paris' }),
-        homeDevice({
-          frostProtection,
-          holidayMode,
-          id: 'device-1',
-          overheatProtection,
-        }),
-      )
-
-      expect(okValue(await facade.getFrostProtection())).toStrictEqual({
-        isEnabled: true,
-        max: 12,
-        min: 6,
-      })
-      expect(okValue(await facade.getHolidayMode())).toStrictEqual({
-        endDate: '2026-08-05T00:00:00',
-        isEnabled: true,
-        startDate: '2026-08-01T00:00:00',
-      })
-      expect(okValue(await facade.getOverheatProtection())).toStrictEqual({
-        isEnabled: true,
-        max: 37,
-        min: 35,
-      })
-    })
-
     it('keeps a freshly disconnected unit available within the persistence window', () => {
       const facade = new HomeDeviceAtaFacade(
-        createApi(),
+        createMockHomeApi(),
         homeDevice({ id: 'device-1', isConnected: false }),
       )
 
@@ -101,7 +43,7 @@ describe('home device ata facade', () => {
 
     it('reports the unit unavailable after a day of continuous disconnection, then clears on reconnect', () => {
       const device = homeDevice({ id: 'device-1', isConnected: false })
-      const facade = new HomeDeviceAtaFacade(createApi(), device)
+      const facade = new HomeDeviceAtaFacade(createMockHomeApi(), device)
       const later = Temporal.Now.plainDateTimeISO('UTC').add({ hours: 25 })
       const spy = vi
         .spyOn(Temporal.Now, 'plainDateTimeISO')
@@ -118,7 +60,7 @@ describe('home device ata facade', () => {
 
     it('resolves the registry model by id, never a pinned snapshot', () => {
       const facade = new HomeDeviceAtaFacade(
-        createApi(),
+        createMockHomeApi(),
         homeDevice({ id: 'device-1', isConnected: false }),
       )
       homeDevice({ id: 'device-1', isConnected: true })
@@ -128,7 +70,7 @@ describe('home device ata facade', () => {
 
     it('reports existence and throws once the registry drops the id', () => {
       const facade = new HomeDeviceAtaFacade(
-        createApi(),
+        createMockHomeApi(),
         homeDevice({ id: 'device-gone' }),
       )
 
@@ -143,7 +85,7 @@ describe('home device ata facade', () => {
 
     it('returns null when protection is not configured', async () => {
       const facade = new HomeDeviceAtaFacade(
-        createApi(),
+        createMockHomeApi(),
         homeDevice({ id: 'device-1' }),
       )
 
@@ -156,7 +98,7 @@ describe('home device ata facade', () => {
   describe('settings accessors', () => {
     it('should read operation mode from settings', () => {
       const facade = new HomeDeviceAtaFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel({ OperationMode: 'Heat' }),
       )
 
@@ -165,7 +107,7 @@ describe('home device ata facade', () => {
 
     it('should read power as boolean', () => {
       const facade = new HomeDeviceAtaFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel({ Power: 'True' }),
       )
 
@@ -174,7 +116,7 @@ describe('home device ata facade', () => {
 
     it('should read standby as boolean', () => {
       const facade = new HomeDeviceAtaFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel({ InStandbyMode: 'True', Power: 'True' }),
       )
 
@@ -183,7 +125,7 @@ describe('home device ata facade', () => {
 
     it('should read temperatures as numbers', () => {
       const facade = new HomeDeviceAtaFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel({ RoomTemperature: '21.5', SetTemperature: '20' }),
       )
 
@@ -193,7 +135,7 @@ describe('home device ata facade', () => {
 
     it('should read fan speed and vane directions from settings', () => {
       const facade = new HomeDeviceAtaFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel({
           SetFanSpeed: 'Auto',
           VaneHorizontalDirection: 'Centre',
@@ -208,7 +150,7 @@ describe('home device ata facade', () => {
 
     it('should normalize numeric fan speed string from Home API', () => {
       const facade = new HomeDeviceAtaFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel({ SetFanSpeed: '0' }),
       )
 
@@ -217,7 +159,7 @@ describe('home device ata facade', () => {
 
     it('should read rssi from device data', () => {
       const facade = new HomeDeviceAtaFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel({}, {}, -42),
       )
 
@@ -225,7 +167,7 @@ describe('home device ata facade', () => {
     })
 
     it('should return defaults for missing settings', () => {
-      const facade = new HomeDeviceAtaFacade(createApi(), createModel())
+      const facade = new HomeDeviceAtaFacade(createMockHomeApi(), createModel())
 
       expect(facade.operationMode).toBe('')
       expect(facade.power).toBe(false)
@@ -236,14 +178,14 @@ describe('home device ata facade', () => {
     })
 
     it('should read device name', () => {
-      const facade = new HomeDeviceAtaFacade(createApi(), createModel())
+      const facade = new HomeDeviceAtaFacade(createMockHomeApi(), createModel())
 
       expect(facade.name).toBe('Test ClassicDevice')
     })
 
     it('should expose device capabilities', () => {
       const facade = new HomeDeviceAtaFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel({}, { minTempHeat: 8 }),
       )
 
@@ -253,7 +195,7 @@ describe('home device ata facade', () => {
 
   describe('updateValues validation', () => {
     it('should throw on empty values', async () => {
-      const facade = new HomeDeviceAtaFacade(createApi(), createModel())
+      const facade = new HomeDeviceAtaFacade(createMockHomeApi(), createModel())
 
       await expect(facade.updateValues({})).rejects.toThrow(
         new NoChangesError('device-1'),
@@ -261,7 +203,7 @@ describe('home device ata facade', () => {
     })
 
     it('should treat explicitly-undefined values as absent', async () => {
-      const facade = new HomeDeviceAtaFacade(createApi(), createModel())
+      const facade = new HomeDeviceAtaFacade(createMockHomeApi(), createModel())
 
       await expect(
         facade.updateValues(cast({ setTemperature: undefined })),
@@ -269,7 +211,7 @@ describe('home device ata facade', () => {
     })
 
     it('should drop undefined-valued keys before forwarding', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const facade = new HomeDeviceAtaFacade(api, createModel())
 
       await facade.updateValues(
@@ -284,7 +226,7 @@ describe('home device ata facade', () => {
 
   describe('updatePower', () => {
     it('forwards a power-only payload, defaulting to on', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const facade = new HomeDeviceAtaFacade(api, createModel())
 
       await facade.updatePower()
@@ -293,7 +235,7 @@ describe('home device ata facade', () => {
     })
 
     it('powers off when passed false', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const facade = new HomeDeviceAtaFacade(api, createModel())
 
       await facade.updatePower(false)
@@ -307,7 +249,7 @@ describe('home device ata facade', () => {
   describe('temperature range and step', () => {
     it('should read the per-mode range from the device capabilities', () => {
       const facade = new HomeDeviceAtaFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel(
           { OperationMode: 'Heat' },
           { maxTempHeat: 31, minTempHeat: 10 },
@@ -336,7 +278,7 @@ describe('home device ata facade', () => {
     // changed at the source changes what consumers render.
     it('should follow the advertised bounds', () => {
       const facade = new HomeDeviceAtaFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel(
           { OperationMode: 'Heat' },
           { maxTempHeat: 28, minTempHeat: 12 },
@@ -348,7 +290,7 @@ describe('home device ata facade', () => {
 
     it('should step by a half degree when the unit advertises it', () => {
       const facade = new HomeDeviceAtaFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel({}, { hasHalfDegreeIncrements: true }),
       )
 
@@ -357,7 +299,7 @@ describe('home device ata facade', () => {
 
     it('should step by a whole degree otherwise', () => {
       const facade = new HomeDeviceAtaFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel({}, { hasHalfDegreeIncrements: false }),
       )
 
@@ -367,7 +309,7 @@ describe('home device ata facade', () => {
 
   describe('temperature clamping', () => {
     it('should clamp temperature to heat range', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const facade = new HomeDeviceAtaFacade(
         api,
         createModel(
@@ -383,7 +325,7 @@ describe('home device ata facade', () => {
     })
 
     it('should clamp temperature to cool range', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const facade = new HomeDeviceAtaFacade(
         api,
         createModel(
@@ -399,7 +341,7 @@ describe('home device ata facade', () => {
     })
 
     it('should clamp temperature to automatic range', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const facade = new HomeDeviceAtaFacade(
         api,
         createModel(
@@ -415,7 +357,7 @@ describe('home device ata facade', () => {
     })
 
     it('should clamp temperature to dry range', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const facade = new HomeDeviceAtaFacade(
         api,
         createModel(
@@ -431,7 +373,7 @@ describe('home device ata facade', () => {
     })
 
     it('should use requested operation mode for clamping when changing both', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const facade = new HomeDeviceAtaFacade(
         api,
         createModel(
@@ -448,7 +390,7 @@ describe('home device ata facade', () => {
     })
 
     it('should pass through temperature when no clamping needed', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const facade = new HomeDeviceAtaFacade(
         api,
         createModel({ OperationMode: 'Heat' }),
@@ -461,7 +403,7 @@ describe('home device ata facade', () => {
     })
 
     it('should not modify values without temperature', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const facade = new HomeDeviceAtaFacade(
         api,
         createModel({ OperationMode: 'Heat' }),
@@ -472,7 +414,7 @@ describe('home device ata facade', () => {
     })
 
     it('should pass through temperature for unknown operation mode', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const facade = new HomeDeviceAtaFacade(
         api,
         createModel({ OperationMode: '' }),
@@ -487,7 +429,7 @@ describe('home device ata facade', () => {
 
   describe('api delegation', () => {
     it('should delegate getEnergy with device id', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const facade = new HomeDeviceAtaFacade(api, createModel())
       const params = { from: '2026-03-01', interval: 'Day', to: '2026-03-02' }
       await facade.getEnergy(params)
@@ -496,7 +438,7 @@ describe('home device ata facade', () => {
     })
 
     it('delegates the protection writes with its own ATA unit bucket', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const facade = new HomeDeviceAtaFacade(api, createModel())
 
       await facade.updateFrostProtection({ isEnabled: true, max: 20, min: 2 })
@@ -533,7 +475,7 @@ describe('home device ata facade', () => {
     })
 
     it('should delegate getErrorLog and project the neutral entries', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       vi.mocked(api.getErrorLog).mockResolvedValue(
         ok([
           {
@@ -559,7 +501,7 @@ describe('home device ata facade', () => {
     })
 
     it('should delegate getSignal with device id', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const facade = new HomeDeviceAtaFacade(api, createModel())
       const params = { from: '2026-03-01', to: '2026-03-02' }
       await facade.getSignal(params)
@@ -568,7 +510,7 @@ describe('home device ata facade', () => {
     })
 
     it('builds the temperature chart from the trend-summary report', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       vi.mocked(api.getTemperatures).mockResolvedValue(
         ok([
           {
@@ -603,7 +545,7 @@ describe('home device ata facade', () => {
     })
 
     it('propagates a trend-summary failure untouched', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const failure = { ok: false as const, status: 500 }
       vi.mocked(api.getTemperatures).mockResolvedValue(cast(failure))
       const facade = new HomeDeviceAtaFacade(api, createModel())
@@ -612,18 +554,13 @@ describe('home device ata facade', () => {
     })
 
     it('charts a multi-day energy report in local-day kWh buckets', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       vi.mocked(api.getEnergy).mockResolvedValue(
-        ok({
-          measureData: [
-            {
-              type: 'cumulative_energy_consumed_since_last_upload',
-              values: [
-                { time: '2026-03-01 00:00:00.000000000', value: '571.0' },
-              ],
-            },
-          ],
-        }),
+        ok(
+          homeEnergyEnvelope('cumulative_energy_consumed_since_last_upload', [
+            { time: '2026-03-01 00:00:00.000000000', value: '571.0' },
+          ]),
+        ),
       )
       const facade = new HomeDeviceAtaFacade(api, createModel())
 
@@ -648,19 +585,17 @@ describe('home device ata facade', () => {
 
     it('lands evening UTC buckets on the next local calendar day', async () => {
       // Pin the label locale: the runner's default is not ours.
-      const api = createApi({ locale: 'fr-FR', timezone: 'Europe/Paris' })
+      const api = createMockHomeApi({
+        locale: 'fr-FR',
+        timezone: 'Europe/Paris',
+      })
       vi.mocked(api.getEnergy).mockResolvedValue(
-        ok({
-          measureData: [
-            {
-              type: 'cumulative_energy_consumed_since_last_upload',
-              values: [
-                // 23:30 UTC = 00:30 the next day in winter Paris time.
-                { time: '2026-03-01 23:30:00.000000000', value: '100.0' },
-              ],
-            },
-          ],
-        }),
+        ok(
+          homeEnergyEnvelope('cumulative_energy_consumed_since_last_upload', [
+            // 23:30 UTC = 00:30 the next day in winter Paris time.
+            { time: '2026-03-01 23:30:00.000000000', value: '100.0' },
+          ]),
+        ),
       )
       const facade = new HomeDeviceAtaFacade(api, createModel())
 
@@ -676,7 +611,7 @@ describe('home device ata facade', () => {
     })
 
     it('keeps raw UTC day buckets beyond a month', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       vi.mocked(api.getEnergy).mockResolvedValue(ok({ measureData: [] }))
       const facade = new HomeDeviceAtaFacade(api, createModel())
 
@@ -691,18 +626,13 @@ describe('home device ata facade', () => {
     })
 
     it('switches a one-day energy report to hourly buckets', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       vi.mocked(api.getEnergy).mockResolvedValue(
-        ok({
-          measureData: [
-            {
-              type: 'cumulative_energy_consumed_since_last_upload',
-              values: [
-                { time: '2026-03-01 09:00:00.000000000', value: '200.0' },
-              ],
-            },
-          ],
-        }),
+        ok(
+          homeEnergyEnvelope('cumulative_energy_consumed_since_last_upload', [
+            { time: '2026-03-01 09:00:00.000000000', value: '200.0' },
+          ]),
+        ),
       )
       const facade = new HomeDeviceAtaFacade(api, createModel())
 
@@ -724,7 +654,7 @@ describe('home device ata facade', () => {
     })
 
     it('keeps hourly buckets when the one-day window drifts by ms', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       vi.mocked(api.getEnergy).mockResolvedValue(ok({ measureData: [] }))
       const facade = new HomeDeviceAtaFacade(api, createModel())
 
@@ -755,16 +685,13 @@ describe('home device ata facade', () => {
     })
 
     it('builds the signal chart over the requested hour', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       vi.mocked(api.getSignal).mockResolvedValue(
-        ok({
-          measureData: [
-            {
-              type: 'rssi',
-              values: [{ time: '2026-03-01 09:05:00.000000000', value: '-66' }],
-            },
-          ],
-        }),
+        ok(
+          homeEnergyEnvelope('rssi', [
+            { time: '2026-03-01 09:05:00.000000000', value: '-66' },
+          ]),
+        ),
       )
       const facade = new HomeDeviceAtaFacade(api, createModel())
 
@@ -781,16 +708,13 @@ describe('home device ata facade', () => {
     })
 
     it('covers today on a five-minute grid when no hour is given', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       vi.mocked(api.getSignal).mockResolvedValue(
-        ok({
-          measureData: [
-            {
-              type: 'rssi',
-              values: [{ time: '2026-03-01 00:02:00.000000000', value: '-70' }],
-            },
-          ],
-        }),
+        ok(
+          homeEnergyEnvelope('rssi', [
+            { time: '2026-03-01 00:02:00.000000000', value: '-70' },
+          ]),
+        ),
       )
       const facade = new HomeDeviceAtaFacade(api, createModel())
 

--- a/tests/unit/home-device-atw-facade.test.ts
+++ b/tests/unit/home-device-atw-facade.test.ts
@@ -1,15 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
-import { NoChangesError } from '../../src/errors/index.ts'
 import { HomeDeviceAtwFacade } from '../../src/facades/home-device-atw.ts'
 import { Temporal } from '../../src/temporal.ts'
-import { type HomeAtwDeviceCapabilities, ok } from '../../src/types/index.ts'
-import { cast, mock, mockTemporalNowZoned, okValue } from '../helpers.ts'
 import {
+  type HomeAtwDeviceCapabilities,
+  type HomeEnergyData,
+  type Result,
+  ok,
+} from '../../src/types/index.ts'
+import { cast, mockTemporalNowZoned, okValue } from '../helpers.ts'
+import {
+  createMockHomeApi,
   homeAtwDevice,
+  homeEnergyEnvelope,
   homeReportPoint,
-  homeTestRegistry,
   resetHomeDevices,
 } from '../home-fixtures.ts'
 
@@ -20,32 +24,14 @@ const createModel = (
 ): ReturnType<typeof homeAtwDevice> =>
   homeAtwDevice({ capabilities, id: 'atw-1', name: 'Test ATW', rssi, settings })
 
-const energyBucket = (value: string): ReturnType<typeof ok<object>> =>
-  ok({
-    measureData: [
-      {
-        type: 'interval_energy',
-        values: [{ time: '2026-05-09 00:00:00.000000000', value }],
-      },
-    ],
-  })
-
-const createApi = (overrides: Partial<HomeAPIAdapter> = {}): HomeAPIAdapter =>
-  mock<HomeAPIAdapter>({
-    ...overrides,
-    getAtwInternalTemperatures:
-      vi.fn<HomeAPIAdapter['getAtwInternalTemperatures']>(),
-    getEnergy: vi.fn<HomeAPIAdapter['getEnergy']>(),
-    getErrorLog: vi.fn<HomeAPIAdapter['getErrorLog']>(),
-    getSignal: vi.fn<HomeAPIAdapter['getSignal']>(),
-    getTemperatures: vi.fn<HomeAPIAdapter['getTemperatures']>(),
-    registry: homeTestRegistry,
-    updateFrostProtection: vi.fn<HomeAPIAdapter['updateFrostProtection']>(),
-    updateHolidayMode: vi.fn<HomeAPIAdapter['updateHolidayMode']>(),
-    updateOverheatProtection:
-      vi.fn<HomeAPIAdapter['updateOverheatProtection']>(),
-    updateValues: vi.fn<HomeAPIAdapter['updateValues']>().mockResolvedValue(),
-  })
+// One pinned-time bucket per response: the consumed/produced split is
+// carried by the request's `measure` param, not the envelope.
+const energyBucket = (value: string): Result<HomeEnergyData> =>
+  ok(
+    homeEnergyEnvelope('interval_energy', [
+      { time: '2026-05-09 00:00:00.000000000', value },
+    ]),
+  )
 
 describe('home device atw facade', () => {
   beforeEach(resetHomeDevices)
@@ -62,7 +48,7 @@ describe('home device atw facade', () => {
       ['SomeNewFtcMode', 'room'],
     ])('normalizes zone mode %s to %s', (wire, expected) => {
       const facade = new HomeDeviceAtwFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel({ OperationModeZone1: wire }),
       )
 
@@ -71,7 +57,7 @@ describe('home device atw facade', () => {
 
     it('degrades an unknown zone-2 mode to room on a two-zone unit', () => {
       const facade = new HomeDeviceAtwFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel(
           { OperationModeZone2: 'SomeNewFtcMode' },
           { hasZone2: true },
@@ -91,7 +77,7 @@ describe('home device atw facade', () => {
       ['Stop', 'idle'],
     ])('derives the operational state %s as %s', (wire, expected) => {
       const facade = new HomeDeviceAtwFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel({ OperationMode: wire }),
       )
 
@@ -109,7 +95,7 @@ describe('home device atw facade', () => {
       ['Stop', 'idle'],
     ])('projects the zone-1 state of %s as %s', (wire, expected) => {
       const facade = new HomeDeviceAtwFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel({ OperationMode: wire }),
       )
 
@@ -118,7 +104,7 @@ describe('home device atw facade', () => {
 
     it('mirrors the zone-1 projection on zone 2 when present', () => {
       const facade = new HomeDeviceAtwFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel({ OperationMode: 'Heating' }, { hasZone2: true }),
       )
 
@@ -127,7 +113,7 @@ describe('home device atw facade', () => {
 
     it('reads a null zone-2 state on a single-zone unit', () => {
       const facade = new HomeDeviceAtwFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel({ OperationMode: 'Heating' }, { hasZone2: false }),
       )
 
@@ -136,7 +122,7 @@ describe('home device atw facade', () => {
 
     it('reads a null operational state for an unknown mode', () => {
       const facade = new HomeDeviceAtwFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel({ OperationMode: 'SomeNewFtcMode' }),
       )
 
@@ -147,7 +133,7 @@ describe('home device atw facade', () => {
   describe('settings accessors', () => {
     it('reads power, standby, and operation mode from settings', () => {
       const facade = new HomeDeviceAtwFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel({
           InStandbyMode: 'False',
           OperationMode: 'Stop',
@@ -162,7 +148,7 @@ describe('home device atw facade', () => {
 
     it('reads each zone snapshot off its own settings', () => {
       const facade = new HomeDeviceAtwFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel(
           {
             OperationModeZone1: 'HeatRoomTemperature',
@@ -187,7 +173,7 @@ describe('home device atw facade', () => {
 
     it('reads the setpoint step from the advertised increment', () => {
       const facade = new HomeDeviceAtwFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel({}, { temperatureIncrement: 0.5 }),
       )
 
@@ -196,7 +182,7 @@ describe('home device atw facade', () => {
 
     it('reads zone-1 temperatures and setpoint as numbers', () => {
       const facade = new HomeDeviceAtwFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel({
           OperationModeZone1: 'HeatRoomTemperature',
           RoomTemperatureZone1: '19.5',
@@ -211,7 +197,7 @@ describe('home device atw facade', () => {
 
     it('returns null for zone-2 accessors when capabilities.hasZone2 is false', () => {
       const facade = new HomeDeviceAtwFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel(
           { RoomTemperatureZone2: '20', SetTemperatureZone2: '21' },
           { hasZone2: false },
@@ -225,7 +211,7 @@ describe('home device atw facade', () => {
 
     it('exposes zone-2 accessors when capabilities.hasZone2 is true', () => {
       const facade = new HomeDeviceAtwFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel(
           {
             OperationModeZone2: 'CoolRoomTemperature',
@@ -243,7 +229,7 @@ describe('home device atw facade', () => {
 
     it('reads tank, outdoor, and hot-water flags', () => {
       const facade = new HomeDeviceAtwFacade(
-        createApi(),
+        createMockHomeApi(),
         createModel({
           ForcedHotWaterMode: 'True',
           HasCoolingMode: 'True',
@@ -293,7 +279,7 @@ describe('home device atw facade', () => {
       'derives the hot-water operational state ($label)',
       ({ expected, settings }) => {
         const facade = new HomeDeviceAtwFacade(
-          createApi(),
+          createMockHomeApi(),
           createModel(settings),
         )
 
@@ -303,24 +289,8 @@ describe('home device atw facade', () => {
   })
 
   describe('updateValues', () => {
-    it('throws NoChangesError when values is empty', async () => {
-      const facade = new HomeDeviceAtwFacade(createApi(), createModel())
-
-      await expect(facade.updateValues({})).rejects.toBeInstanceOf(
-        NoChangesError,
-      )
-    })
-
-    it('treats explicitly-undefined values as absent', async () => {
-      const facade = new HomeDeviceAtwFacade(createApi(), createModel())
-
-      await expect(
-        facade.updateValues(cast({ setTemperatureZone1: undefined })),
-      ).rejects.toBeInstanceOf(NoChangesError)
-    })
-
     it('drops undefined-valued keys before forwarding', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const facade = new HomeDeviceAtwFacade(api, createModel())
 
       await facade.updateValues(
@@ -333,7 +303,7 @@ describe('home device atw facade', () => {
     })
 
     it('clamps zone-1 setpoint to capability bounds before forwarding', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const facade = new HomeDeviceAtwFacade(
         api,
         createModel({}, { maxSetTemperature: 28, minSetTemperature: 12 }),
@@ -347,7 +317,7 @@ describe('home device atw facade', () => {
     })
 
     it('clamps zone-2 setpoint to capability bounds before forwarding', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const facade = new HomeDeviceAtwFacade(
         api,
         createModel({}, { maxSetTemperature: 28, minSetTemperature: 12 }),
@@ -361,7 +331,7 @@ describe('home device atw facade', () => {
     })
 
     it('clamps tank setpoint to tank-temperature bounds', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const facade = new HomeDeviceAtwFacade(
         api,
         createModel(
@@ -378,7 +348,7 @@ describe('home device atw facade', () => {
     })
 
     it('forwards non-temperature fields unchanged', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const facade = new HomeDeviceAtwFacade(api, createModel())
 
       await facade.updateValues({
@@ -397,7 +367,7 @@ describe('home device atw facade', () => {
 
   describe('updatePower', () => {
     it('forwards a power-only payload, defaulting to on', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const facade = new HomeDeviceAtwFacade(api, createModel())
 
       await facade.updatePower()
@@ -406,7 +376,7 @@ describe('home device atw facade', () => {
     })
 
     it('powers off when passed false', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const facade = new HomeDeviceAtwFacade(api, createModel())
 
       await facade.updatePower(false)
@@ -417,12 +387,12 @@ describe('home device atw facade', () => {
 
   describe('ownership', () => {
     it('exposes isOwner from the backing model', () => {
-      const owned = new HomeDeviceAtwFacade(createApi(), createModel())
+      const owned = new HomeDeviceAtwFacade(createMockHomeApi(), createModel())
 
       expect(owned.isOwner).toBe(true)
 
       const guest = new HomeDeviceAtwFacade(
-        createApi(),
+        createMockHomeApi(),
         homeAtwDevice({ id: 'atw-1' }, false),
       )
 
@@ -432,7 +402,7 @@ describe('home device atw facade', () => {
 
   describe('telemetry passthroughs', () => {
     it('delegates getEnergy to getEnergy with the chosen measure', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const facade = new HomeDeviceAtwFacade(api, createModel())
       const params = {
         from: '2026-05-01T00:00:00Z',
@@ -447,7 +417,7 @@ describe('home device atw facade', () => {
     })
 
     it('delegates the protection writes with its own ATW unit bucket', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const facade = new HomeDeviceAtwFacade(api, createModel())
 
       await facade.updateFrostProtection({ isEnabled: true, max: 12, min: 6 })
@@ -468,7 +438,7 @@ describe('home device atw facade', () => {
     })
 
     it('delegates getErrorLog and projects the neutral entries', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       vi.mocked(api.getErrorLog).mockResolvedValue(
         ok([
           {
@@ -494,7 +464,7 @@ describe('home device atw facade', () => {
     })
 
     it('builds the internal-temperatures chart from its report', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       vi.mocked(api.getAtwInternalTemperatures).mockResolvedValue(
         ok([
           {
@@ -572,7 +542,7 @@ describe('home device atw facade', () => {
     }
 
     it('merges comfort and internal series with mode bands', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       vi.mocked(api.getTemperatures).mockResolvedValue(ok([comfortReport]))
       vi.mocked(api.getAtwInternalTemperatures).mockResolvedValue(
         ok([internalReport]),
@@ -605,7 +575,7 @@ describe('home device atw facade', () => {
     })
 
     it('propagates a comfort-graph failure untouched', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const failure = { ok: false as const, status: 500 }
       vi.mocked(api.getTemperatures).mockResolvedValue(cast(failure))
       vi.mocked(api.getAtwInternalTemperatures).mockResolvedValue(ok([]))
@@ -615,7 +585,7 @@ describe('home device atw facade', () => {
     })
 
     it('propagates an internal-temperatures failure untouched', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const failure = { ok: false as const, status: 500 }
       vi.mocked(api.getTemperatures).mockResolvedValue(ok([]))
       vi.mocked(api.getAtwInternalTemperatures).mockResolvedValue(cast(failure))
@@ -625,7 +595,7 @@ describe('home device atw facade', () => {
     })
 
     it('builds one specific hour on a minute grid', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       vi.mocked(api.getTemperatures).mockResolvedValue(ok([comfortReport]))
       vi.mocked(api.getAtwInternalTemperatures).mockResolvedValue(ok([]))
       const facade = new HomeDeviceAtwFacade(api, createModel())
@@ -642,7 +612,7 @@ describe('home device atw facade', () => {
 
     it('covers today on a five-minute grid when no hour is given', async () => {
       // Pin the label locale: the runner's default is not ours.
-      const api = createApi({ locale: 'fr-FR' })
+      const api = createMockHomeApi({ locale: 'fr-FR' })
       vi.mocked(api.getTemperatures).mockResolvedValue(ok([comfortReport]))
       vi.mocked(api.getAtwInternalTemperatures).mockResolvedValue(ok([]))
       const facade = new HomeDeviceAtwFacade(api, createModel())
@@ -664,7 +634,7 @@ describe('home device atw facade', () => {
     })
 
     it('chunks a wide window and merges the reports', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       vi.mocked(api.getTemperatures).mockResolvedValue(ok([comfortReport]))
       vi.mocked(api.getAtwInternalTemperatures).mockResolvedValue(ok([]))
       const facade = new HomeDeviceAtwFacade(api, createModel())
@@ -696,7 +666,7 @@ describe('home device atw facade', () => {
     })
 
     it('drops the bands just beyond the hourly grid', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       vi.mocked(api.getTemperatures).mockResolvedValue(ok([comfortReport]))
       vi.mocked(api.getAtwInternalTemperatures).mockResolvedValue(ok([]))
       const facade = new HomeDeviceAtwFacade(api, createModel())
@@ -720,7 +690,7 @@ describe('home device atw facade', () => {
     })
 
     it('propagates a chunk failure untouched', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const failure = { ok: false as const, status: 503 }
       vi.mocked(api.getTemperatures)
         .mockResolvedValueOnce(ok([comfortReport]))
@@ -738,7 +708,7 @@ describe('home device atw facade', () => {
     })
 
     it('aggregates operation modes into Classic-shaped pie data', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       vi.mocked(api.getTemperatures).mockResolvedValue(ok([comfortReport]))
       const facade = new HomeDeviceAtwFacade(api, createModel())
 
@@ -759,10 +729,10 @@ describe('home device atw facade', () => {
 
   describe('energy report', () => {
     it('charts consumed and produced daily series in kWh', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       vi.mocked(api.getEnergy)
-        .mockResolvedValueOnce(cast(energyBucket('2.5')))
-        .mockResolvedValueOnce(cast(energyBucket('13.5')))
+        .mockResolvedValueOnce(energyBucket('2.5'))
+        .mockResolvedValueOnce(energyBucket('13.5'))
       const facade = new HomeDeviceAtwFacade(api, createModel())
 
       const value = okValue(
@@ -796,21 +766,21 @@ describe('home device atw facade', () => {
     })
 
     it('propagates the first energy failure untouched', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const failure = { ok: false as const, status: 429 }
       vi.mocked(api.getEnergy)
         .mockResolvedValueOnce(cast(failure))
-        .mockResolvedValueOnce(cast(energyBucket('1.0')))
+        .mockResolvedValueOnce(energyBucket('1.0'))
       const facade = new HomeDeviceAtwFacade(api, createModel())
 
       await expect(facade.getEnergyReport()).resolves.toBe(failure)
     })
 
     it('propagates a produced-side failure untouched', async () => {
-      const api = createApi()
+      const api = createMockHomeApi()
       const failure = { ok: false as const, status: 502 }
       vi.mocked(api.getEnergy)
-        .mockResolvedValueOnce(cast(energyBucket('1.0')))
+        .mockResolvedValueOnce(energyBucket('1.0'))
         .mockResolvedValueOnce(cast(failure))
       const facade = new HomeDeviceAtwFacade(api, createModel())
 

--- a/tests/unit/home-facade-manager.test.ts
+++ b/tests/unit/home-facade-manager.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { HomeAPIAdapter } from '../../src/api/home-types.ts'
 import type { HomeDevice } from '../../src/entities/home-device.ts'
 import type { HomeRegistry } from '../../src/entities/home-registry.ts'
 import { HomeDeviceType } from '../../src/constants.ts'
@@ -14,57 +13,47 @@ import {
 } from '../../src/facades/home-types.ts'
 import { cast, defined, mock } from '../helpers.ts'
 import {
+  createMockHomeApi,
   homeAtwDevice,
   homeDevice,
-  homeTestRegistry,
   resetHomeDevices,
 } from '../home-fixtures.ts'
 
 const createModel = (): ReturnType<typeof homeDevice> =>
   homeDevice({ id: 'device-1', name: 'Test ClassicDevice' })
 
-const createApi = (): HomeAPIAdapter =>
-  mock<HomeAPIAdapter>({
-    getEnergy: vi.fn<HomeAPIAdapter['getEnergy']>(),
-    getErrorLog: vi.fn<HomeAPIAdapter['getErrorLog']>(),
-    getSignal: vi.fn<HomeAPIAdapter['getSignal']>(),
-    getTemperatures: vi.fn<HomeAPIAdapter['getTemperatures']>(),
-    registry: homeTestRegistry,
-    updateValues: vi.fn<HomeAPIAdapter['updateValues']>(),
-  })
-
 describe('home facade manager', () => {
   beforeEach(resetHomeDevices)
 
   it('returns null when no instance is provided', () => {
-    const manager = new HomeFacadeManager(createApi())
+    const manager = new HomeFacadeManager(createMockHomeApi())
 
     expect(manager.get()).toBeNull()
   })
 
   it('returns an ATA facade for an ATA device model', () => {
-    const manager = new HomeFacadeManager(createApi())
+    const manager = new HomeFacadeManager(createMockHomeApi())
     const facade = manager.get(createModel())
 
     expect(facade).toBeInstanceOf(HomeDeviceAtaFacade)
   })
 
   it('returns an ATW facade for an ATW device model', () => {
-    const manager = new HomeFacadeManager(createApi())
+    const manager = new HomeFacadeManager(createMockHomeApi())
     const facade = manager.get(homeAtwDevice({ id: 'atw-1' }))
 
     expect(facade).toBeInstanceOf(HomeDeviceAtwFacade)
   })
 
   it('caches facades for the same instance', () => {
-    const manager = new HomeFacadeManager(createApi())
+    const manager = new HomeFacadeManager(createMockHomeApi())
     const model = createModel()
 
     expect(manager.get(model)).toBe(manager.get(model))
   })
 
   it('returns different facades for different instances', () => {
-    const manager = new HomeFacadeManager(createApi())
+    const manager = new HomeFacadeManager(createMockHomeApi())
     const model1 = createModel()
     const model2 = homeDevice({
       id: 'device-2',
@@ -76,7 +65,7 @@ describe('home facade manager', () => {
   })
 
   it('resolves a device facade by id and null for an unknown id', () => {
-    const manager = new HomeFacadeManager(createApi())
+    const manager = new HomeFacadeManager(createMockHomeApi())
     const ata = homeDevice({ id: 'by-id-ata' })
     const atw = homeAtwDevice({ id: 'by-id-atw' })
 
@@ -86,7 +75,7 @@ describe('home facade manager', () => {
   })
 
   it('exposes the connection type and narrows via the facade guards', () => {
-    const manager = new HomeFacadeManager(createApi())
+    const manager = new HomeFacadeManager(createMockHomeApi())
     const facades: HomeDeviceFacadeAny[] = [
       manager.get(homeDevice({ id: 'guard-ata' })),
       manager.get(homeAtwDevice({ id: 'guard-atw' })),
@@ -101,7 +90,7 @@ describe('home facade manager', () => {
   })
 
   it('returns null for a model of an unknown connection type', () => {
-    const manager = new HomeFacadeManager(createApi())
+    const manager = new HomeFacadeManager(createMockHomeApi())
     const rogue = homeDevice({ id: 'rogue' })
     Object.defineProperty(rogue, 'type', { value: 'unknown' })
 
@@ -114,7 +103,7 @@ describe('home facade manager', () => {
       getZones: vi.fn<HomeRegistry['getZones']>().mockReturnValue([]),
     }
     const manager = new HomeFacadeManager(
-      mock<HomeAPIAdapter>({ registry: cast(registry) }),
+      createMockHomeApi({ registry: cast(registry) }),
     )
 
     expect(manager.getBuildings({ type: HomeDeviceType.Ata })).toStrictEqual([])
@@ -130,11 +119,10 @@ describe('home facade manager', () => {
       ['atw-1', homeAtwDevice({ id: 'atw-1' })],
       ['device-1', createModel()],
     ])
-    const api = mock<HomeAPIAdapter>({
+    const api = createMockHomeApi({
       registry: mock<HomeRegistry>({
         getById: vi.fn<HomeRegistry['getById']>((id) => devicesById.get(id)),
       }),
-      updateFrostProtection: vi.fn<HomeAPIAdapter['updateFrostProtection']>(),
     })
     const manager = new HomeFacadeManager(api)
 
@@ -159,12 +147,10 @@ describe('home facade manager', () => {
       ['atw-1', homeAtwDevice({ id: 'atw-1' })],
       ['device-1', createModel()],
     ])
-    const api = mock<HomeAPIAdapter>({
+    const api = createMockHomeApi({
       registry: mock<HomeRegistry>({
         getById: vi.fn<HomeRegistry['getById']>((id) => devicesById.get(id)),
       }),
-      updateOverheatProtection:
-        vi.fn<HomeAPIAdapter['updateOverheatProtection']>(),
     })
     const manager = new HomeFacadeManager(api)
 
@@ -185,14 +171,12 @@ describe('home facade manager', () => {
   })
 
   it('skips the overheat write when no ATA id remains', async () => {
-    const api = mock<HomeAPIAdapter>({
+    const api = createMockHomeApi({
       registry: mock<HomeRegistry>({
         getById: vi.fn<HomeRegistry['getById']>(() =>
           homeAtwDevice({ id: 'atw-1' }),
         ),
       }),
-      updateOverheatProtection:
-        vi.fn<HomeAPIAdapter['updateOverheatProtection']>(),
     })
     const manager = new HomeFacadeManager(api)
 
@@ -206,11 +190,10 @@ describe('home facade manager', () => {
   })
 
   it('batches holiday mode by device type', async () => {
-    const api = mock<HomeAPIAdapter>({
+    const api = createMockHomeApi({
       registry: mock<HomeRegistry>({
         getById: vi.fn<HomeRegistry['getById']>(() => createModel()),
       }),
-      updateHolidayMode: vi.fn<HomeAPIAdapter['updateHolidayMode']>(),
     })
     const manager = new HomeFacadeManager(api)
 
@@ -233,11 +216,7 @@ describe('home facade manager', () => {
 
 describe('holiday-mode write projection', () => {
   it("projects an enabled window from the caller's clock onto UTC", async () => {
-    const api = mock<HomeAPIAdapter>({
-      registry: homeTestRegistry,
-      timezone: 'Europe/Paris',
-      updateHolidayMode: vi.fn<HomeAPIAdapter['updateHolidayMode']>(),
-    })
+    const api = createMockHomeApi({ timezone: 'Europe/Paris' })
     const manager = new HomeFacadeManager(api)
 
     // Paris summer wall clock (UTC+2): midnight locally is 22:00 UTC

--- a/tests/unit/home-report.test.ts
+++ b/tests/unit/home-report.test.ts
@@ -16,7 +16,7 @@ import {
 } from '../../src/facades/home-report.ts'
 import { Temporal } from '../../src/temporal.ts'
 import { mockTemporalNowZoned } from '../helpers.ts'
-import { homeReportPoint } from '../home-fixtures.ts'
+import { homeEnergyEnvelope, homeReportPoint } from '../home-fixtures.ts'
 
 const PARIS = 'Europe/Paris'
 
@@ -638,17 +638,13 @@ describe.concurrent(toHomeEnergyOptions, () => {
     const options = toHomeEnergyOptions({
       sources: [
         {
-          data: {
-            measureData: [
-              {
-                type: 'cumulative_energy_consumed_since_last_upload',
-                values: [
-                  { time: '2026-07-15 00:00:00.000000000', value: '0.0' },
-                  { time: '2026-07-17 00:00:00.000000000', value: '571.0' },
-                ],
-              },
+          data: homeEnergyEnvelope(
+            'cumulative_energy_consumed_since_last_upload',
+            [
+              { time: '2026-07-15 00:00:00.000000000', value: '0.0' },
+              { time: '2026-07-17 00:00:00.000000000', value: '571.0' },
             ],
-          },
+          ),
           name: 'Consumed',
           scale: 0.001,
         },
@@ -677,12 +673,12 @@ describe.concurrent(toHomeEnergyOptions, () => {
     const options = toHomeEnergyOptions({
       sources: [
         {
-          data: { measureData: [{ type: 'consumed', values: [bucket] }] },
+          data: homeEnergyEnvelope('consumed', [bucket]),
           name: 'Consumed',
           scale: 1,
         },
         {
-          data: { measureData: [{ type: 'produced', values: [bucket] }] },
+          data: homeEnergyEnvelope('produced', [bucket]),
           name: 'Produced',
           scale: 1,
         },
@@ -704,17 +700,10 @@ describe.concurrent(toHomeSignalOptions, () => {
       'UTC',
     )
     const options = toHomeSignalOptions({
-      data: {
-        measureData: [
-          {
-            type: 'rssi',
-            values: [
-              { time: '2026-07-17 08:58:00.000000000', value: '-70' },
-              { time: '2026-07-17 09:30:30.000000000', value: '-66' },
-            ],
-          },
-        ],
-      },
+      data: homeEnergyEnvelope('rssi', [
+        { time: '2026-07-17 08:58:00.000000000', value: '-70' },
+        { time: '2026-07-17 09:30:30.000000000', value: '-66' },
+      ]),
       name: 'Garage',
       window: { from: window.from, to: window.to },
     })


### PR DESCRIPTION
## Summary

Post-wave (0–3) cleanup pass: the 25 confirmed findings of the adversarial sweep over the mutualization diff, plus one latent test defect found while gating. **No public-surface change** — nothing the sweep touched is reachable through the exports map, the root barrel, or a published interface. Version → **51.0.1**, CHANGELOG entry included.

### Factorings & simplifications (src)
- `getEnergyReport` builds the chart in one pass from the neutral extract (the A→B→A re-shaping is gone); `formatLabels` exported from `utils.ts` for it.
- New `resolveHomeFineWindow` in `home-report.ts`: the "today on a five-minute grid with a now-cutoff vs one hour on a minute grid" fork existed twice (signal + hourly temperatures); both reads now share it.
- The recurring `await Promise.resolve(…)` rule-pair escape (promise-function-async ⇄ require-await) is one named `resolved()` helper carrying the single documented disable; all 11 sites migrated, the six cross-referencing comment chains dropped.
- `#coupleOperationModes` loses guards its own construction proves; `#zoneMode` helper (Home ATW); `#memberUnits` rides `toHomeProtectionUnits`; `getZoneState` → true-private `#zoneState`; dead `MS_PER_SECOND` removed.

### Dead tests & fixtures
- 12 kernel-duplicated tests deleted — the contract kernels in `tests/contracts/` are the one home of cross-dialect clauses (availability trio, zone2-as-capability, building frost/holiday reads + disable, no-op update pairs, context protection reads).
- Shared fixtures adopted everywhere: `populatedClassicRegistry` in all 9 kernels (arrays now optional), new `createMockHomeApi` (22 hand-rolled `mock<HomeAPIAdapter>` sites), new `homeEnergyEnvelope` (12 envelope hand-rolls; divergent shapes deliberately left).

### Docs
- README: `ClassicFacadeManager(api)` (the second argument is gone), and the Home example reads type-narrowed devices via `getDevicesByType(HomeDeviceType.Ata)` instead of the nonexistent `getAll()`.
- `@category` aligned: the neutral contract modules (`/atw-state`, `/error-log`) join `protection`/`holiday-mode` under **Facades**; the three Classic error-log shapes move Configuration → **Types**. Two history-narrating comments rewritten as intent.

### Found while gating: vacuous expiry tests under native Temporal
On Node 26 (native `Temporal`, which `temporal-polyfill` delegates to), the five fake-timer token-expiry tests never actually expired the session — `Temporal.Now` ignores vi's fake clock — so they passed vacuously and the refresh branches (`home.ts` abort-signal spread, refresh-token guard, `token-auth.ts` signal spread) went uncovered locally. They now pin `Temporal.Now.instant` through the existing `mockTemporalNowInstant()` helper (built for exactly this concern) and restore it with the timers. Coverage: **100 % on all four metrics** on Node 26 and the lts leg alike.

## Verification
- `format` / `lint` / `typecheck` / `docs`: clean.
- `test:coverage`: 51 files, 1113 tests, 100 % statements/branches/functions/lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn