### PR TITLE
build: official TypeScript 6/7 side-by-side layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,11 @@ is on: no runtime enums, no parameter properties, no runtime namespaces.
 - `npm run lint` / `npm run lint:fix` — ESLint (runs with an 8 GB heap).
 - `npm test` / `npm run test:coverage` — vitest; coverage must stay at 100%.
 - `npm run typecheck` — `tsc` from `@typescript/native` (TypeScript 7);
-  does not cover `*.config.ts` (the lint does). The tooling (typedoc,
-  typescript-eslint) still resolves the separate `typescript` 6.x install.
+  does not cover `*.config.ts` (the lint does). Official 6/7 side-by-side
+  layout: the `typescript` name aliases `@typescript/typescript6` (the
+  TS6 JS API) for the tools that import it (typedoc, typescript-eslint),
+  while `@typescript/native` is the native 7.x compiler running typecheck
+  and build — until TS 7.1 ships its programmatic API.
 - `npm run build` — purges `dist` before emitting, because `tsc` overwrites
   but never deletes: a module renamed or removed in `src` would otherwise
   survive in `dist`, and `files` ships that directory, so `prepare` would

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "typedoc": "^0.28.20",
         "typedoc-plugin-coverage": "^4.0.3",
         "typedoc-plugin-mdn-links": "^5.1.1",
-        "typescript": "~6.0.3",
+        "typescript": "npm:@typescript/typescript6@^6.0.2",
         "vitest": "^4.1.7"
       },
       "engines": {
@@ -1706,6 +1706,21 @@
         "@typescript/typescript-sunos-x64": "7.0.2",
         "@typescript/typescript-win32-arm64": "7.0.2",
         "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/@typescript/old": {
+      "name": "typescript",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
@@ -6379,17 +6394,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "name": "@typescript/typescript6",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript6/-/typescript6-6.0.2.tgz",
+      "integrity": "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==",
       "dev": true,
       "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+      "dependencies": {
+        "@typescript/old": "npm:typescript@^6"
       },
-      "engines": {
-        "node": ">=14.17"
+      "bin": {
+        "tsc6": "bin/tsc6"
       }
     },
     "node_modules/typescript-eslint": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "typedoc": "^0.28.20",
     "typedoc-plugin-coverage": "^4.0.3",
     "typedoc-plugin-mdn-links": "^5.1.1",
-    "typescript": "~6.0.3",
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vitest": "^4.1.7"
   },
   "engines": {


### PR DESCRIPTION
## Why

The TypeScript 7.0 announcement makes the npm `typescript` package at 7.x the native compiler, and officially continues the TS6 JS API as `@typescript/typescript6` — recommended aliased under the `typescript` name for tools with a `typescript` peer/import (typescript-eslint, typedoc).

We had the aliasing inverted: the real `typescript` package was pinned `~6.0.3` — a line that no longer receives maintenance — while `@typescript/native: npm:typescript@^7.0.2` already matched the announcement's recommended spelling for the native side. This PR adopts the official form verbatim:

- `"typescript": "~6.0.3"` → `"typescript": "npm:@typescript/typescript6@^6.0.2"`
- `@typescript/native` (npm `typescript@^7.0.2`, the native compiler) is unchanged and keeps running `typecheck`/`build` — until TS 7.1 ships its programmatic API.

Note the nominal 6.0.3 → 6.0.2 step on the compat package: `@typescript/typescript6` starts at 6.0.2, and future 6.x fixes land there.

## Verification

- `npm ls typescript` → `typescript@npm:@typescript/typescript6@6.0.2`, deduped into typescript-eslint and typedoc.
- `node ./node_modules/@typescript/native/bin/tsc --version` → `Version 7.0.2`.
- Full gates green: `typecheck`, `lint`, `test` (1113 passed), `build`, `format`, `docs`.

## Docs

- CLAUDE.md (Commands): the stale "tooling still resolves the separate `typescript` 6.x install" sentence now describes the official layout (typescript name → `@typescript/typescript6` alias for the JS-API tools; `@typescript/native` → the native 7.x compiler). README.md and CONTRIBUTING.md carry no sentence describing the old arrangement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn