### PR TITLE
fix: redact every credential from a thrown HttpError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [52.0.0] - 2026-08-21
+
+### Changed
+
+- **BREAKING — a thrown `HttpError` no longer carries a typed, verbatim payload.** `HttpError` loses its `T` type parameter and `response.data` is now `unknown`, because a failed response body is a DIAGNOSTIC payload rather than a contract: upstreams echo the credential they just rejected (a Classic 500 returns `LoginData.ContextKey`, a 401 can mirror the bearer, the OIDC token endpoint names the refresh token in its error text), and every one of those values is now redacted. Migration: an `HttpError<Foo>` annotation becomes `HttpError`, and code reading `error.response.data` narrows it itself — nothing in this SDK ever did.
+
+### Fixed
+
+- **Credentials no longer travel inside a thrown `HttpError`.** The error carried a verbatim snapshot of the exchange that failed, and that object reaches every host logger — including the diagnostic reports users paste into issues, where a live bearer token was found on 2026-08-21. It leaked far more than that token: the Classic sign-in posts the account's **password and email in the request body**, the context key rides `X-MitsContextKey`, a session cookie comes back in the response headers, and the response BODY echoes secrets of its own. Every field naming a secret now reads `******` — request headers, body and query parameters, response headers and body alike — redacted in the constructor, so no call site can reintroduce the leak by forgetting to sanitize. What the retry policies read (`retry-after` and friends) passes through untouched. Verified by probe against `util.inspect`, `console.error`, `JSON.stringify(error)` and the `{ ...error }` spread.
+- **The account's email address no longer appears in a routine sync log.** `OwnerEmail` — which the Classic list payload carries on every device of every successful poll — was outside the redaction vocabulary, so a 200 response wrote it to the host log. It is now blanked like every other credential, along with the OAuth vocabulary (`access_token`, `refresh_token`, `id_token`, `token`, `code`, `code_verifier`, `client_secret`).
+- **A `404` on Home's `/context` is an account with no home, not a stale session.** The BFF answers `404` when the signed-in account has no MELCloud Home home — the token was accepted, since a rejected one answers `401` — but the SDK read the missing context as a failed session reuse and escalated to a full sign-in, which then failed, armed the 15-minute login backoff and reported an authentication loss, indefinitely. Such an account now settles: `isAuthenticated()` reads `true`, `fetch()` answers `[]` with an empty registry, and no sign-in is attempted. The situation is stated once per episode, not once per poll, and the expected `404` is no longer filed as an API failure — a `404` from any other endpoint is classified exactly as before. Polling continues, so a home created later is picked up on its own.
+
+### Added
+
+- **`HttpStatus.NotFound`** — the 404 the Home context branch now names.
+
+### Adoption note
+
+`isAuthenticated()` no longer implies an identity: for an account with no home it reads `true` while `user` and `context` stay `null`. Consumers deriving a display name or an email from `getUser()` after checking `isAuthenticated()` should handle the `null`; consumers that only ask "can this session serve requests" need no change.
+
 ## [51.0.1] - 2026-08-18
 
 ### Changed
@@ -583,6 +603,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[52.0.0]: https://github.com/OlivierZal/melcloud-api/compare/v51.0.1...v52.0.0
 [51.0.1]: https://github.com/OlivierZal/melcloud-api/compare/v51.0.0...v51.0.1
 [51.0.0]: https://github.com/OlivierZal/melcloud-api/compare/v50.0.0...v51.0.0
 [50.0.0]: https://github.com/OlivierZal/melcloud-api/compare/v49.2.0...v50.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,37 @@ is on: no runtime enums, no parameter properties, no runtime namespaces.
   (Sunday = 0) unlike the 1-based ISO labels of `Report/*`. ATA Home
   daily energy buckets are watt-hours and idle days are omitted
   entirely; ATW buckets are kWh.
+- A `404` from Home's `/context` is not a failure: it is how the BFF
+  answers an account that has no MELCloud Home home. The token was
+  accepted (a rejected one answers `401`), so the session is valid and
+  simply has nothing to describe — `isAuthenticated()` reads `true`,
+  the registry stays empty, and no sign-in is attempted. Reading it as
+  a stale session is what looped a real user's app for hours: reuse
+  deemed failed → full sign-in → rejected at Cognito → 15-minute
+  backoff → repeat (observed 2026-08-21).
+- Secrets never travel inside a thrown error. `HttpError` redacts its
+  whole snapshot at construction — request headers, BODY and query
+  parameters, plus the response headers — because that object reaches
+  every host logger and lands verbatim in the diagnostic reports users
+  paste into issues; one leaked a live bearer token before the fix.
+  The body matters as much as the header: Classic's
+  `/Login/ClientLogin3` posts the account's password and email, so a
+  header-only redaction (the first attempt, caught in review) still
+  leaked the credential. Redaction sits in the constructor rather than
+  at the logging sites so no future call site can reintroduce the
+  leak; the sensitive-key vocabulary is shared with the call loggers
+  (`isSensitive`/`redactValue` in `src/observability/context.ts`),
+  never re-declared. The RESPONSE is redacted too, headers and body:
+  an upstream echoes the credential it just rejected (a Classic 500
+  returns `LoginData.ContextKey`, the OIDC token endpoint names the
+  refresh token in its error text), which is why `response.data` is
+  typed `unknown` — a failed body is a diagnostic payload, never a
+  contract. Two rounds of review were needed to reach that: the first
+  attempt redacted headers only, the second still left the response
+  body raw. When adding a wire field that names a credential, extend
+  the ONE vocabulary — `owneremail` is there because the Classic list
+  payload carries the account address on every device of every
+  successful sync, the single entry that blanks a routine 200.
 - Setpoint increments: both Home facades expose a derived
   `temperatureStep` (ATA from `hasHalfDegreeIncrements`, ATW from the
   FTC's own `temperatureIncrement` declaration — the direct field wins

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Both clients keep their session alive without caller involvement:
 - **Persistence** — pass a `settingManager` (a simple `get`/`set` string store) to persist tokens and credentials across restarts; without one, everything stays in memory and a new instance signs in from scratch.
 
 > [!IMPORTANT]
-> The `SettingManager` receives the access/refresh tokens **and the account password** as plain strings. You are responsible for backing it with secure storage (encrypted settings store, OS keychain, …) — do not write it to a world-readable file. The SDK redacts credentials, tokens and cookies from its own log output.
+> The `SettingManager` receives the access/refresh tokens **and the account password** as plain strings. You are responsible for backing it with secure storage (encrypted settings store, OS keychain, …) — do not write it to a world-readable file. The SDK redacts credentials from everything it emits: its own log output, and the request/response snapshot carried by a thrown `HttpError` — bearer token, `X-MitsContextKey`, session cookie, sign-in body and query alike — so an error object handed to a host logger, or pasted into a diagnostic report, carries no secret.
 
 ```ts title="setting-manager"
 const settings = new Map<string, string>()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "51.0.1",
+  "version": "52.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "51.0.1",
+      "version": "52.0.0",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "51.0.1",
+  "version": "52.0.0",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -49,6 +49,8 @@ import { performTokenAuth, refreshAccessToken } from './token-auth.ts'
 const API_BASE_URL = 'https://mobile.bff.melcloudhome.com'
 const ATA_UNIT_PATH = '/monitor/ataunit'
 const ATW_UNIT_PATH = '/monitor/atwunit'
+const CONTEXT_PATH = '/context'
+
 const FROST_PROTECTION_PATH = '/monitor/protection/frost'
 const HOLIDAY_MODE_PATH = '/monitor/holidaymode'
 const OVERHEAT_PROTECTION_PATH = '/monitor/protection/overheat'
@@ -218,8 +220,10 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
   }
 
   /**
-   * Currently authenticated user, or `null` when unauthenticated.
-   * Derived from the most recent `/context` response.
+   * Currently authenticated user, derived from the most recent
+   * `/context` response. `null` when unauthenticated — and also when
+   * the signed-in account has no home, which answers `404` and so
+   * carries no identity to derive.
    * @returns The user, or `null`.
    */
   public get user(): HomeUser | null {
@@ -227,6 +231,15 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
   }
 
   #context: HomeContext | null = null
+
+  // A `404` on `/context` is how the BFF answers an account that has no
+  // MELCloud Home home: the token was accepted (a rejected one answers
+  // `401`), so the session is valid and simply has nothing to describe.
+  // Kept distinct from "not signed in" because the two demand opposite
+  // handling — retrying a sign-in can never conjure a home, and looping
+  // on it burns the login backoff and reports a session lost that never
+  // was.
+  #hasNoHome = false
 
   readonly #locale: string | undefined
 
@@ -289,6 +302,10 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
   public async fetch(): Promise<HomeBuilding[]> {
     return this.runSyncCycle(async () => {
       const data = await this.#fetchContext()
+      if (data === null) {
+        this.#registry.syncDevices([])
+        return []
+      }
       this.#registry.syncDevices([
         // Guest entries first: the registry upsert is last-write-wins
         // per id, so a device duplicated across `buildings` and
@@ -490,16 +507,23 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
     } catch {
       // Deliberately swallowed: the request pipeline logged the
       // failure and a real 401 has cleared the user state already.
+      // `#markNoHome` is the other, non-401 clearer: an account with
+      // no home has no identity to report, and answers `null` here
+      // without the failure ever surfacing.
     }
     return this.#user
   }
 
   /**
-   * Whether the BFF `/context` call has resolved a user identity.
-   * @returns `true` once authenticated.
+   * Whether the session is usable: `true` once `/context` resolved a
+   * user identity, and also for an account the BFF accepted but that
+   * has no MELCloud Home home — there {@link user} and {@link context}
+   * stay `null`, so an authenticated client is NOT a promise of an
+   * identity.
+   * @returns `true` while the session can serve requests.
    */
   public isAuthenticated(): boolean {
-    return this.#user !== null
+    return this.#user !== null || this.#hasNoHome
   }
 
   /**
@@ -533,6 +557,7 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
 
   protected override clearPersistedSession(): void {
     this.#user = null
+    this.#hasNoHome = false
     // The context getter promises "cleared on session invalidation":
     // without this, a logged-out client keeps exposing the previous
     // account's buildings and devices.
@@ -599,6 +624,21 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
     )
   }
 
+  // The `/context` `404` is this account's normal answer (see
+  // `#requestContext`), so the request pipeline must not file it as an
+  // API failure on every poll. Any other failure, including a `404`
+  // from any other endpoint, logs as before.
+  protected override logError(error: unknown): void {
+    if (
+      isHttpError(error) &&
+      error.response.status === HttpStatus.NotFound &&
+      error.config?.url === CONTEXT_PATH
+    ) {
+      return
+    }
+    super.logError(error)
+  }
+
   /**
    * Home considers a session in need of refresh when the access
    * token is within {@link SESSION_REFRESH_AHEAD_MS} of its real
@@ -650,11 +690,13 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
    * requires a parsed context on top of the identity: a `true` reuse
    * promises a verified registry, so an identity-only round-trip
    * (the salvage parse failed) must fall through to the full-auth
-   * path instead of claiming the reuse completed.
+   * path instead of claiming the reuse completed. An account with no
+   * home reuses too: its session is valid, there is simply nothing to
+   * verify against.
    * @returns `true` when persisted tokens verified against the BFF.
    */
   protected override reuseSucceeded(): boolean {
-    return this.isAuthenticated() && this.context !== null
+    return this.#hasNoHome || (this.isAuthenticated() && this.context !== null)
   }
 
   protected override async syncRegistry(): Promise<void> {
@@ -721,8 +763,11 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
    * that still validates per unit.
    * @returns The fetched home context.
    */
-  async #fetchContext(): Promise<HomeContext> {
-    const raw = await this.requestData('get', '/context')
+  async #fetchContext(): Promise<HomeContext | null> {
+    const raw = await this.#requestContext()
+    if (raw === null) {
+      return null
+    }
     this.#user = parseUser(
       parseOrThrow(HomeUserContextSchema, raw, 'GET /context'),
     )
@@ -814,6 +859,27 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
     })
   }
 
+  // The state an account with no home settles into: no identity, no
+  // context, and the marker up — so the session reads valid and nothing
+  // ever tries to sign in again on its behalf.
+  #markNoHome(): void {
+    const wasKnown = this.#hasNoHome
+    this.#user = null
+    this.#context = null
+    this.#hasNoHome = true
+    // Emptied here rather than at one call site, so the state is the
+    // same whichever entry point observed the `404`.
+    this.#registry.syncDevices([])
+    // Once per episode, not once per sync cycle: the timer keeps
+    // polling so a home created later is picked up, and a settled
+    // state must not read as a minute-by-minute alarm.
+    if (!wasKnown) {
+      this.logger.log(
+        'This account has no MELCloud Home home: signed in, nothing to sync',
+      )
+    }
+  }
+
   // Per-unit endpoints differ by connection type; the registry is the
   // routing truth for an id the caller addresses blindly.
   #modelFor(id: string): HomeDevice {
@@ -863,6 +929,28 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
     }
     this.#storeTokens(tokens)
     return true
+  }
+
+  // Sole owner of the no-home marker, in both directions: a `404` raises
+  // it, any answer at all clears it. Answers `null` for that one failure
+  // which is not a failure — an account with no home. Every other status
+  // propagates, so a real transport or authorization problem still
+  // reaches the retry and sign-in paths untouched.
+  async #requestContext(): Promise<unknown> {
+    try {
+      const raw = await this.requestData('get', CONTEXT_PATH)
+      this.#hasNoHome = false
+      return raw
+    } catch (error) {
+      if (
+        !isHttpError(error) ||
+        error.response.status !== HttpStatus.NotFound
+      ) {
+        throw error
+      }
+      this.#markNoHome()
+      return null
+    }
   }
 
   #storeTokens({

--- a/src/api/home.ts
+++ b/src/api/home.ts
@@ -303,7 +303,8 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
     return this.runSyncCycle(async () => {
       const data = await this.#fetchContext()
       if (data === null) {
-        this.#registry.syncDevices([])
+        // `#markNoHome` already emptied the registry, on whichever
+        // entry point saw the 404.
         return []
       }
       this.#registry.syncDevices([
@@ -499,6 +500,9 @@ export class HomeAPI extends BaseAPI implements HomeAPIAdapter {
    * reactive-401 path (`reauthenticate()`) is the single owner of
    * clearing the authentication state, so a definitive rejection has
    * already nulled the user by the time the failure surfaces here.
+   * A `404` is the one answer that is neither: the account has no
+   * home, so this settles the no-home state — `null` user, empty
+   * registry — rather than returning the last known one.
    * @returns The user or `null`.
    */
   public async getUser(): Promise<HomeUser | null> {

--- a/src/http/errors.ts
+++ b/src/http/errors.ts
@@ -1,5 +1,36 @@
+import { isSensitive, REDACTED, redactValue } from '../observability/context.ts'
+
+// The snapshot travels inside a thrown error, so it reaches every
+// logger a host happens to run — including the diagnostic reports users
+// paste into issues. Redacting at construction removes the leak as a
+// class: no call site can retain a credential by forgetting to
+// sanitize. Every field carrying one is covered, not just the obvious
+// header: the Classic sign-in puts the account's password in the
+// request BODY, and a session cookie comes back in the response.
+const redactHeaders = <T>(
+  headers: Readonly<Record<string, T>>,
+): Record<string, string | T> =>
+  Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [
+      key,
+      isSensitive(key) ? REDACTED : value,
+    ]),
+  )
+
+const redactParams = (
+  params: Readonly<Record<string, unknown>>,
+): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(params).map(([key, value]) => [
+      key,
+      isSensitive(key) ? REDACTED : redactValue(value),
+    ]),
+  )
+
 /**
- * Snapshot of the request that triggered an {@link HttpError}.
+ * Snapshot of the request that triggered an {@link HttpError}. Any
+ * value naming a secret — header, body field or query parameter —
+ * reads as `******`.
  * @category HTTP
  */
 export interface HttpErrorRequestConfig {
@@ -14,17 +45,21 @@ export interface HttpErrorRequestConfig {
  * Thrown by {@link HttpClient} whenever an upstream response has a non-2xx
  * status. The shape mirrors what downstream code needs: `response.status`,
  * `response.headers`, and `response.data`.
- * @template T - Type of the parsed body of the failed response, exposed as
- * `response.data`.
+ *
+ * Both halves are redacted: a failed response body is a DIAGNOSTIC
+ * payload, not a contract — upstreams echo the credential they just
+ * rejected, and the SDK's own loggers have always blanked it. It is
+ * therefore typed `unknown`, since nothing may rely on the shape of a
+ * value whose secrets have been replaced.
  * @category HTTP
  */
-export class HttpError<T = unknown> extends Error {
+export class HttpError extends Error {
   public readonly config?: HttpErrorRequestConfig | undefined
 
   public readonly isHttpError = true
 
   public readonly response: {
-    readonly data: T
+    readonly data: unknown
     readonly headers: Record<string, string | string[]>
     readonly status: number
   }
@@ -45,7 +80,7 @@ export class HttpError<T = unknown> extends Error {
     message: string,
     options: {
       response: {
-        data: T
+        data: unknown
         headers: Record<string, string | string[]>
         status: number
       }
@@ -56,8 +91,26 @@ export class HttpError<T = unknown> extends Error {
     super(message, options)
     const { config, response } = options
     this.name = 'HttpError'
-    this.response = response
-    this.config = config
+    this.response = {
+      ...response,
+      data: redactValue(response.data),
+      headers: redactHeaders(response.headers),
+    }
+    this.config =
+      config === undefined
+        ? config
+        : {
+            ...config,
+            ...(config.data !== undefined && {
+              data: redactValue(config.data),
+            }),
+            ...(config.headers !== undefined && {
+              headers: redactHeaders(config.headers),
+            }),
+            ...(config.params !== undefined && {
+              params: redactParams(config.params),
+            }),
+          }
   }
 }
 

--- a/src/http/status.ts
+++ b/src/http/status.ts
@@ -16,6 +16,11 @@ export const HttpStatus = {
    */
   GatewayTimeout: 504,
   /**
+   * HTTP 404 — the resource does not exist. On Home's `/context` it is
+   * the answer for an account with no home, not a failure.
+   */
+  NotFound: 404,
+  /**
    * HTTP 503 — transient service unavailability. Eligible for retry on GET.
    */
   ServiceUnavailable: 503,

--- a/src/observability/context.ts
+++ b/src/observability/context.ts
@@ -27,20 +27,43 @@ const logKeys = [
   'errorMessage',
 ]
 
-const REDACTED = '******'
+/**
+ * Placeholder written over any value whose key names a secret.
+ */
+export const REDACTED = '******'
 
+// Every key that names a credential on either wire, plus the OAuth
+// vocabulary the Home flow speaks. `owneremail` earns its place from
+// the Classic list payload, which carries the account's address on
+// EVERY device of EVERY successful sync — the one entry here that
+// blanks a routine 200 rather than a failure.
 const sensitiveKeys = new Set([
+  'access_token',
   'authorization',
+  'client_secret',
+  'code',
+  'code_verifier',
   'contextkey',
   'cookie',
   'email',
+  'id_token',
+  'owneremail',
   'password',
+  'refresh_token',
   'set-cookie',
+  'token',
   'username',
   'x-mitscontextkey',
 ])
 
-const isSensitive = (key: string): boolean =>
+/**
+ * Whether a header or payload key names a secret — the one vocabulary
+ * shared by the call loggers and the {@link HttpError} request
+ * snapshot, so a secret cannot reach a log through either route.
+ * @param key - Header or payload key, in any casing.
+ * @returns `true` when the value behind the key must be redacted.
+ */
+export const isSensitive = (key: string): boolean =>
   sensitiveKeys.has(key.toLowerCase())
 
 // Detect a string that looks like an `application/x-www-form-urlencoded`
@@ -71,7 +94,15 @@ const redactFormEncoded = (value: string): string | undefined => {
   return keysToRedact.length > 0 ? params.toString() : undefined
 }
 
-const redactValue = (value: unknown): unknown => {
+/**
+ * Redacts every value whose key names a secret, walking nested objects,
+ * arrays and form-encoded strings — the deep counterpart of
+ * {@link isSensitive}, shared with the {@link HttpError} snapshot so a
+ * request body cannot leak a credential the loggers would have hidden.
+ * @param value - Any payload: object, array, string or primitive.
+ * @returns The value with sensitive entries replaced by {@link REDACTED}.
+ */
+export const redactValue = (value: unknown): unknown => {
   if (typeof value === 'string') {
     return redactFormEncoded(value) ?? value
   }

--- a/tests/unit/home-api.test.ts
+++ b/tests/unit/home-api.test.ts
@@ -14,8 +14,10 @@ import { type HttpResponse, HttpError } from '../../src/http/index.ts'
 import { Temporal } from '../../src/temporal.ts'
 import {
   cast,
+  createHttpError,
   createLogger,
   createMockHttpClient,
+  createServerError,
   createSettingStore,
   defined,
   matchObject,
@@ -321,6 +323,18 @@ const httpUnauthorized = (url = '/context'): HttpError =>
     config: { url },
     response: { data: undefined, headers: {}, status: 401 },
   })
+
+// How the BFF answers an account that owns no MELCloud Home home: the
+// token was accepted (a rejected one answers 401), the account simply
+// has nothing to describe.
+const httpNotFound = (url = '/context'): HttpError =>
+  createHttpError({ message: 'Not Found', status: 404, url })
+
+const NO_HOME_LOG =
+  'This account has no MELCloud Home home: signed in, nothing to sync'
+
+const countTokenCalls = (): number =>
+  mockFetch.mock.calls.filter((call) => isTokenEndpointCall(call)).length
 
 describe('melcloud home API', () => {
   let melCloudHomeApi: { create: typeof HomeAPI.create }
@@ -665,6 +679,184 @@ describe('melcloud home API', () => {
       const buildings = await api.fetch()
 
       expect(buildings).toStrictEqual([])
+    })
+  })
+
+  // A 404 on `/context` says "this account has no MELCloud Home home",
+  // never "the session went stale": the token IS valid (a rejected one
+  // answers 401). Escalating it to a full re-login looped forever in
+  // the wild — 404 → reuse deemed failed → sign-in → Cognito login
+  // page → AuthenticationError → 15-minute backoff → repeat — and
+  // notified "session lost" to a user who has no Home account at all.
+  describe('account without a MELCloud Home home', () => {
+    it('answers an empty building list, empties the registry, and stays authenticated', async () => {
+      setupSuccessfulLogin()
+      const logger = createLogger()
+      const api = await createApi({ logger })
+      // Sync a real context first, so the emptying below is observable
+      // rather than vacuous.
+      mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
+      await api.fetch()
+
+      expect(api.registry.getById('device-1')).toBeDefined()
+
+      mockRequest.mockRejectedValueOnce(httpNotFound())
+      const buildings = await api.fetch()
+
+      expect(buildings).toStrictEqual([])
+      expect(api.registry.getDevices()).toHaveLength(0)
+      expect(api.context).toBeNull()
+      expect(api.isAuthenticated()).toBe(true)
+      expect(logger.log).toHaveBeenCalledWith('[Home]', NO_HOME_LOG)
+    })
+
+    it('states the situation once, not on every poll', async () => {
+      setupSuccessfulLogin()
+      const logger = createLogger()
+      const api = await createApi({ logger })
+      mockRequest.mockRejectedValueOnce(httpNotFound())
+      await api.fetch()
+      mockRequest.mockRejectedValueOnce(httpNotFound())
+      await api.fetch()
+      const noHomeLines = vi
+        .mocked(logger.log)
+        .mock.calls.filter(([, line]) => line === NO_HOME_LOG)
+
+      expect(noHomeLines).toHaveLength(1)
+    })
+
+    it('states it again after a home appears and goes away', async () => {
+      setupSuccessfulLogin()
+      const logger = createLogger()
+      const api = await createApi({ logger })
+      mockRequest.mockRejectedValueOnce(httpNotFound())
+      await api.fetch()
+      mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
+      await api.fetch()
+      mockRequest.mockRejectedValueOnce(httpNotFound())
+      await api.fetch()
+      const noHomeLines = vi
+        .mocked(logger.log)
+        .mock.calls.filter(([, line]) => line === NO_HOME_LOG)
+
+      expect(noHomeLines).toHaveLength(2)
+    })
+
+    it('reuses the persisted session instead of attempting a full sign-in', async () => {
+      const { settingManager } = persistedSessionStore()
+      const onAuthenticationLost = vi.fn<() => void>()
+      mockRequest.mockRejectedValueOnce(httpNotFound())
+
+      const api = await melCloudHomeApi.create({
+        baseURL: BASE_URL,
+        events: { onAuthenticationLost },
+        settingManager,
+        transport: mockHttpClient,
+      })
+
+      expect(api.isAuthenticated()).toBe(true)
+      expect(api.registry.getDevices()).toHaveLength(0)
+      // No OIDC round-trip at all — the token endpoint above all.
+      expect(mockFetch).not.toHaveBeenCalled()
+      expect(onAuthenticationLost).not.toHaveBeenCalled()
+    })
+
+    it('syncs normally once /context answers again', async () => {
+      const { settingManager } = persistedSessionStore()
+      mockRequest.mockRejectedValueOnce(httpNotFound())
+      const api = await createFromPersistedStore(settingManager)
+
+      // The marker is up: authenticated on the strength of the 404
+      // alone, with no identity behind it yet.
+      expect(api.isAuthenticated()).toBe(true)
+      expect(api.user).toBeNull()
+
+      mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
+      const buildings = await api.fetch()
+
+      expect(buildings).toStrictEqual([mockBuilding])
+      expect(api.registry.getById('device-1')).toBeDefined()
+      expect(api.isAuthenticated()).toBe(true)
+      expect(api.user).not.toBeNull()
+    })
+
+    it('leaves a 404 from any other endpoint classified as a failure', async () => {
+      setupSuccessfulLogin()
+      const logger = createLogger()
+      const api = await createApi({ logger })
+      mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
+      await api.fetch()
+      mockRequest.mockRejectedValueOnce(
+        httpNotFound('/telemetry/telemetry/energy/device-1'),
+      )
+      const result = await api.getEnergy('device-1', {
+        from: '2026-08-01T00:00:00Z',
+        interval: 'Day',
+        measure: 'consumed',
+        to: '2026-08-02T00:00:00Z',
+      })
+
+      expect(result.ok).toBe(false)
+      expect(api.isAuthenticated()).toBe(true)
+      expect(api.context).not.toBeNull()
+      expect(logger.log).not.toHaveBeenCalledWith('[Home]', NO_HOME_LOG)
+    })
+
+    it('reads unauthenticated after logging out', async () => {
+      const { settingManager } = persistedSessionStore()
+      mockRequest.mockRejectedValueOnce(httpNotFound())
+      const api = await createFromPersistedStore(settingManager)
+
+      expect(api.isAuthenticated()).toBe(true)
+
+      api.logOut()
+
+      expect(api.isAuthenticated()).toBe(false)
+      expect(api.registry.getDevices()).toHaveLength(0)
+    })
+
+    // The sibling behaviour must not have moved: only a 404 is a
+    // no-home verdict, everything else stays a plain failure that
+    // keeps the last good registry and says nothing about a home.
+    it.each([
+      ['a 500 HttpError', createServerError(500, '/context')],
+      ['a network error', new Error('network down')],
+    ])('leaves %s propagating untouched', async (_name, error: unknown) => {
+      setupSuccessfulLogin()
+      const logger = createLogger()
+      const api = await createApi({ logger })
+      mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
+      await api.fetch()
+      mockRequest.mockRejectedValueOnce(error)
+
+      const buildings = await api.fetch()
+
+      expect(buildings).toStrictEqual([])
+      expect(api.registry.getById('device-1')).toBeDefined()
+      expect(api.context).not.toBeNull()
+      expect(logger.log).not.toHaveBeenCalledWith('[Home]', NO_HOME_LOG)
+    })
+
+    it('still drives the reactive re-auth path on a 401', async () => {
+      setupSuccessfulLogin()
+      const logger = createLogger()
+      const api = await createApi({ logger })
+      const tokenCallsBeforeRefresh = countTokenCalls()
+      mockRequest.mockRejectedValueOnce(httpUnauthorized())
+      // The reactive handler refreshes first — one extra token call.
+      mockFetch.mockResolvedValueOnce(
+        mockFetchResponse({
+          ...mockTokenResponse,
+          access_token: 'refreshed-after-401',
+        }),
+      )
+      mockRequest.mockResolvedValueOnce(mockResponse(mockContext, {}, 200))
+
+      const buildings = await api.fetch()
+
+      expect(buildings).toStrictEqual([mockBuilding])
+      expect(countTokenCalls()).toBe(tokenCallsBeforeRefresh + 1)
+      expect(logger.log).not.toHaveBeenCalledWith('[Home]', NO_HOME_LOG)
     })
   })
 

--- a/tests/unit/http-client.test.ts
+++ b/tests/unit/http-client.test.ts
@@ -50,11 +50,119 @@ describe('httpError', () => {
 
     expect(error.config).toBeUndefined()
   })
+
+  // Security regression guard (user report, 2026-08-21): the request
+  // snapshot rides inside the thrown error into every host logger and
+  // into the diagnostic reports users paste into issues, and it used to
+  // carry `Authorization: Bearer …` verbatim.
+  it('redacts secret-bearing request headers and leaves the others verbatim', () => {
+    const error = new HttpError('boom', {
+      config: {
+        headers: {
+          Authorization: 'Bearer secret',
+          'Content-Type': 'application/json',
+          'X-MitsContextKey': 'ctx',
+        },
+      },
+      response: { data: null, headers: {}, status: 401 },
+    })
+
+    expect(error.config?.headers).toStrictEqual({
+      Authorization: '******',
+      'Content-Type': 'application/json',
+      'X-MitsContextKey': '******',
+    })
+  })
+
+  it.each(['authorization', 'Authorization', 'AUTHORIZATION'])(
+    'redacts %s regardless of casing',
+    (key) => {
+      const error = new HttpError('boom', {
+        config: { headers: { [key]: 'Bearer secret' } },
+        response: { data: null, headers: {}, status: 401 },
+      })
+
+      expect(error.config?.headers?.[key]).toBe('******')
+    },
+  )
+
+  it('passes a config without headers through unchanged', () => {
+    const config = {
+      data: { id: 1 },
+      method: 'POST',
+      params: { verbose: true },
+      url: '/where',
+    }
+    const error = new HttpError('boom', {
+      config,
+      response: { data: null, headers: {}, status: 500 },
+    })
+
+    expect(error.config).toStrictEqual(config)
+    // No `headers` key conjured out of the absent one.
+    expect(error.config?.headers).toBeUndefined()
+  })
+
+  // What came back is redacted by the same vocabulary: a session cookie
+  // is a credential wherever it sits. Everything the retry policies read
+  // — `retry-after` above all — must survive untouched.
+  it('redacts the secrets the server sent back', () => {
+    const error = new HttpError('boom', {
+      config: { headers: { Authorization: 'Bearer secret' } },
+      response: {
+        data: null,
+        headers: {
+          authorization: 'Bearer echoed',
+          'retry-after': '30',
+          'set-cookie': ['session=1', 'flag=2'],
+          'x-trace': 'abc',
+        },
+        status: 500,
+      },
+    })
+
+    expect(error.config?.headers?.Authorization).toBe('******')
+    expect(error.response.headers.authorization).toBe('******')
+    expect(error.response.headers['set-cookie']).toBe('******')
+    expect(error.response.headers['retry-after']).toBe('30')
+    expect(error.response.headers['x-trace']).toBe('abc')
+  })
+
+  // The Classic sign-in carries the account's password in the BODY, and
+  // a credential can ride a query string too: the snapshot redacts every
+  // field, not just the obvious header.
+  it('redacts the credentials in the body and the query', () => {
+    const error = new HttpError('boom', {
+      config: {
+        data: {
+          AppVersion: '1.38.4.0',
+          Email: 'user@example.com',
+          Password: 'hunter2',
+          Persist: true,
+        },
+        method: 'post',
+        params: { password: 'in-query', trace: 'keep' },
+        url: '/Login/ClientLogin3',
+      },
+      response: { data: null, headers: {}, status: 500 },
+    })
+
+    expect(error.config?.data).toStrictEqual({
+      AppVersion: '1.38.4.0',
+      Email: '******',
+      Password: '******',
+      Persist: true,
+    })
+    expect(error.config?.params?.password).toBe('******')
+    expect(error.config?.params?.trace).toBe('keep')
+  })
 })
 
 describe(isHttpError, () => {
   it('narrows HttpError instances', () => {
-    const error = new HttpError('boom', {
+    // Typed `unknown`, which is where the guard earns its keep: the
+    // error arrives from a `catch`, not from a constructor call.
+    const error: unknown = new HttpError('boom', {
       response: { data: null, headers: {}, status: 500 },
     })
 
@@ -192,6 +300,38 @@ describe(HttpClient, () => {
         status: 429,
       },
     })
+  })
+
+  // The end-to-end clause that would have caught the leak: the error a
+  // real request throws must not carry the bearer token that request
+  // just sent — default headers and per-request headers alike.
+  it('redacts the credentials of the request that failed', async () => {
+    mockFetch.mockResolvedValueOnce(
+      mockFetchResponse({ err: 'denied' }, {}, 403),
+    )
+    const client = new HttpClient({
+      baseURL: BASE_URL,
+      headers: { 'X-MitsContextKey': 'ctx' },
+      timeout: 0,
+    })
+
+    const promise = client.request({
+      headers: { Authorization: 'Bearer secret', 'X-Trace': 'keep-me' },
+      url: '/guarded',
+    })
+
+    await expect(promise).rejects.toMatchObject({
+      config: {
+        headers: {
+          Authorization: '******',
+          'X-MitsContextKey': '******',
+          'X-Trace': 'keep-me',
+        },
+      },
+    })
+    // Redaction is a reporting concern, not a transport one: the wire
+    // still carried the real credential.
+    expect(extractHeaders().Authorization).toBe('Bearer secret')
   })
 
   it('returns text when the response is not JSON', async () => {


### PR DESCRIPTION
## The report behind it

A user's diagnostic report, pasted into a support thread on 2026-08-21, contained a live `Authorization: Bearer …`. The SDK puts a verbatim snapshot of the failed exchange inside the `HttpError` it throws, and that object reaches every logger a host happens to run — `this.error('Failed to fetch devices:', error)` and friends — so it lands in whatever the user shares.

The token was the least of it. Two rounds of adversarial review, each with a working probe, found the leak was wider every time:

- **request body** — Classic's `/Login/ClientLogin3` posts `{ Email, Password }`, so a 5xx, a 429 or a WAF 403 during sign-in put the account's **plaintext password** into the thrown object (a rejected credential answers 201, so this is the transport-failure path);
- **response headers** — the session cookie comes back there;
- **response body** — the upstream echoes what it rejected: a Classic 500 returns `LoginData.ContextKey`, a 401 can mirror the bearer, and the OIDC token endpoint names the refresh token in its error text;
- **query parameters** — a credential can ride one;
- **a routine 200** — `OwnerEmail` sits on every device of every Classic list response and was outside the redaction vocabulary, so every successful poll wrote the account's email address to the log.

The SDK's own structured loggers had always redacted these. Only the thrown object was raw.

## The change

Redaction happens in the `HttpError` **constructor**, so the defect class is gone rather than guarded: no call site, present or future, can retain a credential by forgetting to sanitize. Request headers, body and query parameters, plus response headers and body, all pass through the one vocabulary the loggers already used (`isSensitive`, `redactValue`, `REDACTED` — now exported rather than duplicated). What the retry policies read, `retry-after` above all, passes through untouched.

**Breaking**: `HttpError` loses its `T` parameter and `response.data` is `unknown`. A failed body is a diagnostic payload, not a contract — nothing in this SDK ever read it, and after redaction nothing may rely on its shape.

## Second fix: an account with no MELCloud Home home

The same report showed the app looping for hours. A `404` on `/context` means the signed-in account has no home — the token was accepted, since a rejected one answers `401` — but the SDK read the missing context as a failed session reuse, escalated to a full sign-in, failed, armed the 15-minute backoff, reported an authentication loss, and repeated. That account now settles: authenticated, empty registry, stated once per episode rather than once per poll, with the expected 404 no longer filed as an API failure. A 404 from any other endpoint keeps its classification, pinned by a test. Polling continues, so a home created later is picked up on its own.

## Verification

format, lint, typecheck, docs: clean. 1160 tests, coverage 100 % on all four metrics. Probes assert that no secret survives `util.inspect`, `console.error`, `JSON.stringify(error)` or the `{ ...error }` spread, and that a routine sync log no longer carries the account address.

The twin leak in heatzy-api shipped as 13.0.1 and reached users as com.heatzy 23.3.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn