### PR TITLE
fix: redact the OIDC failure text and the URL query

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,14 +58,6 @@ updates:
         patterns:
           - '@vitest/*'
           - vitest
-    # TypeScript 7 has no stable typedoc: 0.28.x caps its peer at 6.0.x and
-    # only the 1.0.0-dev prereleases widen it. Taking the major would trade a
-    # blocked bump for a prerelease docs toolchain in a published package.
-    # Drop this once typedoc 1.0 ships stable.
-    ignore:
-      - dependency-name: typescript
-        update-types:
-          - version-update:semver-major
     package-ecosystem: npm
     registries:
       - npm-github

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [52.0.1] - 2026-08-25
+
+### Security
+
+- **The OIDC token endpoint's failure text is now actually redacted.** 52.0.0 overclaimed this: it stated the value the token endpoint echoes was covered ("every one of those values is now redacted"), but the endpoint's non-2xx body is kept as raw TEXT and the string redaction only understood form-encoded strings — JSON text such as `{"error":"invalid_grant","refresh_token":"…"}` passed through verbatim into the thrown `HttpError`, which the host then logs ("Refresh token exchange failed:"). The shared redaction vocabulary now attempts a JSON parse on every string: on success the parsed value is redacted recursively and re-serialized, so a token-bearing field inside JSON text reads `******` in the error snapshot and the call loggers alike; any other string keeps the form-encoded/raw behavior.
+- **The request URL's query string is redacted in the `HttpError` snapshot.** A token can ride inline in the URL (`?code=…`) rather than in the `params` record; the query portion now passes through the same form-encoded redaction as the bodies. Latent hardening — no SDK call site puts a credential there today.
+
 ## [52.0.0] - 2026-08-21
 
 ### Changed
 
 - **BREAKING — a thrown `HttpError` no longer carries a typed, verbatim payload.** `HttpError` loses its `T` type parameter and `response.data` is now `unknown`, because a failed response body is a DIAGNOSTIC payload rather than a contract: upstreams echo the credential they just rejected (a Classic 500 returns `LoginData.ContextKey`, a 401 can mirror the bearer, the OIDC token endpoint names the refresh token in its error text), and every one of those values is now redacted. Migration: an `HttpError<Foo>` annotation becomes `HttpError`, and code reading `error.response.data` narrows it itself — nothing in this SDK ever did.
 
-### Fixed
+### Security
 
 - **Credentials no longer travel inside a thrown `HttpError`.** The error carried a verbatim snapshot of the exchange that failed, and that object reaches every host logger — including the diagnostic reports users paste into issues, where a live bearer token was found on 2026-08-21. It leaked far more than that token: the Classic sign-in posts the account's **password and email in the request body**, the context key rides `X-MitsContextKey`, a session cookie comes back in the response headers, and the response BODY echoes secrets of its own. Every field naming a secret now reads `******` — request headers, body and query parameters, response headers and body alike — redacted in the constructor, so no call site can reintroduce the leak by forgetting to sanitize. What the retry policies read (`retry-after` and friends) passes through untouched. Verified by probe against `util.inspect`, `console.error`, `JSON.stringify(error)` and the `{ ...error }` spread.
 - **The account's email address no longer appears in a routine sync log.** `OwnerEmail` — which the Classic list payload carries on every device of every successful poll — was outside the redaction vocabulary, so a 200 response wrote it to the host log. It is now blanked like every other credential, along with the OAuth vocabulary (`access_token`, `refresh_token`, `id_token`, `token`, `code`, `code_verifier`, `client_secret`).
+
+### Fixed
+
 - **A `404` on Home's `/context` is an account with no home, not a stale session.** The BFF answers `404` when the signed-in account has no MELCloud Home home — the token was accepted, since a rejected one answers `401` — but the SDK read the missing context as a failed session reuse and escalated to a full sign-in, which then failed, armed the 15-minute login backoff and reported an authentication loss, indefinitely. Such an account now settles: `isAuthenticated()` reads `true`, `fetch()` answers `[]` with an empty registry, and no sign-in is attempted. The situation is stated once per episode, not once per poll, and the expected `404` is no longer filed as an API failure — a `404` from any other endpoint is classified exactly as before. Polling continues, so a home created later is picked up on its own.
 
 ### Added
@@ -603,6 +613,7 @@ Note: `HomeDevice`'s constructor now takes the typed entry bag (`{ building, dev
 
 For releases up to and including `37.2.1`, see the [GitHub releases page](https://github.com/OlivierZal/melcloud-api/releases) — entries were not tracked in this file before.
 
+[52.0.1]: https://github.com/OlivierZal/melcloud-api/compare/v52.0.0...v52.0.1
 [52.0.0]: https://github.com/OlivierZal/melcloud-api/compare/v51.0.1...v52.0.0
 [51.0.1]: https://github.com/OlivierZal/melcloud-api/compare/v51.0.0...v51.0.1
 [51.0.0]: https://github.com/OlivierZal/melcloud-api/compare/v50.0.0...v51.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,12 @@ is on: no runtime enums, no parameter properties, no runtime namespaces.
   TS6 JS API) for the tools that import it (typedoc, typescript-eslint),
   while `@typescript/native` is the native 7.x compiler running typecheck
   and build — until TS 7.1 ships its programmatic API. `@typescript/native`
-  installs no `.bin` shim at all, and both `.bin/tsc` and `.bin/tsc6`
-  resolve to the compat package's TypeScript 6, so a bare `tsc` in a
-  script would silently typecheck against TS 6. The explicit path is the
-  only route to the 7.x compiler; never shorten it.
+  does declare a `tsc` bin, but LOSES the `.bin/tsc` slot to
+  `@typescript/old` (the TS 6 the compat package depends on) under
+  npm's bin-conflict resolution — so the shim a bare `tsc` runs is
+  TypeScript 6, like `.bin/tsc6`, and a bare `tsc` in a script would
+  silently typecheck against TS 6. The explicit path is the only
+  reliable route to the 7.x compiler; never shorten it.
 - `npm run build` — purges `dist` before emitting, because `tsc` overwrites
   but never deletes: a module renamed or removed in `src` would otherwise
   survive in `dist`, and `files` ships that directory, so `prepare` would

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "52.0.0",
+  "version": "52.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@olivierzal/melcloud-api",
-      "version": "52.0.0",
+      "version": "52.0.1",
       "license": "MIT",
       "dependencies": {
         "temporal-polyfill": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@olivierzal/melcloud-api",
-  "version": "52.0.0",
+  "version": "52.0.1",
   "description": "MELCloud API for Node.js",
   "keywords": [
     "melcloud",

--- a/src/http/errors.ts
+++ b/src/http/errors.ts
@@ -1,4 +1,9 @@
-import { isSensitive, REDACTED, redactValue } from '../observability/context.ts'
+import {
+  isSensitive,
+  REDACTED,
+  redactUrl,
+  redactValue,
+} from '../observability/context.ts'
 
 // The snapshot travels inside a thrown error, so it reaches every
 // logger a host happens to run — including the diagnostic reports users
@@ -110,6 +115,10 @@ export class HttpError extends Error {
             ...(config.params !== undefined && {
               params: redactParams(config.params),
             }),
+            // A token can ride inline in the URL (`?code=…`) rather
+            // than in `params`; the query string is redacted like any
+            // other form-encoded carrier.
+            ...(config.url !== undefined && { url: redactUrl(config.url) }),
           }
   }
 }

--- a/src/observability/context.ts
+++ b/src/observability/context.ts
@@ -94,17 +94,34 @@ const redactFormEncoded = (value: string): string | undefined => {
   return keysToRedact.length > 0 ? params.toString() : undefined
 }
 
+// JSON text is the other string-borne carrier of secrets: the OIDC
+// token endpoint answers a refusal as JSON TEXT (kept raw because a
+// failed body is a diagnostic payload, not a contract), and a
+// token-bearing field inside it would otherwise pass through verbatim —
+// the form-encoded branch alone cannot see it. `undefined` is a safe
+// failure marker: no JSON text parses to it.
+const parseJsonText = (value: string): unknown => {
+  try {
+    return JSON.parse(value) as unknown
+  } catch {
+    return undefined
+  }
+}
+
 /**
  * Redacts every value whose key names a secret, walking nested objects,
- * arrays and form-encoded strings — the deep counterpart of
- * {@link isSensitive}, shared with the {@link HttpError} snapshot so a
- * request body cannot leak a credential the loggers would have hidden.
+ * arrays, JSON-encoded and form-encoded strings — the deep counterpart
+ * of {@link isSensitive}, shared with the {@link HttpError} snapshot so
+ * a request body cannot leak a credential the loggers would have hidden.
  * @param value - Any payload: object, array, string or primitive.
  * @returns The value with sensitive entries replaced by {@link REDACTED}.
  */
 export const redactValue = (value: unknown): unknown => {
   if (typeof value === 'string') {
-    return redactFormEncoded(value) ?? value
+    const parsed = parseJsonText(value)
+    return parsed === undefined
+      ? (redactFormEncoded(value) ?? value)
+      : JSON.stringify(redactValue(parsed))
   }
   if (typeof value !== 'object' || value === null) {
     return value
@@ -118,6 +135,23 @@ export const redactValue = (value: unknown): unknown => {
       isSensitive(key) ? REDACTED : redactValue(property),
     ]),
   )
+}
+
+/**
+ * Redacts the query-string portion of a URL through the same
+ * form-encoded vocabulary as the bodies: a token can ride inline in the
+ * URL (`?code=…`) rather than in a separate `params` record, and the
+ * URL travels into every log line and thrown-error snapshot.
+ * @param url - Request URL, with or without a query string.
+ * @returns The URL with sensitive query values replaced by {@link REDACTED}.
+ */
+export const redactUrl = (url: string): string => {
+  const [path = '', ...querySegments] = url.split('?')
+  if (querySegments.length === 0) {
+    return url
+  }
+  const redacted = redactFormEncoded(querySegments.join('?'))
+  return redacted === undefined ? url : `${path}?${redacted}`
 }
 
 /**

--- a/tests/unit/http-client.test.ts
+++ b/tests/unit/http-client.test.ts
@@ -156,6 +156,46 @@ describe('httpError', () => {
     expect(error.config?.params?.password).toBe('******')
     expect(error.config?.params?.trace).toBe('keep')
   })
+
+  // The OIDC token endpoint answers a refusal as JSON TEXT and the
+  // failed body is kept raw — `refreshAccessToken` logs this exact
+  // error ("Refresh token exchange failed:"), so a token-bearing field
+  // inside the text must already read `******` when it gets there.
+  it('redacts token-bearing fields inside a raw JSON error text', () => {
+    const error = new HttpError('boom', {
+      config: { method: 'POST', url: '/connect/token' },
+      response: {
+        data: '{"error":"invalid_grant","refresh_token":"tok-123"}',
+        headers: {},
+        status: 400,
+      },
+    })
+
+    expect(error.response.data).toBe(
+      '{"error":"invalid_grant","refresh_token":"******"}',
+    )
+  })
+
+  // A token can ride inline in the URL (`?code=…`) rather than in the
+  // `params` record: the query string passes through the same
+  // form-encoded redaction as the bodies.
+  it('redacts the token-bearing query of the request URL', () => {
+    const error = new HttpError('boom', {
+      config: { method: 'GET', url: '/callback?code=auth-code&state=xyz' },
+      response: { data: null, headers: {}, status: 400 },
+    })
+
+    expect(error.config?.url).toBe('/callback?code=******&state=xyz')
+  })
+
+  it('leaves a URL whose query names no secret verbatim', () => {
+    const error = new HttpError('boom', {
+      config: { method: 'GET', url: '/Device/Get?id=42' },
+      response: { data: null, headers: {}, status: 404 },
+    })
+
+    expect(error.config?.url).toBe('/Device/Get?id=42')
+  })
 })
 
 describe(isHttpError, () => {

--- a/tests/unit/observability.test.ts
+++ b/tests/unit/observability.test.ts
@@ -271,6 +271,39 @@ describe('sensitive data redaction', () => {
     expect(params.get('after')).toBe('kept')
   })
 
+  it('redacts token-bearing fields inside JSON-encoded string bodies', () => {
+    // The OIDC token endpoint answers a refusal as JSON TEXT (kept raw
+    // because a failed body is a diagnostic payload, not a contract);
+    // without a JSON attempt in the string branch, a token-bearing
+    // field inside that text would ride into every log line verbatim.
+    const config = createConfig({
+      data: '{"error":"invalid_grant","error_description":"expired","refresh_token":"tok-123"}',
+    })
+    const call = new APICallRequestData(config)
+    const parsed = parseRecord(parseRequestData(call.toString()))
+
+    expect(parsed.refresh_token).toBe('******')
+    expect(parsed.error).toBe('invalid_grant')
+    expect(parsed.error_description).toBe('expired')
+  })
+
+  it('redacts sensitive keys nested inside JSON-encoded string bodies', () => {
+    const config = createConfig({
+      data: '{"outer":{"password":"s3cret","safe":"ok"}}',
+    })
+    const call = new APICallRequestData(config)
+    const parsed = parseRecord(parseRequestData(call.toString()))
+
+    expect(parsed.outer).toStrictEqual({ password: '******', safe: 'ok' })
+  })
+
+  it('keeps the content of secret-free JSON-encoded strings', () => {
+    const config = createConfig({ data: '{"status":"ok"}' })
+    const call = new APICallRequestData(config)
+
+    expect(parseRequestData(call.toString())).toBe('{"status":"ok"}')
+  })
+
   it('passes through non-sensitive form-encoded strings unchanged', () => {
     const config = createConfig({ data: 'page=2&limit=50' })
     const call = new APICallRequestData(config)

--- a/tests/unit/observability.test.ts
+++ b/tests/unit/observability.test.ts
@@ -271,38 +271,30 @@ describe('sensitive data redaction', () => {
     expect(params.get('after')).toBe('kept')
   })
 
-  it('redacts token-bearing fields inside JSON-encoded string bodies', () => {
-    // The OIDC token endpoint answers a refusal as JSON TEXT (kept raw
-    // because a failed body is a diagnostic payload, not a contract);
-    // without a JSON attempt in the string branch, a token-bearing
-    // field inside that text would ride into every log line verbatim.
-    const config = createConfig({
-      data: '{"error":"invalid_grant","error_description":"expired","refresh_token":"tok-123"}',
-    })
-    const call = new APICallRequestData(config)
-    const parsed = parseRecord(parseRequestData(call.toString()))
+  // The OIDC token endpoint answers a refusal as JSON TEXT (kept raw
+  // because a failed body is a diagnostic payload, not a contract);
+  // without a JSON attempt in the string branch, a token-bearing field
+  // inside that text would ride into every log line verbatim.
+  it.each([
+    [
+      'a token-bearing field',
+      '{"error":"invalid_grant","error_description":"expired","refresh_token":"tok-123"}',
+      '{"error":"invalid_grant","error_description":"expired","refresh_token":"******"}',
+    ],
+    [
+      'a nested sensitive key',
+      '{"outer":{"password":"s3cret","safe":"ok"}}',
+      '{"outer":{"password":"******","safe":"ok"}}',
+    ],
+    ['no secret at all', '{"status":"ok"}', '{"status":"ok"}'],
+  ])(
+    'redacts JSON-encoded string bodies carrying %s',
+    (_name, data, expected) => {
+      const call = new APICallRequestData(createConfig({ data }))
 
-    expect(parsed.refresh_token).toBe('******')
-    expect(parsed.error).toBe('invalid_grant')
-    expect(parsed.error_description).toBe('expired')
-  })
-
-  it('redacts sensitive keys nested inside JSON-encoded string bodies', () => {
-    const config = createConfig({
-      data: '{"outer":{"password":"s3cret","safe":"ok"}}',
-    })
-    const call = new APICallRequestData(config)
-    const parsed = parseRecord(parseRequestData(call.toString()))
-
-    expect(parsed.outer).toStrictEqual({ password: '******', safe: 'ok' })
-  })
-
-  it('keeps the content of secret-free JSON-encoded strings', () => {
-    const config = createConfig({ data: '{"status":"ok"}' })
-    const call = new APICallRequestData(config)
-
-    expect(parseRequestData(call.toString())).toBe('{"status":"ok"}')
-  })
+      expect(parseRequestData(call.toString())).toBe(expected)
+    },
+  )
 
   it('passes through non-sensitive form-encoded strings unchanged', () => {
     const config = createConfig({ data: 'page=2&limit=50' })


### PR DESCRIPTION
## What

Two confirmed follow-ups of the 52.0.0 redaction retrospective, released as **52.0.1** (patch: fixes within the stated 52.0.0 surface, no API change).

- **The OIDC token endpoint's failure text is now actually redacted.** `fetchPostForm` keeps a failed token-endpoint body as raw TEXT, and `redactValue`'s string branch only understood form-encoded strings — JSON text such as `{"error":"invalid_grant","refresh_token":"…"}` passed through verbatim into the thrown `HttpError`, which the host logs ("Refresh token exchange failed:"). Fixed at the vocabulary level: the string branch now attempts a JSON parse; on success the parsed value is redacted recursively and re-serialized, so both the call loggers and the `HttpError` snapshot benefit. Any other string keeps the form-encoded/raw behavior.
- **The `HttpError` snapshot redacts the query-string portion of `config.url`** through the existing form-encoded redactor (latent hardening: a token inline in the URL, `?code=…` — no SDK call site puts a credential there today).

Both fixes are mutation-checked: four hand-applied mutants (JSON branch removed, recursion dropped, URL redaction removed from the constructor, `redactUrl` passthrough) each killed by the new tests.

## Also in this PR

- **CHANGELOG accuracy**: the new 52.0.1 entry states 52.0.0's overclaim plainly ("every one of those values is now redacted" was not yet true for the raw-text path), and both security entries — 52.0.0's and 52.0.1's — now sit under `### Security`, the Keep a Changelog category the file's own header declares; the no-home `404` fix stays under `### Fixed`.
- **CLAUDE.md fact fix**: `@typescript/native` does declare a `tsc` bin (`bin: {"tsc": "./bin/tsc"}` — measured); it loses the `.bin/tsc` slot to `@typescript/old` under npm's bin-conflict resolution, so the shim a bare `tsc` runs is TypeScript 6. The conclusion (only the explicit path is reliable) stands.
- **Dependabot**: the inert `typescript` semver-major ignore is removed — `typescript` now aliases `@typescript/typescript6`, so the ignore matched nothing (same rationale as homey-kit's 2026-08-19 removal).
- Version bumped to 52.0.1 (release rides this PR, matching the 52.0.0 precedent).

## Gates

`format` / `lint` / `typecheck` / `test:coverage` (100 % × 4) / `build` / `docs` — all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKsbttD4wLTrZnZDwKK1Fn