### PR TITLE
docs: pin the explicit native-compiler path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,17 @@ is on: no runtime enums, no parameter properties, no runtime namespaces.
 
 - `npm run lint` / `npm run lint:fix` — ESLint (runs with an 8 GB heap).
 - `npm test` / `npm run test:coverage` — vitest; coverage must stay at 100%.
-- `npm run typecheck` — `tsc` from `@typescript/native` (TypeScript 7);
-  does not cover `*.config.ts` (the lint does). Official 6/7 side-by-side
+- `npm run typecheck` — the native TypeScript 7 compiler, reached by its
+  explicit path `node ./node_modules/@typescript/native/bin/tsc`; does
+  not cover `*.config.ts` (the lint does). Official 6/7 side-by-side
   layout: the `typescript` name aliases `@typescript/typescript6` (the
   TS6 JS API) for the tools that import it (typedoc, typescript-eslint),
   while `@typescript/native` is the native 7.x compiler running typecheck
-  and build — until TS 7.1 ships its programmatic API.
+  and build — until TS 7.1 ships its programmatic API. `@typescript/native`
+  installs no `.bin` shim at all, and both `.bin/tsc` and `.bin/tsc6`
+  resolve to the compat package's TypeScript 6, so a bare `tsc` in a
+  script would silently typecheck against TS 6. The explicit path is the
+  only route to the 7.x compiler; never shorten it.
 - `npm run build` — purges `dist` before emitting, because `tsc` overwrites
   but never deletes: a module renamed or removed in `src` would otherwise
   survive in `dist`, and `files` ships that directory, so `prepare` would

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ npm ci
 Run the same suite that CI runs on every pull request:
 
 ```sh title="checks"
-npm run typecheck       # native tsc --noEmit
+npm run typecheck       # @typescript/native/bin/tsc --noEmit (a bare tsc is TS 6)
 npm run lint            # ESLint with the all + strict-type-checked configs
 npm run format          # prettier --check (run npm run format:fix to write)
 npm test                # vitest run


### PR DESCRIPTION
Under the TypeScript 6/7 side-by-side layout (`@typescript/native: npm:typescript@^7.0.2` + `typescript: npm:@typescript/typescript6@^6.0.2`), the `tsc` binary slot does not belong to the compiler we typecheck and build with.

Measured in this repo:

- `readlink node_modules/.bin/tsc` → `../@typescript/old/bin/tsc`, and running it prints `Version 6.0.3` — the compat package `@typescript/typescript6` depends on `npm:typescript@^6` under the name `@typescript/old`, and that shim wins the `tsc` slot.
- `node ./node_modules/@typescript/native/bin/tsc --version` → `Version 7.0.2`. The native package installs no `.bin` shim; the explicit path is the only way to reach it.
- `.bin/tsc6` also runs 6.0.3. The TS6 line exists only for tools that import the JS API programmatically (typescript-eslint, typedoc), never as a binary.

Consequence: a bare `tsc` in `typecheck` or `build` would silently typecheck against TypeScript 6 while every gate stayed green. The scripts already use the explicit path — this note records why it must stay, so a future edit does not "simplify" it.

Docs only: one rewritten bullet in `CLAUDE.md` and one code-block comment in `CONTRIBUTING.md`. No code, scripts, `package.json` or tests touched. `npm run format` and `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn